### PR TITLE
Add Cloud Run workflow file

### DIFF
--- a/.github/workflows/google-cloudrun-docker.yml
+++ b/.github/workflows/google-cloudrun-docker.yml
@@ -1,0 +1,70 @@
+# This workflow build and push a Docker container to Google Artifact Registry
+# and deploy it on Cloud Run when a commit is pushed to the "dev"
+# branch.
+
+name: 'Build and Deploy to Cloud Run'
+
+on:
+  push:
+    branches:
+      - '"dev"'
+
+env:
+  PROJECT_ID: 'my-project' # TODO: update to your Google Cloud project ID
+  REGION: 'us-central1' # TODO: update to your region
+  SERVICE: 'my-service' # TODO: update to your service name
+  WORKLOAD_IDENTITY_PROVIDER: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider' # TODO: update to your workload identity provider
+
+jobs:
+  deploy:
+    runs-on: 'ubuntu-latest'
+
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # actions/checkout@v4
+
+      # Configure Workload Identity Federation and generate an access token.
+      #
+      # See https://github.com/google-github-actions/auth for more options,
+      # including authenticating via a JSON credentials file.
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@f112390a2df9932162083945e46d439060d66ec2' # google-github-actions/auth@v2
+        with:
+          workload_identity_provider: '${{ env.WORKLOAD_IDENTITY_PROVIDER }}'
+
+      # BEGIN - Docker auth and build
+      #
+      # If you already have a container image, you can omit these steps.
+      - name: 'Docker Auth'
+        uses: 'docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567' # docker/login-action@v3
+        with:
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.auth_token }}'
+          registry: '${{ env.REGION }}-docker.pkg.dev'
+
+      - name: 'Build and Push Container'
+        run: |-
+          DOCKER_TAG="$${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:${{ github.sha }}"
+          docker build --tag "${DOCKER_TAG}" .
+          docker push "${DOCKER_TAG}"
+      - name: 'Deploy to Cloud Run'
+
+        # END - Docker auth and build
+
+        uses: 'google-github-actions/deploy-cloudrun@33553064113a37d688aa6937bacbdc481580be17' # google-github-actions/deploy-cloudrun@v2
+        with:
+          service: '${{ env.SERVICE }}'
+          region: '${{ env.REGION }}'
+          # NOTE: If using a pre-built image, update the image name below:
+
+          image: '${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:${{ github.sha }}'
+      # If required, use the Cloud Run URL output in later steps
+      - name: 'Show output'
+        run: |2-
+
+          echo ${{ steps.deploy.outputs.url }}

--- a/.github/workflows/google-cloudrun-docker.yml
+++ b/.github/workflows/google-cloudrun-docker.yml
@@ -1,19 +1,21 @@
-# This workflow build and push a Docker container to Google Artifact Registry
-# and deploy it on Cloud Run when a commit is pushed to the "dev"
+# This workflow builds and pushes Docker containers to Google Artifact Registry
+# and deploys both backend and frontend on Cloud Run when a commit is pushed to the "production"
 # branch.
 
-name: 'Build and Deploy to Cloud Run'
+name: 'Build and Deploy QueryPal to Cloud Run'
 
 on:
   push:
     branches:
-      - '"dev"'
+      - 'production'
+  workflow_dispatch:
 
 env:
-  PROJECT_ID: 'my-project' # TODO: update to your Google Cloud project ID
-  REGION: 'us-central1' # TODO: update to your region
-  SERVICE: 'my-service' # TODO: update to your service name
-  WORKLOAD_IDENTITY_PROVIDER: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider' # TODO: update to your workload identity provider
+  PROJECT_ID: 'gen-lang-client-0698668474'
+  REGION: 'europe-west1'
+  BACKEND_SERVICE: 'querypal-backend'
+  FRONTEND_SERVICE: 'querypal-frontend'
+  WORKLOAD_IDENTITY_PROVIDER: 'projects/gen-lang-client-0698668474/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
 
 jobs:
   deploy:
@@ -28,9 +30,6 @@ jobs:
         uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # actions/checkout@v4
 
       # Configure Workload Identity Federation and generate an access token.
-      #
-      # See https://github.com/google-github-actions/auth for more options,
-      # including authenticating via a JSON credentials file.
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@f112390a2df9932162083945e46d439060d66ec2' # google-github-actions/auth@v2
@@ -38,8 +37,6 @@ jobs:
           workload_identity_provider: '${{ env.WORKLOAD_IDENTITY_PROVIDER }}'
 
       # BEGIN - Docker auth and build
-      #
-      # If you already have a container image, you can omit these steps.
       - name: 'Docker Auth'
         uses: 'docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567' # docker/login-action@v3
         with:
@@ -47,24 +44,64 @@ jobs:
           password: '${{ steps.auth.outputs.auth_token }}'
           registry: '${{ env.REGION }}-docker.pkg.dev'
 
-      - name: 'Build and Push Container'
+      # Build and Push Backend Container
+      - name: 'Build and Push Backend Container'
         run: |-
-          DOCKER_TAG="$${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:${{ github.sha }}"
-          docker build --tag "${DOCKER_TAG}" .
+          cd backend
+          DOCKER_TAG="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.BACKEND_SERVICE }}:${{ github.sha }}"
+          docker build --tag "${DOCKER_TAG}" --platform linux/amd64 .
           docker push "${DOCKER_TAG}"
-      - name: 'Deploy to Cloud Run'
 
-        # END - Docker auth and build
-
+      # Deploy Backend to Cloud Run
+      - id: 'deploy-backend'
+        name: 'Deploy Backend to Cloud Run'
         uses: 'google-github-actions/deploy-cloudrun@33553064113a37d688aa6937bacbdc481580be17' # google-github-actions/deploy-cloudrun@v2
         with:
-          service: '${{ env.SERVICE }}'
+          service: '${{ env.BACKEND_SERVICE }}'
           region: '${{ env.REGION }}'
-          # NOTE: If using a pre-built image, update the image name below:
+          image: '${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.BACKEND_SERVICE }}:${{ github.sha }}'
+          env_vars: |
+            AZURE_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}
+            AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}
+            AZURE_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}
+            ARM_SCOPE=https://management.azure.com/.default
+            GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}
+            DB_USER=${{ secrets.DB_USER }}
+            DB_PASS=${{ secrets.DB_PASS }}
+            DB_NAME=querypal
+            DB_UNIX_SOCKET=/cloudsql/gen-lang-client-0698668474:europe-west1:querypal-db
+          flags: |
+            --port=8000
+            --add-cloudsql-instances=gen-lang-client-0698668474:europe-west1:querypal-db
+            --allow-unauthenticated
 
-          image: '${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}:${{ github.sha }}'
-      # If required, use the Cloud Run URL output in later steps
-      - name: 'Show output'
-        run: |2-
+      # Build and Push Frontend Container
+      - name: 'Build and Push Frontend Container'
+        run: |-
+          cd frontend
+          DOCKER_TAG="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.FRONTEND_SERVICE }}:${{ github.sha }}"
+          docker build --tag "${DOCKER_TAG}" --platform linux/amd64 \
+            --build-arg VITE_API_BASE_URL=${{ steps.deploy-backend.outputs.url }} \
+            --build-arg VITE_AZURE_REDIRECT_URI=https://${{ env.FRONTEND_SERVICE }}-zynyyoxona-ew.a.run.app \
+            .
+          docker push "${DOCKER_TAG}"
 
-          echo ${{ steps.deploy.outputs.url }}
+      # Deploy Frontend to Cloud Run
+      - id: 'deploy-frontend'
+        name: 'Deploy Frontend to Cloud Run'
+        uses: 'google-github-actions/deploy-cloudrun@33553064113a37d688aa6937bacbdc481580be17' # google-github-actions/deploy-cloudrun@v2
+        with:
+          service: '${{ env.FRONTEND_SERVICE }}'
+          region: '${{ env.REGION }}'
+          image: '${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.FRONTEND_SERVICE }}:${{ github.sha }}'
+          env_vars: |
+            PORT=4000
+          flags: |
+            --port=4000
+            --allow-unauthenticated
+
+      # Show output URLs
+      - name: 'Show deployment URLs'
+        run: |-
+          echo "Backend URL: ${{ steps.deploy-backend.outputs.url }}"
+          echo "Frontend URL: ${{ steps.deploy-frontend.outputs.url }}"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous deployment to Google Cloud Run. The workflow automates the process of building a Docker image, pushing it to Google Artifact Registry, and deploying it to Cloud Run whenever changes are pushed to the "production" branch.

**New CI/CD workflow for Google Cloud Run deployment:**

* Added `.github/workflows/google-cloudrun-docker.yml` to automate Docker build, push to Google Artifact Registry, and deployment to Cloud Run on pushes to the "dev" branch. The workflow uses Workload Identity Federation for authentication and outputs the deployed service URL.