### PR TITLE
feat: UI rework — Hub, command palette, workspace persistence, query handover to Explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ deployment_note.txt
 
 # Temporary files
 development_plans.txt
+
+# claude files
+CLAUDE.md
+.claude/settings.local.json
+HANDOFF.md

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ development_plans.txt
 CLAUDE.md
 .claude/settings.local.json
 HANDOFF.md
+DESIGN_HANDBOOK.md

--- a/backend/routes/audit.py
+++ b/backend/routes/audit.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Header, Body, HTTPException
 from pydantic import BaseModel
 from typing import List, Dict, Any, Optional
-from services.audit_service import process_audit_question
+from services.audit_service import process_audit_question, get_recent_activity
 from services.gemini_service import VisualizationConfig
+from services.user_queries_service import get_user_id_from_token
 
 router = APIRouter()
 
@@ -18,6 +19,15 @@ class AuditQueryResponse(BaseModel):
     visualization: Optional[VisualizationConfig] = None
 
 
+class RecentActivityItem(BaseModel):
+    database_name: str
+    collection_name: str
+    operation: str
+    document_id: str
+    user_email: str
+    timestamp_utc: str
+
+
 @router.post("/query", response_model=AuditQueryResponse)
 def query_audit_log(
     body: AuditQueryRequest = Body(...), authorization: str = Header(...)
@@ -25,9 +35,13 @@ def query_audit_log(
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid token format")
 
-    # We might want to validate the token here even if we don't use it for the pg connection directly yet
-    # user_token = authorization.replace("Bearer ", "")
-    # access_token = exchange_token_obo(user_token)
-
     response = process_audit_question(body.question)
     return AuditQueryResponse(**response)
+
+
+@router.get("/recent", response_model=List[RecentActivityItem])
+def recent_activity(authorization: str = Header(...), limit: int = 10):
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid token format")
+    user_email = get_user_id_from_token(authorization.replace("Bearer ", ""))
+    return get_recent_activity(user_email=user_email, limit=min(limit, 50))

--- a/backend/services/audit_service.py
+++ b/backend/services/audit_service.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Dict, Any, List
 from services.pg_connection import get_connection
 from services.gemini_service import generate_audit_sql, summarize_audit_results
 
@@ -34,6 +34,36 @@ def execute_audit_query(sql_query: str) -> list:
     except Exception as e:
         print(f"Error executing audit query: {e}")
         return [{"error": str(e)}]
+
+
+def get_recent_activity(user_email: str, limit: int = 10) -> List[Dict[str, Any]]:
+    """Returns the most recent write_audit_log rows for a specific user."""
+    try:
+        conn = get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT user_email, operation, database_name, collection_name, document_id, timestamp_utc
+            FROM write_audit_log
+            WHERE user_email = %s
+            ORDER BY timestamp_utc DESC
+            LIMIT %s
+            """,
+            (user_email, limit),
+        )
+        columns = [desc[0] for desc in cur.description]
+        rows = []
+        for row in cur.fetchall():
+            item = dict(zip(columns, row))
+            if hasattr(item.get("timestamp_utc"), "isoformat"):
+                item["timestamp_utc"] = item["timestamp_utc"].isoformat()
+            rows.append(item)
+        cur.close()
+        conn.close()
+        return rows
+    except Exception as e:
+        print(f"Error fetching recent activity: {e}")
+        return []
 
 
 def process_audit_question(question: str) -> Dict[str, Any]:

--- a/backend/services/react_agent_service.py
+++ b/backend/services/react_agent_service.py
@@ -21,7 +21,6 @@ if not logger.handlers:
 from services.gemini_service import extract_python_code
 from services.mongo_service import execute_mongo_query, transform_mongo_result
 
-
 WRITE_METHODS = {
     "insert_one",
     "insert_many",

--- a/frontend/components/AnalysisResultDisplay.tsx
+++ b/frontend/components/AnalysisResultDisplay.tsx
@@ -1,94 +1,170 @@
-
 import React from 'react';
-import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend, ArcElement, PointElement, LineElement, PolarAreaController, RadarController, DoughnutController, PieController, BarController, LineController, ScatterController, BubbleController } from 'chart.js';
+import {
+  Chart as ChartJS,
+  CategoryScale, LinearScale, BarElement,
+  Title, Tooltip, Legend, ArcElement,
+  PointElement, LineElement,
+  PolarAreaController, RadarController,
+  DoughnutController, PieController,
+  BarController, LineController,
+  ScatterController, BubbleController,
+} from 'chart.js';
 import { Chart } from 'react-chartjs-2';
 import { AnalysisResult } from '../types';
-import { AiSparkleIcon } from './icons/material-icons-imports';
 import { useTheme } from '../contexts/ThemeContext';
 
-// Register all necessary Chart.js components
 ChartJS.register(
-    CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend, ArcElement, PointElement, LineElement, 
-    PolarAreaController, RadarController, DoughnutController, PieController, BarController, LineController,
-    ScatterController, BubbleController
+  CategoryScale, LinearScale, BarElement,
+  Title, Tooltip, Legend, ArcElement,
+  PointElement, LineElement,
+  PolarAreaController, RadarController,
+  DoughnutController, PieController,
+  BarController, LineController,
+  ScatterController, BubbleController,
 );
 
 interface AnalysisResultDisplayProps {
-    result: AnalysisResult;
+  result: AnalysisResult;
 }
 
+const SparkleIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.5" strokeLinecap="round">
+    <path d="M8 1v3M8 12v3M1 8h3M12 8h3M3.05 3.05l2.12 2.12M10.83 10.83l2.12 2.12M3.05 12.95l2.12-2.12M10.83 5.17l2.12-2.12" />
+  </svg>
+);
+
+const CHART_TYPE_LABELS: Record<string, string> = {
+  bar: 'Bar chart',
+  line: 'Line chart',
+  pie: 'Pie chart',
+  doughnut: 'Doughnut chart',
+  polarArea: 'Polar area',
+  radar: 'Radar chart',
+  scatter: 'Scatter plot',
+  bubble: 'Bubble chart',
+};
+
 const AnalysisResultDisplay: React.FC<AnalysisResultDisplayProps> = ({ result }) => {
-    const { theme } = useTheme();
+  const { theme } = useTheme();
 
-    // Dynamically adjust chart options for dark/light theme
-    const themedChartOptions = React.useMemo(() => {
-        const isDark = theme === 'dark';
-        const textColor = isDark ? '#cbd5e1' : '#475569'; // slate-300 : slate-600
-        const gridColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)';
+  const themedChartOptions = React.useMemo(() => {
+    const isDark = theme === 'dark';
+    const textColor = isDark ? 'rgba(255,255,255,0.55)' : 'rgba(0,0,0,0.45)';
+    const gridColor = isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.07)';
+    const base = result.chartOptions || {};
 
-        // Deep merge our theme options into the AI-provided options
-        const baseOptions = result.chartOptions || {};
-        
-        const themeOverrides = {
-            plugins: {
-                legend: {
-                    labels: { color: textColor }
-                },
-                title: {
-                    color: textColor
-                }
-            },
-            scales: {
-                x: {
-                    ...baseOptions.scales?.x,
-                    ticks: { ...baseOptions.scales?.x?.ticks, color: textColor },
-                    grid: { ...baseOptions.scales?.x?.grid, color: gridColor },
-                    title: { ...baseOptions.scales?.x?.title, color: textColor }
-                },
-                y: {
-                    ...baseOptions.scales?.y,
-                    ticks: { ...baseOptions.scales?.y?.ticks, color: textColor },
-                    grid: { ...baseOptions.scales?.y?.grid, color: gridColor },
-                    title: { ...baseOptions.scales?.y?.title, color: textColor }
-                }
-            }
-        };
-        
-        // A simple deep merge
-        return {
-            ...baseOptions,
-            ...themeOverrides,
-            plugins: { ...baseOptions.plugins, ...themeOverrides.plugins },
-            scales: { ...baseOptions.scales, ...themeOverrides.scales }
-        };
+    return {
+      ...base,
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        ...base.plugins,
+        legend: {
+          ...base.plugins?.legend,
+          labels: {
+            ...base.plugins?.legend?.labels,
+            color: textColor,
+            font: { family: 'Geist, sans-serif', size: 11 },
+            boxWidth: 10,
+            padding: 14,
+          },
+        },
+        title: { ...base.plugins?.title, color: textColor },
+        tooltip: {
+          ...base.plugins?.tooltip,
+          backgroundColor: isDark ? 'rgba(30,30,36,0.95)' : 'rgba(255,255,255,0.98)',
+          titleColor: isDark ? '#e2e8f0' : '#1e293b',
+          bodyColor: isDark ? '#94a3b8' : '#475569',
+          borderColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.08)',
+          borderWidth: 1,
+          cornerRadius: 8,
+          padding: 10,
+          titleFont: { family: 'Geist, sans-serif', size: 12, weight: '600' },
+          bodyFont: { family: 'Geist Mono, monospace', size: 11 },
+        },
+      },
+      scales: {
+        x: {
+          ...base.scales?.x,
+          ticks: { ...base.scales?.x?.ticks, color: textColor, font: { family: 'Geist Mono, monospace', size: 10 } },
+          grid: { ...base.scales?.x?.grid, color: gridColor },
+          border: { color: gridColor },
+          title: { ...base.scales?.x?.title, color: textColor },
+        },
+        y: {
+          ...base.scales?.y,
+          ticks: { ...base.scales?.y?.ticks, color: textColor, font: { family: 'Geist Mono, monospace', size: 10 } },
+          grid: { ...base.scales?.y?.grid, color: gridColor },
+          border: { color: gridColor },
+          title: { ...base.scales?.y?.title, color: textColor },
+        },
+      },
+    };
+  }, [result.chartOptions, theme]);
 
-    }, [result.chartOptions, theme]);
+  const chartLabel = CHART_TYPE_LABELS[result.chartType] ?? result.chartType;
 
-    return (
-        <div className="space-y-4 animate-fade-in">
-            <h3 className="text-sm font-semibold text-slate-600 dark:text-slate-400 uppercase tracking-wider">AI Analysis</h3>
-            <div className="bg-white dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-lg p-6 flex flex-col md:flex-row gap-6">
-                {/* Insight Text */}
-                <div className="md:w-1/3 space-y-4">
-                    <div className="flex items-center gap-3">
-                        <AiSparkleIcon className="w-7 h-7 text-blue-500 flex-shrink-0" />
-                        <h4 className="text-lg font-bold text-slate-800 dark:text-slate-200">Insight</h4>
-                    </div>
-                    <p className="text-slate-600 dark:text-slate-300 text-sm leading-relaxed">
-                        {result.insight}
-                    </p>
-                </div>
-                {/* Chart */}
-                <div className="md:w-2/3 min-h-[300px]">
-                    <Chart 
-                        type={result.chartType} 
-                        data={result.chartData} 
-                        options={themedChartOptions} 
-                    />
-                </div>
-            </div>
+  return (
+    <div
+      className="qa-card"
+      style={{ padding: 0, overflow: 'hidden', animation: 'fadeIn 0.25s' }}
+    >
+      {/* Header — matches QueryResult card header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 10,
+        padding: '9px 14px', borderBottom: '1px solid var(--border)', flexShrink: 0,
+      }}>
+        <span style={{
+          width: 24, height: 24, borderRadius: 6, flexShrink: 0,
+          background: 'var(--accent-soft)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <SparkleIcon />
+        </span>
+        <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
+          AI Analysis
+        </span>
+        <span className="qa-chip accent" style={{ textTransform: 'capitalize', marginLeft: 2 }}>
+          {chartLabel}
+        </span>
+      </div>
+
+      {/* Body — insight + chart side by side */}
+      <div style={{ display: 'flex', minHeight: 320 }}>
+        {/* Insight panel */}
+        <div style={{
+          width: 220, flexShrink: 0,
+          padding: '16px 18px',
+          borderRight: '1px solid var(--border)',
+          display: 'flex', flexDirection: 'column', gap: 10,
+          background: 'var(--soft)',
+        }}>
+          <div style={{
+            fontSize: 10.5, fontWeight: 500,
+            textTransform: 'uppercase', letterSpacing: '0.08em',
+            color: 'var(--muted)', fontFamily: 'var(--font-body)',
+          }}>
+            Insight
+          </div>
+          <p style={{
+            fontSize: 13, color: 'var(--fg)', lineHeight: 1.65,
+            fontFamily: 'var(--font-body)', margin: 0,
+          }}>
+            {result.insight}
+          </p>
         </div>
-    );
+
+        {/* Chart panel */}
+        <div style={{ flex: 1, padding: '20px 24px', position: 'relative', minWidth: 0 }}>
+          <Chart
+            type={result.chartType}
+            data={result.chartData}
+            options={themedChartOptions}
+          />
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default AnalysisResultDisplay;

--- a/frontend/components/AppLayout.tsx
+++ b/frontend/components/AppLayout.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTheme } from '../contexts/ThemeContext';
 import AppSidebar from './AppSidebar';
 import AppTopBar from './AppTopBar';
+import CommandPalette from './CommandPalette';
 import { CollectionSummary, DbInfo, CosmosDBAccount } from '../types';
 
 interface AppLayoutProps {
@@ -34,6 +37,46 @@ const AppLayout: React.FC<AppLayoutProps> = ({
   availableAccounts,
   onSwitchAccount,
 }) => {
+  const navigate = useNavigate();
+  const { toggleTheme } = useTheme();
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  const explorerHref = accountId && databaseName
+    ? `/data-explorer/${encodeURIComponent(accountId)}/${encodeURIComponent(databaseName)}`
+    : null;
+
+  useEffect(() => {
+    const handle = (e: KeyboardEvent) => {
+      const meta = e.metaKey || e.ctrlKey;
+      if (!meta) return;
+
+      if (e.key === 'k') {
+        e.preventDefault();
+        setPaletteOpen(v => !v);
+        return;
+      }
+
+      if (e.shiftKey) {
+        switch (e.key) {
+          case '1': e.preventDefault(); setPaletteOpen(false); navigate('/query-generator'); return;
+          case '2': e.preventDefault(); setPaletteOpen(false); if (explorerHref) navigate(explorerHref); return;
+          case '3': e.preventDefault(); setPaletteOpen(false); navigate('/analytics'); return;
+          case '4': e.preventDefault(); setPaletteOpen(false); navigate('/audit'); return;
+          case 'S': case 's': e.preventDefault(); setPaletteOpen(false); navigate('/query-generator?panel=saved'); return;
+        }
+      } else {
+        if (e.key === 'n' || e.key === 'N') {
+          e.preventDefault();
+          setPaletteOpen(false);
+          onNewQuery?.();
+          return;
+        }
+      }
+    };
+    window.addEventListener('keydown', handle);
+    return () => window.removeEventListener('keydown', handle);
+  }, [navigate, explorerHref, onNewQuery, toggleTheme]);
+
   return (
     <div className="qp-app">
       <AppSidebar
@@ -54,11 +97,25 @@ const AppLayout: React.FC<AppLayoutProps> = ({
           databaseName={databaseName}
           collectionName={collectionName}
           onNewQuery={onNewQuery}
+          onOpenPalette={() => setPaletteOpen(true)}
         />
         <main className="qp-content">
           {children}
         </main>
       </div>
+      <CommandPalette
+        open={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        accountId={accountId}
+        databaseName={databaseName}
+        collections={collections}
+        availableDbs={availableDbs}
+        availableAccounts={availableAccounts}
+        onSwitchDatabase={onSwitchDatabase}
+        onSwitchAccount={onSwitchAccount}
+        onCollectionSelect={onCollectionSelect}
+        onNewQuery={onNewQuery}
+      />
     </div>
   );
 };

--- a/frontend/components/AppLayout.tsx
+++ b/frontend/components/AppLayout.tsx
@@ -1,37 +1,52 @@
 import React from 'react';
 import AppSidebar from './AppSidebar';
 import AppTopBar from './AppTopBar';
-import { CollectionSummary } from '../types';
+import { CollectionSummary, DbInfo, CosmosDBAccount } from '../types';
 
 interface AppLayoutProps {
   children: React.ReactNode;
   accountName?: string;
+  accountId?: string;
   databaseName?: string;
   collectionName?: string;
   collections?: CollectionSummary[];
   activeCollection?: string;
   onCollectionSelect?: (name: string) => void;
   onNewQuery?: () => void;
+  availableDbs?: DbInfo[];
+  onSwitchDatabase?: (db: DbInfo) => void;
+  availableAccounts?: CosmosDBAccount[];
+  onSwitchAccount?: (account: CosmosDBAccount) => void;
 }
 
 const AppLayout: React.FC<AppLayoutProps> = ({
   children,
   accountName,
+  accountId,
   databaseName,
   collectionName,
   collections,
   activeCollection,
   onCollectionSelect,
   onNewQuery,
+  availableDbs,
+  onSwitchDatabase,
+  availableAccounts,
+  onSwitchAccount,
 }) => {
   return (
     <div className="qp-app">
       <AppSidebar
         accountName={accountName}
+        accountId={accountId}
         databaseName={databaseName}
         collections={collections}
         activeCollection={activeCollection}
         onCollectionSelect={onCollectionSelect}
+        availableDbs={availableDbs}
+        onSwitchDatabase={onSwitchDatabase}
+        availableAccounts={availableAccounts}
+        onSwitchAccount={onSwitchAccount}
       />
       <div className="qp-main">
         <AppTopBar

--- a/frontend/components/AppLayout.tsx
+++ b/frontend/components/AppLayout.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import AppSidebar from './AppSidebar';
+import AppTopBar from './AppTopBar';
+import { CollectionSummary } from '../types';
+
+interface AppLayoutProps {
+  children: React.ReactNode;
+  accountName?: string;
+  databaseName?: string;
+  collectionName?: string;
+  collections?: CollectionSummary[];
+  activeCollection?: string;
+  onCollectionSelect?: (name: string) => void;
+  onNewQuery?: () => void;
+}
+
+const AppLayout: React.FC<AppLayoutProps> = ({
+  children,
+  accountName,
+  databaseName,
+  collectionName,
+  collections,
+  activeCollection,
+  onCollectionSelect,
+  onNewQuery,
+}) => {
+  return (
+    <div className="qp-app">
+      <AppSidebar
+        accountName={accountName}
+        databaseName={databaseName}
+        collections={collections}
+        activeCollection={activeCollection}
+        onCollectionSelect={onCollectionSelect}
+      />
+      <div className="qp-main">
+        <AppTopBar
+          accountName={accountName}
+          databaseName={databaseName}
+          collectionName={collectionName}
+          onNewQuery={onNewQuery}
+        />
+        <main className="qp-content">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AppLayout;

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -149,9 +149,12 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
         </Link>
 
         {/* Connection chip */}
-        {accountName && (
+        {(accountName || isSwitching) && (
           <div ref={chipRef} style={{ position: 'relative' }}>
-            <style>{`@keyframes qp-spin { to { transform: rotate(360deg); } }`}</style>
+            <style>{`
+              @keyframes qp-spin { to { transform: rotate(360deg); } }
+              @keyframes qp-pulse { 0%,100% { opacity: 0.45; } 50% { opacity: 0.9; } }
+            `}</style>
             {isSwitching ? (
               <div style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '5px 9px', background: 'var(--soft)', borderRadius: 7 }}>
                 <div style={{ width: 14, height: 14, borderRadius: '50%', border: '2px solid var(--border)', borderTopColor: 'var(--accent)', animation: 'qp-spin 0.7s linear infinite', flexShrink: 0 }} />
@@ -159,11 +162,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                   <div style={{ fontSize: 11.5, fontWeight: 500, color: 'var(--muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                     Connecting…
                   </div>
-                  {databaseName && (
-                    <div style={{ fontSize: 10.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', opacity: 0.5 }}>
-                      {databaseName}
-                    </div>
-                  )}
+                  <div style={{ height: 9, marginTop: 3, borderRadius: 4, background: 'var(--border)', animation: 'qp-pulse 1.4s ease-in-out infinite', width: '70%' }} />
                 </div>
               </div>
             ) : (() => {
@@ -357,8 +356,23 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
         })}
       </div>
 
-      {/* Collections */}
-      {collections && collections.length > 0 && (
+      {/* Collections — skeleton while switching, real list when loaded */}
+      {isSwitching && (
+        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', marginTop: 12 }}>
+          <div style={{ padding: '0 8px 6px 8px', fontSize: 10.5, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)' }}>
+            Collections
+          </div>
+          <div style={{ padding: '0 8px', display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {[60, 80, 50].map((w, i) => (
+              <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '5px 8px' }}>
+                <div style={{ width: 11, height: 11, borderRadius: 3, background: 'var(--border)', flexShrink: 0, animation: 'qp-pulse 1.4s ease-in-out infinite' }} />
+                <div style={{ height: 10, borderRadius: 4, background: 'var(--border)', width: `${w}%`, animation: 'qp-pulse 1.4s ease-in-out infinite', animationDelay: `${i * 0.15}s` }} />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {!isSwitching && collections && collections.length > 0 && (
         <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', marginTop: 12 }}>
           <div style={{
             display: 'flex', alignItems: 'center', justifyContent: 'space-between',

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -1,15 +1,20 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
-import { CollectionSummary } from '../types';
+import { CollectionSummary, DbInfo, CosmosDBAccount } from '../types';
 
 interface AppSidebarProps {
   accountName?: string;
+  accountId?: string;
   databaseName?: string;
   collections?: CollectionSummary[];
   activeCollection?: string;
   onCollectionSelect?: (name: string) => void;
   latencyMs?: number;
+  availableDbs?: DbInfo[];
+  onSwitchDatabase?: (db: DbInfo) => void;
+  availableAccounts?: CosmosDBAccount[];
+  onSwitchAccount?: (account: CosmosDBAccount) => void;
 }
 
 type NavItem =
@@ -78,15 +83,44 @@ const itemBase: React.CSSProperties = {
 
 const AppSidebar: React.FC<AppSidebarProps> = ({
   accountName,
+  accountId,
   databaseName,
   collections,
   activeCollection,
   onCollectionSelect,
   latencyMs,
+  availableDbs,
+  onSwitchDatabase,
+  availableAccounts,
+  onSwitchAccount,
 }) => {
   const location = useLocation();
   const navigate = useNavigate();
   const { logout } = useUnifiedAuth();
+  const [showDbPicker, setShowDbPicker] = useState(false);
+  const [sortAlpha, setSortAlpha] = useState(false);
+  const [isSwitching, setIsSwitching] = useState(false);
+  const chipRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!showDbPicker) return;
+    const handleClick = (e: MouseEvent) => {
+      if (chipRef.current && !chipRef.current.contains(e.target as Node)) {
+        setShowDbPicker(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [showDbPicker]);
+
+  // Reset loading state whenever the connection actually changes
+  useEffect(() => {
+    setIsSwitching(false);
+  }, [accountId, databaseName]);
+
+  const explorerHref = accountId && databaseName
+    ? `/data-explorer/${encodeURIComponent(accountId)}/${encodeURIComponent(databaseName)}`
+    : null;
 
   const isActive = (href: string, matchPrefix?: boolean) => {
     if (matchPrefix) return location.pathname.startsWith(href);
@@ -112,30 +146,148 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
 
         {/* Connection chip */}
         {accountName && (
-          <div style={{
-            display: 'flex', alignItems: 'center', gap: 7,
-            padding: '5px 9px', background: 'var(--soft)', borderRadius: 7,
-          }}>
-            <span style={{
-              width: 14, height: 14, borderRadius: 4, background: '#1d6cf2', flexShrink: 0,
-            }} />
-            <div style={{ minWidth: 0, flex: 1 }}>
-              <div style={{
-                fontSize: 11.5, fontWeight: 500, color: 'var(--fg)',
-                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-              }}>{accountName}</div>
-              {databaseName && (
-                <div style={{
-                  fontSize: 10.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)',
-                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                }}>{databaseName}</div>
-              )}
-            </div>
+          <div ref={chipRef} style={{ position: 'relative' }}>
+            <style>{`@keyframes qp-spin { to { transform: rotate(360deg); } }`}</style>
+            {isSwitching ? (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '5px 9px', background: 'var(--soft)', borderRadius: 7 }}>
+                <div style={{ width: 14, height: 14, borderRadius: '50%', border: '2px solid var(--border)', borderTopColor: 'var(--accent)', animation: 'qp-spin 0.7s linear infinite', flexShrink: 0 }} />
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  <div style={{ fontSize: 11.5, fontWeight: 500, color: 'var(--muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    Connecting…
+                  </div>
+                  {databaseName && (
+                    <div style={{ fontSize: 10.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', opacity: 0.5 }}>
+                      {databaseName}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ) : (() => {
+              const hasMultipleAccounts = availableAccounts && availableAccounts.length > 1;
+              const hasMultipleDbs = availableDbs && availableDbs.length > 1;
+              const isPickerEnabled = hasMultipleAccounts || hasMultipleDbs;
+              return (
+                <>
+                  <div
+                    onClick={() => isPickerEnabled ? setShowDbPicker(v => !v) : undefined}
+                    style={{
+                      display: 'flex', alignItems: 'center', gap: 7,
+                      padding: '5px 9px', background: 'var(--soft)', borderRadius: 7,
+                      cursor: isPickerEnabled ? 'pointer' : 'default',
+                    }}
+                  >
+                    <span style={{ width: 14, height: 14, borderRadius: 4, background: '#1d6cf2', flexShrink: 0 }} />
+                    <div style={{ minWidth: 0, flex: 1 }}>
+                      <div style={{ fontSize: 11.5, fontWeight: 500, color: 'var(--fg)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {accountName}
+                      </div>
+                      {databaseName && (
+                        <div style={{ fontSize: 10.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {databaseName}
+                        </div>
+                      )}
+                    </div>
+                    {isPickerEnabled && (
+                      <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" style={{ color: 'var(--muted)', flexShrink: 0 }}>
+                        <path d="M4 6l4 4 4-4"/>
+                      </svg>
+                    )}
+                  </div>
+
+                  {showDbPicker && (
+                    <div style={{
+                      position: 'absolute', top: 'calc(100% + 4px)', left: 0, right: 0, zIndex: 100,
+                      background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 8,
+                      boxShadow: '0 4px 16px rgba(0,0,0,0.10)', overflow: 'hidden',
+                    }}>
+                      {/* Accounts section */}
+                      {hasMultipleAccounts && availableAccounts && (
+                        <>
+                          <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
+                            Cosmos account
+                          </div>
+                          {availableAccounts.map(acc => {
+                            const isCurrent = acc.id === accountId;
+                            return (
+                              <button
+                                key={acc.id}
+                                onClick={() => { if (!isCurrent) { setIsSwitching(true); setShowDbPicker(false); onSwitchAccount?.(acc); } }}
+                                style={{
+                                  width: '100%', display: 'flex', alignItems: 'center', gap: 8,
+                                  padding: '7px 10px', border: 'none', textAlign: 'left',
+                                  cursor: isCurrent ? 'default' : 'pointer',
+                                  background: isCurrent ? 'var(--accent-soft)' : 'transparent',
+                                  color: isCurrent ? 'var(--accent)' : 'var(--fg)',
+                                  fontSize: 12.5, fontFamily: 'var(--font-body)',
+                                }}
+                                onMouseEnter={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                                onMouseLeave={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                              >
+                                <span style={{ width: 10, height: 10, borderRadius: 3, background: isCurrent ? '#1d6cf2' : 'var(--muted)', flexShrink: 0 }} />
+                                <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{acc.name}</span>
+                                {isCurrent && (
+                                  <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ color: 'var(--accent)', flexShrink: 0 }}>
+                                    <path d="M3 8l4 4 6-6"/>
+                                  </svg>
+                                )}
+                              </button>
+                            );
+                          })}
+                        </>
+                      )}
+
+                      {/* Divider between sections */}
+                      {hasMultipleAccounts && hasMultipleDbs && (
+                        <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
+                      )}
+
+                      {/* Databases section */}
+                      {hasMultipleDbs && availableDbs && (
+                        <>
+                          <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
+                            Database
+                          </div>
+                          {availableDbs.map(db => {
+                            const isCurrent = db.name === databaseName;
+                            return (
+                              <button
+                                key={db.name}
+                                onClick={() => { if (!isCurrent) { setIsSwitching(true); setShowDbPicker(false); onSwitchDatabase?.(db); } }}
+                                style={{
+                                  width: '100%', display: 'flex', alignItems: 'center', gap: 8,
+                                  padding: '7px 10px', border: 'none', cursor: 'pointer', textAlign: 'left',
+                                  background: isCurrent ? 'var(--accent-soft)' : 'transparent',
+                                  color: isCurrent ? 'var(--accent)' : 'var(--fg)',
+                                  fontSize: 12.5, fontFamily: 'var(--font-mono)',
+                                }}
+                                onMouseEnter={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                                onMouseLeave={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                              >
+                                <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" style={{ color: isCurrent ? 'var(--accent)' : 'var(--muted)', flexShrink: 0 }}>
+                                  <ellipse cx="8" cy="4" rx="6" ry="2"/><path d="M2 4v8c0 1.1 2.7 2 6 2s6-.9 6-2V4M2 8c0 1.1 2.7 2 6 2s6-.9 6-2"/>
+                                </svg>
+                                {db.name}
+                                {isCurrent && (
+                                  <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ marginLeft: 'auto', color: 'var(--accent)', flexShrink: 0 }}>
+                                    <path d="M3 8l4 4 6-6"/>
+                                  </svg>
+                                )}
+                              </button>
+                            );
+                          })}
+                        </>
+                      )}
+                    </div>
+                  )}
+                </>
+              );
+            })()}
           </div>
         )}
       </div>
 
       {/* Navigation */}
+
       <div style={{ padding: '8px 8px 0', display: 'flex', flexDirection: 'column', gap: 1 }}>
         <div style={{
           fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em',
@@ -143,7 +295,8 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
         }}>Workspace</div>
 
         {NAV_ITEMS.map((item) => {
-          const active = item.href ? isActive(item.href, item.matchPrefix) : false;
+          const resolvedHref = item.label === 'Explorer' ? (explorerHref ?? item.href) : item.href;
+          const active = resolvedHref ? isActive(resolvedHref, item.matchPrefix) : false;
           const style: React.CSSProperties = {
             ...itemBase,
             color: active ? 'var(--fg)' : 'var(--muted)',
@@ -172,10 +325,23 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
             );
           }
 
+          if (item.label === 'Explorer' && !explorerHref) {
+            return (
+              <span
+                key={item.label}
+                style={{ ...style, opacity: 0.4, cursor: 'not-allowed' }}
+                title="Connect to a database first"
+              >
+                {iconSpan}
+                {item.label}
+              </span>
+            );
+          }
+
           return (
             <Link
-              key={item.href}
-              to={item.href!}
+              key={resolvedHref}
+              to={resolvedHref!}
               style={style}
               onMouseEnter={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
               onMouseLeave={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
@@ -196,11 +362,25 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
             fontSize: 10.5, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.08em',
             color: 'var(--muted)',
           }}>
-            <span>Collections</span>
-            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10 }}>{collections.length}</span>
+            <span>Collections <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10 }}>{collections.length}</span></span>
+            <button
+              onClick={() => setSortAlpha(v => !v)}
+              title={sortAlpha ? 'Sorted A–Z (click to reset)' : 'Sort A–Z'}
+              style={{
+                background: sortAlpha ? 'var(--accent-soft)' : 'none',
+                border: 'none', cursor: 'pointer', padding: '2px 5px', borderRadius: 4,
+                color: sortAlpha ? 'var(--accent)' : 'var(--muted)',
+                display: 'flex', alignItems: 'center', gap: 3, fontSize: 10, fontFamily: 'var(--font-body)',
+              }}
+            >
+              <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
+                <path d="M3 4h10M5 8h6M7 12h2"/>
+              </svg>
+              A–Z
+            </button>
           </div>
           <div style={{ flex: 1, overflowY: 'auto', padding: '0 8px' }}>
-            {collections.map((col) => {
+            {(sortAlpha ? [...collections].sort((a, b) => a.name.localeCompare(b.name)) : collections).map((col) => {
               const active = activeCollection === col.name;
               return (
                 <button

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
+import { CollectionSummary } from '../types';
+
+interface AppSidebarProps {
+  accountName?: string;
+  databaseName?: string;
+  collections?: CollectionSummary[];
+  activeCollection?: string;
+  onCollectionSelect?: (name: string) => void;
+}
+
+const NAV_ITEMS = [
+  {
+    label: 'Workspace',
+    href: '/query-generator',
+    icon: (
+      <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <rect x="2" y="2" width="5" height="5" rx="1.5"/>
+        <rect x="9" y="2" width="5" height="5" rx="1.5"/>
+        <rect x="2" y="9" width="5" height="5" rx="1.5"/>
+        <rect x="9" y="9" width="5" height="5" rx="1.5"/>
+      </svg>
+    ),
+  },
+  {
+    label: 'Explorer',
+    href: '/data-explorer',
+    icon: (
+      <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path d="M2 4h12M2 8h12M2 12h7"/>
+      </svg>
+    ),
+    matchPrefix: true,
+  },
+  {
+    label: 'Analytics',
+    href: '/analytics',
+    icon: (
+      <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path d="M2 13L6 8l3 3 3-5 2 2"/>
+      </svg>
+    ),
+  },
+  {
+    label: 'Audit Log',
+    href: '/audit',
+    icon: (
+      <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path d="M4 2h8a1 1 0 011 1v10a1 1 0 01-1 1H4a1 1 0 01-1-1V3a1 1 0 011-1z"/>
+        <path d="M6 6h4M6 9h3"/>
+      </svg>
+    ),
+  },
+];
+
+const AppSidebar: React.FC<AppSidebarProps> = ({
+  accountName,
+  databaseName,
+  collections,
+  activeCollection,
+  onCollectionSelect,
+}) => {
+  const location = useLocation();
+  const { logout } = useUnifiedAuth();
+
+  const isActive = (href: string, matchPrefix?: boolean) => {
+    if (matchPrefix) return location.pathname.startsWith(href);
+    return location.pathname === href;
+  };
+
+  return (
+    <aside className="qp-sidebar" style={{ fontFamily: 'var(--font-body)' }}>
+      {/* Brand */}
+      <div style={{ padding: '16px 16px 12px', borderBottom: '1px solid var(--border)' }}>
+        <Link to="/hub" style={{ textDecoration: 'none', display: 'flex', alignItems: 'center', gap: 9 }}>
+          <span style={{
+            width: 24, height: 24, borderRadius: 7, background: 'var(--fg)', color: 'var(--bg)',
+            display: 'grid', placeItems: 'center',
+            fontFamily: 'var(--font-display)', fontWeight: 600, fontSize: 14, letterSpacing: '-0.04em',
+            flexShrink: 0,
+          }}>Q</span>
+          <span style={{
+            fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 14,
+            color: 'var(--fg)', letterSpacing: '-0.01em',
+          }}>QueryPal</span>
+        </Link>
+
+        {/* Connection chip */}
+        {accountName && (
+          <div style={{
+            marginTop: 10, display: 'flex', alignItems: 'center', gap: 6,
+            padding: '5px 8px', background: 'var(--soft)', borderRadius: 7,
+          }}>
+            <span style={{
+              width: 6, height: 6, borderRadius: '50%', background: 'var(--accent)', flexShrink: 0,
+            }} />
+            <div style={{ minWidth: 0 }}>
+              <div style={{
+                fontSize: 11.5, fontWeight: 500, color: 'var(--fg)',
+                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              }}>{accountName}</div>
+              {databaseName && (
+                <div style={{
+                  fontSize: 10.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)',
+                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                }}>{databaseName}</div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Navigation */}
+      <nav style={{ padding: '8px 8px 0' }}>
+        {NAV_ITEMS.map((item) => {
+          const active = isActive(item.href, item.matchPrefix);
+          return (
+            <Link
+              key={item.href}
+              to={item.href}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 8, padding: '7px 8px',
+                borderRadius: 7, textDecoration: 'none', marginBottom: 2,
+                fontSize: 13, fontWeight: active ? 500 : 400,
+                color: active ? 'var(--fg)' : 'var(--muted)',
+                background: active ? 'var(--soft)' : 'transparent',
+                transition: 'background 0.1s, color 0.1s',
+              }}
+              onMouseEnter={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+              onMouseLeave={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+            >
+              <span style={{ color: active ? 'var(--accent)' : 'var(--muted)', display: 'flex' }}>
+                {item.icon}
+              </span>
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Collections */}
+      {collections && collections.length > 0 && (
+        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', marginTop: 8 }}>
+          <div style={{
+            padding: '6px 16px 4px',
+            fontSize: 10.5, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.08em',
+            color: 'var(--muted)',
+          }}>Collections</div>
+          <div style={{ flex: 1, overflowY: 'auto', padding: '0 8px' }}>
+            {collections.map((col) => {
+              const active = activeCollection === col.name;
+              return (
+                <button
+                  key={col.name}
+                  onClick={() => onCollectionSelect?.(col.name)}
+                  style={{
+                    width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                    padding: '6px 8px', borderRadius: 7, border: 'none', cursor: 'pointer',
+                    background: active ? 'var(--accent-soft)' : 'transparent',
+                    color: active ? 'var(--fg)' : 'var(--muted)',
+                    fontSize: 12.5, fontFamily: 'var(--font-body)', marginBottom: 1,
+                    textAlign: 'left', transition: 'background 0.1s',
+                  }}
+                  onMouseEnter={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                  onMouseLeave={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                >
+                  <span style={{
+                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                    fontFamily: 'var(--font-mono)', fontSize: 11.5,
+                  }}>{col.name}</span>
+                  <span style={{
+                    fontSize: 10, color: 'var(--muted)', flexShrink: 0, marginLeft: 4,
+                    fontFamily: 'var(--font-mono)',
+                  }}>{col.count.toLocaleString()}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Health / bottom */}
+      <div style={{
+        marginTop: 'auto', padding: '10px 16px',
+        borderTop: '1px solid var(--border)',
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'var(--muted)' }}>
+          <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--accent)', flexShrink: 0 }} />
+          Connected
+        </div>
+        <button
+          onClick={logout}
+          title="Sign out"
+          style={{
+            background: 'none', border: 'none', cursor: 'pointer',
+            color: 'var(--muted)', display: 'flex', padding: 4, borderRadius: 5,
+          }}
+        >
+          <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <path d="M6 2H3a1 1 0 00-1 1v10a1 1 0 001 1h3M11 11l3-3-3-3M14 8H6"/>
+          </svg>
+        </button>
+      </div>
+    </aside>
+  );
+};
+
+export default AppSidebar;

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -52,15 +52,6 @@ const NAV_ITEMS: NavItem[] = [
       </svg>
     ),
   },
-  {
-    label: 'Audit Log',
-    href: '/audit',
-    icon: (
-      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
-        <path d="M3 2h7l3 3v9H3zM6 7h5M6 9h5M6 11h3"/>
-      </svg>
-    ),
-  },
 ];
 
 const itemBase: React.CSSProperties = {

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
 import { CollectionSummary, DbInfo, CosmosDBAccount } from '../types';
+import { API_BASE_URL } from '../app.config';
 
 interface AppSidebarProps {
   accountName?: string;
@@ -10,7 +10,6 @@ interface AppSidebarProps {
   collections?: CollectionSummary[];
   activeCollection?: string;
   onCollectionSelect?: (name: string) => void;
-  latencyMs?: number;
   availableDbs?: DbInfo[];
   onSwitchDatabase?: (db: DbInfo) => void;
   availableAccounts?: CosmosDBAccount[];
@@ -41,16 +40,6 @@ const NAV_ITEMS: NavItem[] = [
     icon: (
       <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
         <path d="M2 3h12v3H2zM2 7h12v3H2zM2 11h12v3H2z"/>
-      </svg>
-    ),
-  },
-  {
-    label: 'Saved queries',
-    panel: 'saved',
-    icon: (
-      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
-        <path d="M4 2h6l3 3v9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1z"/>
-        <path d="M6 7h5M6 10h3"/>
       </svg>
     ),
   },
@@ -88,7 +77,6 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   collections,
   activeCollection,
   onCollectionSelect,
-  latencyMs,
   availableDbs,
   onSwitchDatabase,
   availableAccounts,
@@ -96,9 +84,9 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
 }) => {
   const location = useLocation();
   const navigate = useNavigate();
-  const { logout } = useUnifiedAuth();
   const [showDbPicker, setShowDbPicker] = useState(false);
-  const [sortAlpha, setSortAlpha] = useState(false);
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
+  const [collectionSort, setCollectionSort] = useState<'name_asc' | 'name_desc' | 'count_desc' | 'count_asc'>('name_asc');
   const [isSwitching, setIsSwitching] = useState(false);
   const chipRef = useRef<HTMLDivElement>(null);
 
@@ -117,6 +105,22 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   useEffect(() => {
     setIsSwitching(false);
   }, [accountId, databaseName]);
+
+  // Measure API latency by pinging /health every 30s
+  useEffect(() => {
+    const measure = async () => {
+      try {
+        const t0 = performance.now();
+        await fetch(`${API_BASE_URL}/health`, { method: 'GET', cache: 'no-store' });
+        setLatencyMs(Math.round(performance.now() - t0));
+      } catch {
+        setLatencyMs(null);
+      }
+    };
+    measure();
+    const id = setInterval(measure, 30_000);
+    return () => clearInterval(id);
+  }, []);
 
   const explorerHref = accountId && databaseName
     ? `/data-explorer/${encodeURIComponent(accountId)}/${encodeURIComponent(databaseName)}`
@@ -363,24 +367,30 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
             color: 'var(--muted)',
           }}>
             <span>Collections <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10 }}>{collections.length}</span></span>
-            <button
-              onClick={() => setSortAlpha(v => !v)}
-              title={sortAlpha ? 'Sorted A–Z (click to reset)' : 'Sort A–Z'}
+            <select
+              value={collectionSort}
+              onChange={(e) => setCollectionSort(e.target.value as typeof collectionSort)}
+              title="Sort collections"
               style={{
-                background: sortAlpha ? 'var(--accent-soft)' : 'none',
-                border: 'none', cursor: 'pointer', padding: '2px 5px', borderRadius: 4,
-                color: sortAlpha ? 'var(--accent)' : 'var(--muted)',
-                display: 'flex', alignItems: 'center', gap: 3, fontSize: 10, fontFamily: 'var(--font-body)',
+                fontSize: 10, fontFamily: 'var(--font-body)', color: 'var(--muted)',
+                background: 'transparent', border: 'none', cursor: 'pointer',
+                padding: '1px 2px', borderRadius: 4, outline: 'none',
+                appearance: 'none', WebkitAppearance: 'none',
               }}
             >
-              <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
-                <path d="M3 4h10M5 8h6M7 12h2"/>
-              </svg>
-              A–Z
-            </button>
+              <option value="name_asc">A → Z</option>
+              <option value="name_desc">Z → A</option>
+              <option value="count_desc">Most docs</option>
+              <option value="count_asc">Fewest docs</option>
+            </select>
           </div>
           <div style={{ flex: 1, overflowY: 'auto', padding: '0 8px' }}>
-            {(sortAlpha ? [...collections].sort((a, b) => a.name.localeCompare(b.name)) : collections).map((col) => {
+            {([...collections].sort((a, b) => {
+              if (collectionSort === 'name_asc') return a.name.localeCompare(b.name);
+              if (collectionSort === 'name_desc') return b.name.localeCompare(a.name);
+              if (collectionSort === 'count_desc') return b.count - a.count;
+              return a.count - b.count;
+            })).map((col) => {
               const active = activeCollection === col.name;
               return (
                 <button
@@ -421,24 +431,18 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
         borderTop: '1px solid var(--border)',
         display: 'flex', alignItems: 'center', gap: 6,
       }}>
-        <span className="qa-dot ok" />
-        <span style={{ fontSize: 11.5, color: 'var(--muted)', flex: 1 }}>
-          Cluster healthy{latencyMs != null ? ` · ${latencyMs}ms` : ''}
+        {latencyMs == null ? (
+          <span className="qa-dot" style={{ background: 'var(--muted)', opacity: 0.4 }} />
+        ) : latencyMs < 150 ? (
+          <span className="qa-dot ok" />
+        ) : latencyMs < 500 ? (
+          <span className="qa-dot" style={{ background: 'var(--status-warn, #d97706)' }} />
+        ) : (
+          <span className="qa-dot" style={{ background: 'var(--status-err)' }} />
+        )}
+        <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>
+          {latencyMs == null ? 'Connecting…' : latencyMs < 150 ? `${latencyMs}ms · healthy` : latencyMs < 500 ? `${latencyMs}ms · slow` : `${latencyMs}ms · degraded`}
         </span>
-        <button
-          onClick={logout}
-          title="Sign out"
-          style={{
-            background: 'none', border: 'none', cursor: 'pointer',
-            color: 'var(--muted)', display: 'flex', padding: 4, borderRadius: 5,
-          }}
-          onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--fg)'; }}
-          onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
-        >
-          <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-            <path d="M6 2H3a1 1 0 00-1 1v10a1 1 0 001 1h3M11 11l3-3-3-3M14 8H6"/>
-          </svg>
-        </button>
       </div>
     </aside>
   );

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
 import { CollectionSummary } from '../types';
 
@@ -9,14 +9,19 @@ interface AppSidebarProps {
   collections?: CollectionSummary[];
   activeCollection?: string;
   onCollectionSelect?: (name: string) => void;
+  latencyMs?: number;
 }
 
-const NAV_ITEMS = [
+type NavItem =
+  | { label: string; href: string; matchPrefix?: boolean; panel?: never; icon: React.ReactNode }
+  | { label: string; panel: string; href?: never; matchPrefix?: never; icon: React.ReactNode };
+
+const NAV_ITEMS: NavItem[] = [
   {
     label: 'Workspace',
     href: '/query-generator',
     icon: (
-      <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
         <rect x="2" y="2" width="5" height="5" rx="1.5"/>
         <rect x="9" y="2" width="5" height="5" rx="1.5"/>
         <rect x="2" y="9" width="5" height="5" rx="1.5"/>
@@ -27,19 +32,29 @@ const NAV_ITEMS = [
   {
     label: 'Explorer',
     href: '/data-explorer',
+    matchPrefix: true,
     icon: (
-      <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-        <path d="M2 4h12M2 8h12M2 12h7"/>
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+        <path d="M2 3h12v3H2zM2 7h12v3H2zM2 11h12v3H2z"/>
       </svg>
     ),
-    matchPrefix: true,
+  },
+  {
+    label: 'Saved queries',
+    panel: 'saved',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+        <path d="M4 2h6l3 3v9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1z"/>
+        <path d="M6 7h5M6 10h3"/>
+      </svg>
+    ),
   },
   {
     label: 'Analytics',
     href: '/analytics',
     icon: (
-      <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-        <path d="M2 13L6 8l3 3 3-5 2 2"/>
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+        <path d="M2 13h12M4 11V6M7 11V3M10 11V8M13 11V5"/>
       </svg>
     ),
   },
@@ -47,13 +62,19 @@ const NAV_ITEMS = [
     label: 'Audit Log',
     href: '/audit',
     icon: (
-      <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-        <path d="M4 2h8a1 1 0 011 1v10a1 1 0 01-1 1H4a1 1 0 01-1-1V3a1 1 0 011-1z"/>
-        <path d="M6 6h4M6 9h3"/>
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+        <path d="M3 2h7l3 3v9H3zM6 7h5M6 9h5M6 11h3"/>
       </svg>
     ),
   },
 ];
+
+const itemBase: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', gap: 8, padding: '5px 8px',
+  borderRadius: 6, fontSize: 12.5, cursor: 'pointer', textDecoration: 'none',
+  width: '100%', border: 'none', background: 'none', fontFamily: 'var(--font-body)',
+  transition: 'background 0.1s, color 0.1s', textAlign: 'left',
+};
 
 const AppSidebar: React.FC<AppSidebarProps> = ({
   accountName,
@@ -61,8 +82,10 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   collections,
   activeCollection,
   onCollectionSelect,
+  latencyMs,
 }) => {
   const location = useLocation();
+  const navigate = useNavigate();
   const { logout } = useUnifiedAuth();
 
   const isActive = (href: string, matchPrefix?: boolean) => {
@@ -73,7 +96,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   return (
     <aside className="qp-sidebar" style={{ fontFamily: 'var(--font-body)' }}>
       {/* Brand */}
-      <div style={{ padding: '16px 16px 12px', borderBottom: '1px solid var(--border)' }}>
+      <div style={{ padding: '14px 10px 12px', borderBottom: '1px solid var(--border)', display: 'flex', flexDirection: 'column', gap: 10 }}>
         <Link to="/hub" style={{ textDecoration: 'none', display: 'flex', alignItems: 'center', gap: 9 }}>
           <span style={{
             width: 24, height: 24, borderRadius: 7, background: 'var(--fg)', color: 'var(--bg)',
@@ -90,13 +113,13 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
         {/* Connection chip */}
         {accountName && (
           <div style={{
-            marginTop: 10, display: 'flex', alignItems: 'center', gap: 6,
-            padding: '5px 8px', background: 'var(--soft)', borderRadius: 7,
+            display: 'flex', alignItems: 'center', gap: 7,
+            padding: '5px 9px', background: 'var(--soft)', borderRadius: 7,
           }}>
             <span style={{
-              width: 6, height: 6, borderRadius: '50%', background: 'var(--accent)', flexShrink: 0,
+              width: 14, height: 14, borderRadius: 4, background: '#1d6cf2', flexShrink: 0,
             }} />
-            <div style={{ minWidth: 0 }}>
+            <div style={{ minWidth: 0, flex: 1 }}>
               <div style={{
                 fontSize: 11.5, fontWeight: 500, color: 'var(--fg)',
                 overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
@@ -113,41 +136,69 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
       </div>
 
       {/* Navigation */}
-      <nav style={{ padding: '8px 8px 0' }}>
+      <div style={{ padding: '8px 8px 0', display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <div style={{
+          fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em',
+          color: 'var(--muted)', padding: '0 8px 6px', fontWeight: 500,
+        }}>Workspace</div>
+
         {NAV_ITEMS.map((item) => {
-          const active = isActive(item.href, item.matchPrefix);
+          const active = item.href ? isActive(item.href, item.matchPrefix) : false;
+          const style: React.CSSProperties = {
+            ...itemBase,
+            color: active ? 'var(--fg)' : 'var(--muted)',
+            background: active ? 'var(--soft)' : 'transparent',
+            fontWeight: active ? 500 : 400,
+          };
+
+          const iconSpan = (
+            <span style={{ color: active ? 'var(--accent)' : 'var(--muted)', display: 'flex', flexShrink: 0 }}>
+              {item.icon}
+            </span>
+          );
+
+          if (item.panel) {
+            return (
+              <button
+                key={item.label}
+                onClick={() => navigate('/query-generator?panel=' + item.panel)}
+                style={style}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+              >
+                {iconSpan}
+                {item.label}
+              </button>
+            );
+          }
+
           return (
             <Link
               key={item.href}
-              to={item.href}
-              style={{
-                display: 'flex', alignItems: 'center', gap: 8, padding: '7px 8px',
-                borderRadius: 7, textDecoration: 'none', marginBottom: 2,
-                fontSize: 13, fontWeight: active ? 500 : 400,
-                color: active ? 'var(--fg)' : 'var(--muted)',
-                background: active ? 'var(--soft)' : 'transparent',
-                transition: 'background 0.1s, color 0.1s',
-              }}
+              to={item.href!}
+              style={style}
               onMouseEnter={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
               onMouseLeave={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
             >
-              <span style={{ color: active ? 'var(--accent)' : 'var(--muted)', display: 'flex' }}>
-                {item.icon}
-              </span>
+              {iconSpan}
               {item.label}
             </Link>
           );
         })}
-      </nav>
+      </div>
 
       {/* Collections */}
       {collections && collections.length > 0 && (
-        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', marginTop: 8 }}>
+        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', marginTop: 12 }}>
           <div style={{
-            padding: '6px 16px 4px',
+            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+            padding: '0 8px 6px 8px',
             fontSize: 10.5, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.08em',
             color: 'var(--muted)',
-          }}>Collections</div>
+          }}>
+            <span>Collections</span>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10 }}>{collections.length}</span>
+          </div>
           <div style={{ flex: 1, overflowY: 'auto', padding: '0 8px' }}>
             {collections.map((col) => {
               const active = activeCollection === col.name;
@@ -156,8 +207,8 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                   key={col.name}
                   onClick={() => onCollectionSelect?.(col.name)}
                   style={{
-                    width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                    padding: '6px 8px', borderRadius: 7, border: 'none', cursor: 'pointer',
+                    width: '100%', display: 'flex', alignItems: 'center',
+                    padding: '5px 8px', borderRadius: 6, border: 'none', cursor: 'pointer',
                     background: active ? 'var(--accent-soft)' : 'transparent',
                     color: active ? 'var(--fg)' : 'var(--muted)',
                     fontSize: 12.5, fontFamily: 'var(--font-body)', marginBottom: 1,
@@ -166,8 +217,11 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                   onMouseEnter={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
                   onMouseLeave={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
                 >
+                  <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" style={{ marginRight: 7, flexShrink: 0, color: active ? 'var(--accent)' : 'var(--muted)' }}>
+                    <ellipse cx="8" cy="4" rx="6" ry="2"/><path d="M2 4v8c0 1.1 2.7 2 6 2s6-.9 6-2V4M2 8c0 1.1 2.7 2 6 2s6-.9 6-2"/>
+                  </svg>
                   <span style={{
-                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1,
                     fontFamily: 'var(--font-mono)', fontSize: 11.5,
                   }}>{col.name}</span>
                   <span style={{
@@ -183,14 +237,14 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
 
       {/* Health / bottom */}
       <div style={{
-        marginTop: 'auto', padding: '10px 16px',
+        marginTop: 'auto', padding: '8px 10px',
         borderTop: '1px solid var(--border)',
-        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        display: 'flex', alignItems: 'center', gap: 6,
       }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'var(--muted)' }}>
-          <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--accent)', flexShrink: 0 }} />
-          Connected
-        </div>
+        <span className="qa-dot ok" />
+        <span style={{ fontSize: 11.5, color: 'var(--muted)', flex: 1 }}>
+          Cluster healthy{latencyMs != null ? ` · ${latencyMs}ms` : ''}
+        </span>
         <button
           onClick={logout}
           title="Sign out"
@@ -198,6 +252,8 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
             background: 'none', border: 'none', cursor: 'pointer',
             color: 'var(--muted)', display: 'flex', padding: 4, borderRadius: 5,
           }}
+          onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--fg)'; }}
+          onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
         >
           <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
             <path d="M6 2H3a1 1 0 00-1 1v10a1 1 0 001 1h3M11 11l3-3-3-3M14 8H6"/>

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -78,7 +78,6 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   const [showDbPicker, setShowDbPicker] = useState(false);
   const [latencyMs, setLatencyMs] = useState<number | null>(null);
   const [collectionSort, setCollectionSort] = useState<'name_asc' | 'name_desc' | 'count_desc' | 'count_asc'>('name_asc');
-  const [isSwitching, setIsSwitching] = useState(false);
   const chipRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -91,11 +90,6 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
   }, [showDbPicker]);
-
-  // Reset loading state whenever the connection actually changes
-  useEffect(() => {
-    setIsSwitching(false);
-  }, [accountId, databaseName]);
 
   // Measure API latency by pinging /health every 30s
   useEffect(() => {
@@ -139,145 +133,128 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
           }}>QueryPal</span>
         </Link>
 
-        {/* Connection chip */}
-        {(accountName || isSwitching) && (
-          <div ref={chipRef} style={{ position: 'relative' }}>
-            <style>{`
-              @keyframes qp-spin { to { transform: rotate(360deg); } }
-              @keyframes qp-pulse { 0%,100% { opacity: 0.45; } 50% { opacity: 0.9; } }
-            `}</style>
-            {isSwitching ? (
-              <div style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '5px 9px', background: 'var(--soft)', borderRadius: 7 }}>
-                <div style={{ width: 14, height: 14, borderRadius: '50%', border: '2px solid var(--border)', borderTopColor: 'var(--accent)', animation: 'qp-spin 0.7s linear infinite', flexShrink: 0 }} />
-                <div style={{ minWidth: 0, flex: 1 }}>
-                  <div style={{ fontSize: 11.5, fontWeight: 500, color: 'var(--muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                    Connecting…
-                  </div>
-                  <div style={{ height: 9, marginTop: 3, borderRadius: 4, background: 'var(--border)', animation: 'qp-pulse 1.4s ease-in-out infinite', width: '70%' }} />
-                </div>
+        {/* Connection chip — always rendered so the brand section never changes height */}
+        <div ref={chipRef} style={{ position: 'relative' }}>
+          {!accountName ? (
+            /* Placeholder keeps the same height as the real chip */
+            <div style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '5px 9px', background: 'var(--soft)', borderRadius: 7 }}>
+              <span style={{ width: 14, height: 14, borderRadius: 4, background: 'var(--border)', flexShrink: 0 }} />
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <div style={{ height: 11, borderRadius: 3, background: 'var(--border)', width: '65%', marginBottom: 4 }} />
+                <div style={{ height: 9, borderRadius: 3, background: 'var(--border)', width: '45%' }} />
               </div>
-            ) : (() => {
-              const hasMultipleAccounts = availableAccounts && availableAccounts.length > 1;
-              const hasMultipleDbs = availableDbs && availableDbs.length > 1;
-              const isPickerEnabled = hasMultipleAccounts || hasMultipleDbs;
-              return (
-                <>
-                  <div
-                    onClick={() => isPickerEnabled ? setShowDbPicker(v => !v) : undefined}
-                    style={{
-                      display: 'flex', alignItems: 'center', gap: 7,
-                      padding: '5px 9px', background: 'var(--soft)', borderRadius: 7,
-                      cursor: isPickerEnabled ? 'pointer' : 'default',
-                    }}
-                  >
-                    <span style={{ width: 14, height: 14, borderRadius: 4, background: '#1d6cf2', flexShrink: 0 }} />
-                    <div style={{ minWidth: 0, flex: 1 }}>
-                      <div style={{ fontSize: 11.5, fontWeight: 500, color: 'var(--fg)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                        {accountName}
-                      </div>
-                      {databaseName && (
-                        <div style={{ fontSize: 10.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                          {databaseName}
-                        </div>
-                      )}
-                    </div>
-                    {isPickerEnabled && (
-                      <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" style={{ color: 'var(--muted)', flexShrink: 0 }}>
-                        <path d="M4 6l4 4 4-4"/>
-                      </svg>
-                    )}
+            </div>
+          ) : (
+            <>
+              <div
+                onClick={() => ((availableAccounts && availableAccounts.length > 1) || (availableDbs && availableDbs.length > 1)) ? setShowDbPicker(v => !v) : undefined}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 7,
+                  padding: '5px 9px', background: 'var(--soft)', borderRadius: 7,
+                  cursor: ((availableAccounts && availableAccounts.length > 1) || (availableDbs && availableDbs.length > 1)) ? 'pointer' : 'default',
+                }}
+              >
+                <span style={{ width: 14, height: 14, borderRadius: 4, background: '#1d6cf2', flexShrink: 0 }} />
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  <div style={{ fontSize: 11.5, fontWeight: 500, color: 'var(--fg)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {accountName}
                   </div>
-
-                  {showDbPicker && (
-                    <div style={{
-                      position: 'absolute', top: 'calc(100% + 4px)', left: 0, right: 0, zIndex: 100,
-                      background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 8,
-                      boxShadow: '0 4px 16px rgba(0,0,0,0.10)', overflow: 'hidden',
-                    }}>
-                      {/* Accounts section */}
-                      {hasMultipleAccounts && availableAccounts && (
-                        <>
-                          <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
-                            Cosmos account
-                          </div>
-                          {availableAccounts.map(acc => {
-                            const isCurrent = acc.id === accountId;
-                            return (
-                              <button
-                                key={acc.id}
-                                onClick={() => { if (!isCurrent) { setIsSwitching(true); setShowDbPicker(false); onSwitchAccount?.(acc); } }}
-                                style={{
-                                  width: '100%', display: 'flex', alignItems: 'center', gap: 8,
-                                  padding: '7px 10px', border: 'none', textAlign: 'left',
-                                  cursor: isCurrent ? 'default' : 'pointer',
-                                  background: isCurrent ? 'var(--accent-soft)' : 'transparent',
-                                  color: isCurrent ? 'var(--accent)' : 'var(--fg)',
-                                  fontSize: 12.5, fontFamily: 'var(--font-body)',
-                                }}
-                                onMouseEnter={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
-                                onMouseLeave={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
-                              >
-                                <span style={{ width: 10, height: 10, borderRadius: 3, background: isCurrent ? '#1d6cf2' : 'var(--muted)', flexShrink: 0 }} />
-                                <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{acc.name}</span>
-                                {isCurrent && (
-                                  <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ color: 'var(--accent)', flexShrink: 0 }}>
-                                    <path d="M3 8l4 4 6-6"/>
-                                  </svg>
-                                )}
-                              </button>
-                            );
-                          })}
-                        </>
-                      )}
-
-                      {/* Divider between sections */}
-                      {hasMultipleAccounts && hasMultipleDbs && (
-                        <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
-                      )}
-
-                      {/* Databases section */}
-                      {hasMultipleDbs && availableDbs && (
-                        <>
-                          <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
-                            Database
-                          </div>
-                          {availableDbs.map(db => {
-                            const isCurrent = db.name === databaseName;
-                            return (
-                              <button
-                                key={db.name}
-                                onClick={() => { if (!isCurrent) { setIsSwitching(true); setShowDbPicker(false); onSwitchDatabase?.(db); } }}
-                                style={{
-                                  width: '100%', display: 'flex', alignItems: 'center', gap: 8,
-                                  padding: '7px 10px', border: 'none', cursor: 'pointer', textAlign: 'left',
-                                  background: isCurrent ? 'var(--accent-soft)' : 'transparent',
-                                  color: isCurrent ? 'var(--accent)' : 'var(--fg)',
-                                  fontSize: 12.5, fontFamily: 'var(--font-mono)',
-                                }}
-                                onMouseEnter={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
-                                onMouseLeave={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
-                              >
-                                <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" style={{ color: isCurrent ? 'var(--accent)' : 'var(--muted)', flexShrink: 0 }}>
-                                  <ellipse cx="8" cy="4" rx="6" ry="2"/><path d="M2 4v8c0 1.1 2.7 2 6 2s6-.9 6-2V4M2 8c0 1.1 2.7 2 6 2s6-.9 6-2"/>
-                                </svg>
-                                {db.name}
-                                {isCurrent && (
-                                  <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ marginLeft: 'auto', color: 'var(--accent)', flexShrink: 0 }}>
-                                    <path d="M3 8l4 4 6-6"/>
-                                  </svg>
-                                )}
-                              </button>
-                            );
-                          })}
-                        </>
-                      )}
+                  {databaseName && (
+                    <div style={{ fontSize: 10.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {databaseName}
                     </div>
                   )}
-                </>
-              );
-            })()}
-          </div>
-        )}
+                </div>
+                {((availableAccounts && availableAccounts.length > 1) || (availableDbs && availableDbs.length > 1)) && (
+                  <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" style={{ color: 'var(--muted)', flexShrink: 0 }}>
+                    <path d="M4 6l4 4 4-4"/>
+                  </svg>
+                )}
+              </div>
+
+              {showDbPicker && (
+                <div style={{
+                  position: 'absolute', top: 'calc(100% + 4px)', left: 0, right: 0, zIndex: 100,
+                  background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 8,
+                  boxShadow: '0 4px 16px rgba(0,0,0,0.10)', overflow: 'hidden',
+                }}>
+                  {availableAccounts && availableAccounts.length > 1 && (
+                    <>
+                      <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
+                        Cosmos account
+                      </div>
+                      {availableAccounts.map(acc => {
+                        const isCurrent = acc.id === accountId;
+                        return (
+                          <button
+                            key={acc.id}
+                            onClick={() => { if (!isCurrent) { setShowDbPicker(false); onSwitchAccount?.(acc); } }}
+                            style={{
+                              width: '100%', display: 'flex', alignItems: 'center', gap: 8,
+                              padding: '7px 10px', border: 'none', textAlign: 'left',
+                              cursor: isCurrent ? 'default' : 'pointer',
+                              background: isCurrent ? 'var(--accent-soft)' : 'transparent',
+                              color: isCurrent ? 'var(--accent)' : 'var(--fg)',
+                              fontSize: 12.5, fontFamily: 'var(--font-body)',
+                            }}
+                            onMouseEnter={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                            onMouseLeave={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                          >
+                            <span style={{ width: 10, height: 10, borderRadius: 3, background: isCurrent ? '#1d6cf2' : 'var(--muted)', flexShrink: 0 }} />
+                            <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{acc.name}</span>
+                            {isCurrent && (
+                              <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ color: 'var(--accent)', flexShrink: 0 }}>
+                                <path d="M3 8l4 4 6-6"/>
+                              </svg>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </>
+                  )}
+                  {availableAccounts && availableAccounts.length > 1 && availableDbs && availableDbs.length > 1 && (
+                    <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
+                  )}
+                  {availableDbs && availableDbs.length > 1 && (
+                    <>
+                      <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
+                        Database
+                      </div>
+                      {availableDbs.map(db => {
+                        const isCurrent = db.name === databaseName;
+                        return (
+                          <button
+                            key={db.name}
+                            onClick={() => { if (!isCurrent) { setShowDbPicker(false); onSwitchDatabase?.(db); } }}
+                            style={{
+                              width: '100%', display: 'flex', alignItems: 'center', gap: 8,
+                              padding: '7px 10px', border: 'none', cursor: 'pointer', textAlign: 'left',
+                              background: isCurrent ? 'var(--accent-soft)' : 'transparent',
+                              color: isCurrent ? 'var(--accent)' : 'var(--fg)',
+                              fontSize: 12.5, fontFamily: 'var(--font-mono)',
+                            }}
+                            onMouseEnter={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                            onMouseLeave={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                          >
+                            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" style={{ color: isCurrent ? 'var(--accent)' : 'var(--muted)', flexShrink: 0 }}>
+                              <ellipse cx="8" cy="4" rx="6" ry="2"/><path d="M2 4v8c0 1.1 2.7 2 6 2s6-.9 6-2V4M2 8c0 1.1 2.7 2 6 2s6-.9 6-2"/>
+                            </svg>
+                            {db.name}
+                            {isCurrent && (
+                              <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ marginLeft: 'auto', color: 'var(--accent)', flexShrink: 0 }}>
+                                <path d="M3 8l4 4 6-6"/>
+                              </svg>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
       </div>
 
       {/* Navigation */}
@@ -347,23 +324,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
         })}
       </div>
 
-      {/* Collections — skeleton while switching, real list when loaded */}
-      {isSwitching && (
-        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', marginTop: 12 }}>
-          <div style={{ padding: '0 8px 6px 8px', fontSize: 10.5, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)' }}>
-            Collections
-          </div>
-          <div style={{ padding: '0 8px', display: 'flex', flexDirection: 'column', gap: 4 }}>
-            {[60, 80, 50].map((w, i) => (
-              <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '5px 8px' }}>
-                <div style={{ width: 11, height: 11, borderRadius: 3, background: 'var(--border)', flexShrink: 0, animation: 'qp-pulse 1.4s ease-in-out infinite' }} />
-                <div style={{ height: 10, borderRadius: 4, background: 'var(--border)', width: `${w}%`, animation: 'qp-pulse 1.4s ease-in-out infinite', animationDelay: `${i * 0.15}s` }} />
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-      {!isSwitching && collections && collections.length > 0 && (
+      {collections && collections.length > 0 && (
         <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', marginTop: 12 }}>
           <div style={{
             display: 'flex', alignItems: 'center', justifyContent: 'space-between',

--- a/frontend/components/AppTopBar.tsx
+++ b/frontend/components/AppTopBar.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
 import { useTheme } from '../contexts/ThemeContext';
 
@@ -15,12 +16,41 @@ const AppTopBar: React.FC<AppTopBarProps> = ({
   collectionName,
   onNewQuery,
 }) => {
-  const { user } = useUnifiedAuth();
+  const { user, logout } = useUnifiedAuth();
   const { theme, toggleTheme } = useTheme();
+  const navigate = useNavigate();
+  const [showUserMenu, setShowUserMenu] = useState(false);
+  const [showSignOutConfirm, setShowSignOutConfirm] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   const initials = user?.name
     ? user.name.split(' ').map((n) => n[0]).join('').slice(0, 2).toUpperCase()
     : 'U';
+
+  useEffect(() => {
+    if (!showUserMenu) return;
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setShowUserMenu(false);
+        setShowSignOutConfirm(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [showUserMenu]);
+
+  const handleAvatarClick = () => {
+    setShowUserMenu(v => !v);
+    setShowSignOutConfirm(false);
+  };
+
+  const handleSignOutClick = () => {
+    setShowSignOutConfirm(true);
+  };
+
+  const handleSignOutConfirm = () => {
+    logout();
+  };
 
   return (
     <header className="qp-topbar">
@@ -71,7 +101,7 @@ const AppTopBar: React.FC<AppTopBarProps> = ({
         </button>
       )}
 
-      {/* Theme toggle — shows icon for what you'll switch TO */}
+      {/* Theme toggle */}
       <button
         onClick={toggleTheme}
         title="Toggle theme"
@@ -81,12 +111,10 @@ const AppTopBar: React.FC<AppTopBarProps> = ({
         }}
       >
         {theme === 'light' ? (
-          /* Moon: click to go dark */
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
           </svg>
         ) : (
-          /* Sun: click to go light */
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="12" cy="12" r="4"/>
             <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
@@ -108,18 +136,130 @@ const AppTopBar: React.FC<AppTopBarProps> = ({
         </svg>
       </button>
 
-      {/* User avatar */}
-      <div
-        title={user?.name || user?.email}
-        style={{
-          width: 28, height: 28, borderRadius: '50%',
-          background: 'var(--accent-soft)', color: 'var(--accent)',
-          display: 'grid', placeItems: 'center',
-          fontSize: 11, fontWeight: 600, fontFamily: 'var(--font-body)',
-          cursor: 'default',
-        }}
-      >
-        {initials}
+      {/* User avatar + dropdown */}
+      <div ref={menuRef} style={{ position: 'relative' }}>
+        <button
+          onClick={handleAvatarClick}
+          title={user?.name || user?.email}
+          style={{
+            width: 28, height: 28, borderRadius: '50%',
+            background: showUserMenu ? 'var(--accent)' : 'var(--accent-soft)',
+            color: showUserMenu ? '#fff' : 'var(--accent)',
+            display: 'grid', placeItems: 'center',
+            fontSize: 11, fontWeight: 600, fontFamily: 'var(--font-body)',
+            cursor: 'pointer', border: 'none',
+            transition: 'background 0.15s, color 0.15s',
+          }}
+        >
+          {initials}
+        </button>
+
+        {showUserMenu && (
+          <div style={{
+            position: 'absolute', top: 'calc(100% + 8px)', right: 0, zIndex: 200,
+            background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 10,
+            boxShadow: '0 8px 24px rgba(0,0,0,0.12)', minWidth: 220,
+            overflow: 'hidden',
+          }}>
+            {/* User info */}
+            <div style={{ padding: '12px 14px 10px', borderBottom: '1px solid var(--border)' }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--fg)', fontFamily: 'var(--font-body)', marginBottom: 2 }}>
+                {user?.name || 'User'}
+              </div>
+              {user?.email && (
+                <div style={{ fontSize: 11.5, color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>
+                  {user.email}
+                </div>
+              )}
+            </div>
+
+            {/* Saved queries */}
+            <div style={{ padding: '6px 6px' }}>
+              <button
+                onClick={() => { setShowUserMenu(false); navigate('/query-generator?panel=saved'); }}
+                style={{
+                  width: '100%', display: 'flex', alignItems: 'center', gap: 9,
+                  padding: '7px 10px', borderRadius: 7, border: 'none',
+                  background: 'transparent', color: 'var(--fg)',
+                  fontSize: 12.5, fontFamily: 'var(--font-body)', cursor: 'pointer', textAlign: 'left',
+                }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+              >
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" style={{ color: 'var(--muted)', flexShrink: 0 }}>
+                  <path d="M4 2h6l3 3v9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1z"/>
+                  <path d="M6 7h5M6 10h3"/>
+                </svg>
+                Saved queries
+              </button>
+            </div>
+
+            {/* Divider */}
+            <div style={{ height: 1, background: 'var(--border)', margin: '0 6px' }} />
+
+            {/* Sign out */}
+            <div style={{ padding: '6px 6px' }}>
+              {!showSignOutConfirm ? (
+                <button
+                  onClick={handleSignOutClick}
+                  style={{
+                    width: '100%', display: 'flex', alignItems: 'center', gap: 9,
+                    padding: '7px 10px', borderRadius: 7, border: 'none',
+                    background: 'transparent', color: 'var(--fg)',
+                    fontSize: 12.5, fontFamily: 'var(--font-body)', cursor: 'pointer', textAlign: 'left',
+                  }}
+                  onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = 'color-mix(in oklch, var(--status-err) 8%, var(--panel))'; (e.currentTarget as HTMLElement).style.color = 'var(--status-err)'; }}
+                  onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; (e.currentTarget as HTMLElement).style.color = 'var(--fg)'; }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ flexShrink: 0 }}>
+                    <path d="M6 2H3a1 1 0 00-1 1v10a1 1 0 001 1h3M11 11l3-3-3-3M14 8H6"/>
+                  </svg>
+                  Sign out
+                </button>
+              ) : (
+                <div style={{
+                  padding: '10px 10px 8px',
+                  background: 'color-mix(in oklch, var(--status-err) 7%, var(--panel))',
+                  borderRadius: 7,
+                }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 8 }}>
+                    <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="var(--status-err)" strokeWidth="1.5" style={{ flexShrink: 0 }}>
+                      <path d="M8 1L15 14H1L8 1z"/><path d="M8 6v4M8 11.5v.5"/>
+                    </svg>
+                    <span style={{ fontSize: 12, color: 'var(--status-err)', fontFamily: 'var(--font-body)', fontWeight: 500 }}>
+                      Sign out of QueryPal?
+                    </span>
+                  </div>
+                  <p style={{ fontSize: 11.5, color: 'var(--muted)', fontFamily: 'var(--font-body)', margin: '0 0 10px', lineHeight: 1.4 }}>
+                    Any unsaved changes will be lost.
+                  </p>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    <button
+                      onClick={() => setShowSignOutConfirm(false)}
+                      style={{
+                        flex: 1, padding: '5px 0', borderRadius: 6, border: '1px solid var(--border)',
+                        background: 'var(--panel)', color: 'var(--fg)', fontSize: 12,
+                        fontFamily: 'var(--font-body)', cursor: 'pointer', fontWeight: 500,
+                      }}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={handleSignOutConfirm}
+                      style={{
+                        flex: 1, padding: '5px 0', borderRadius: 6, border: '1px solid var(--status-err)',
+                        background: 'var(--status-err)', color: '#fff', fontSize: 12,
+                        fontFamily: 'var(--font-body)', cursor: 'pointer', fontWeight: 600,
+                      }}
+                    >
+                      Sign out
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
       </div>
     </header>
   );

--- a/frontend/components/AppTopBar.tsx
+++ b/frontend/components/AppTopBar.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
+import { useTheme } from '../contexts/ThemeContext';
+
+interface AppTopBarProps {
+  accountName?: string;
+  databaseName?: string;
+  collectionName?: string;
+  onNewQuery?: () => void;
+}
+
+const AppTopBar: React.FC<AppTopBarProps> = ({
+  accountName,
+  databaseName,
+  collectionName,
+  onNewQuery,
+}) => {
+  const { user } = useUnifiedAuth();
+  const { theme, toggleTheme } = useTheme();
+
+  const initials = user?.name
+    ? user.name.split(' ').map((n) => n[0]).join('').slice(0, 2).toUpperCase()
+    : 'U';
+
+  return (
+    <header className="qp-topbar">
+      {/* Breadcrumb */}
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 5, fontSize: 12.5, color: 'var(--muted)', minWidth: 0 }}>
+        {accountName && (
+          <>
+            <span style={{ color: 'var(--fg)', fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 140 }}>{accountName}</span>
+          </>
+        )}
+        {databaseName && (
+          <>
+            <span style={{ opacity: 0.4 }}>›</span>
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 140 }}>{databaseName}</span>
+          </>
+        )}
+        {collectionName && (
+          <>
+            <span style={{ opacity: 0.4 }}>›</span>
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 120 }}>{collectionName}</span>
+          </>
+        )}
+      </div>
+
+      {/* ⌘K hint */}
+      <button
+        style={{
+          display: 'flex', alignItems: 'center', gap: 6,
+          padding: '5px 10px', border: '1px solid var(--border)', borderRadius: 7,
+          background: 'var(--soft)', color: 'var(--muted)', fontSize: 12,
+          cursor: 'pointer', fontFamily: 'var(--font-body)',
+        }}
+        title="Command palette (coming soon)"
+      >
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <circle cx="7" cy="7" r="4.5"/>
+          <path d="M10.5 10.5l3 3"/>
+        </svg>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>⌘K</span>
+      </button>
+
+      {onNewQuery && (
+        <button className="qa-btn primary" onClick={onNewQuery} style={{ fontSize: 12.5 }}>
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M8 3v10M3 8h10"/>
+          </svg>
+          New query
+        </button>
+      )}
+
+      {/* Theme toggle — shows icon for what you'll switch TO */}
+      <button
+        onClick={toggleTheme}
+        title="Toggle theme"
+        style={{
+          background: 'none', border: 'none', cursor: 'pointer',
+          color: 'var(--muted)', display: 'flex', padding: 5, borderRadius: 6,
+        }}
+      >
+        {theme === 'light' ? (
+          /* Moon: click to go dark */
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+          </svg>
+        ) : (
+          /* Sun: click to go light */
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="4"/>
+            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+          </svg>
+        )}
+      </button>
+
+      {/* Notifications */}
+      <button
+        style={{
+          background: 'none', border: 'none', cursor: 'pointer',
+          color: 'var(--muted)', display: 'flex', padding: 5, borderRadius: 6,
+        }}
+        title="Notifications"
+      >
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <path d="M8 1.5A3.5 3.5 0 0111.5 5v3.5l1 1.5H3.5l1-1.5V5A3.5 3.5 0 018 1.5z"/>
+          <path d="M6.5 13a1.5 1.5 0 003 0"/>
+        </svg>
+      </button>
+
+      {/* User avatar */}
+      <div
+        title={user?.name || user?.email}
+        style={{
+          width: 28, height: 28, borderRadius: '50%',
+          background: 'var(--accent-soft)', color: 'var(--accent)',
+          display: 'grid', placeItems: 'center',
+          fontSize: 11, fontWeight: 600, fontFamily: 'var(--font-body)',
+          cursor: 'default',
+        }}
+      >
+        {initials}
+      </div>
+    </header>
+  );
+};
+
+export default AppTopBar;

--- a/frontend/components/AppTopBar.tsx
+++ b/frontend/components/AppTopBar.tsx
@@ -8,6 +8,7 @@ interface AppTopBarProps {
   databaseName?: string;
   collectionName?: string;
   onNewQuery?: () => void;
+  onOpenPalette?: () => void;
 }
 
 const AppTopBar: React.FC<AppTopBarProps> = ({
@@ -15,6 +16,7 @@ const AppTopBar: React.FC<AppTopBarProps> = ({
   databaseName,
   collectionName,
   onNewQuery,
+  onOpenPalette,
 }) => {
   const { user, logout } = useUnifiedAuth();
   const { theme, toggleTheme } = useTheme();
@@ -75,15 +77,16 @@ const AppTopBar: React.FC<AppTopBarProps> = ({
         )}
       </div>
 
-      {/* ⌘K hint */}
+      {/* ⌘K command palette trigger */}
       <button
+        onClick={onOpenPalette}
         style={{
           display: 'flex', alignItems: 'center', gap: 6,
           padding: '5px 10px', border: '1px solid var(--border)', borderRadius: 7,
           background: 'var(--soft)', color: 'var(--muted)', fontSize: 12,
           cursor: 'pointer', fontFamily: 'var(--font-body)',
         }}
-        title="Command palette (coming soon)"
+        title="Command palette (⌘K)"
       >
         <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
           <circle cx="7" cy="7" r="4.5"/>

--- a/frontend/components/CollectionActionPanel.tsx
+++ b/frontend/components/CollectionActionPanel.tsx
@@ -1,22 +1,12 @@
 
 import React, { useState, useEffect } from 'react';
 import { CollectionInfo } from '../types';
-import { XIcon, InfoIcon, ChevronDownIcon, IndexIcon, FileJsonIcon } from './icons/material-icons-imports';
+import { XIcon, ChevronDownIcon } from './icons/material-icons-imports';
 
-// --- New Schema Viewer Components ---
-
-/**
- * Infers the displayable type of a given value, detecting BSON types.
- * @param value The value to infer the type from.
- * @returns A string representing the type.
- */
 const getType = (value: any): string => {
   if (value === null) return 'null';
   if (Array.isArray(value)) {
-    if (value.length > 0) {
-      // Show the type of elements within the array
-      return `Array<${getType(value[0])}>`;
-    }
+    if (value.length > 0) return `Array<${getType(value[0])}>`;
     return 'Array<any>';
   }
   if (value && typeof value === 'object') {
@@ -24,56 +14,57 @@ const getType = (value: any): string => {
     if (value.$date && Object.keys(value).length === 1) return 'Date';
     return 'Object';
   }
-  const type = typeof value;
-  // Capitalize the first letter for display (e.g., 'string' -> 'String')
-  return type.charAt(0).toUpperCase() + type.slice(1);
+  const t = typeof value;
+  return t.charAt(0).toUpperCase() + t.slice(1);
 };
+
+const TYPE_COLORS: Record<string, string> = {
+  String:    '#3a6a3a',
+  Number:    '#1d6cf2',
+  Boolean:   '#c98d42',
+  ObjectId:  '#7c4fba',
+  Date:      '#1d8fa0',
+  Object:    '#6c6760',
+  null:      '#c94250',
+};
+
+const typeColor = (t: string) =>
+  TYPE_COLORS[t.split('<')[0]] ?? '#6c6760';
 
 interface SchemaRendererProps {
   data: Record<string, any>;
   indent?: number;
 }
 
-/**
- * A recursive React component that renders a document schema into an HTML tree.
- */
-export const SchemaRenderer: React.FC<SchemaRendererProps> = ({ data, indent = 0 }) => {
-  const padStyle = { paddingLeft: `${indent * 24}px` };
+export const SchemaRenderer: React.FC<SchemaRendererProps> = ({ data, indent = 0 }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+    {Object.entries(data).map(([key, value]) => {
+      const type = getType(value);
+      const isNested =
+        (type === 'Object' || type.startsWith('Array<Object>')) &&
+        value &&
+        (Array.isArray(value) ? value.length > 0 : Object.keys(value).length > 0);
+      const nestedData = Array.isArray(value) ? value[0] : value;
 
-  return (
-    <div className="space-y-1">
-      {Object.entries(data).map(([key, value]) => {
-        const type = getType(value);
-
-        const renderField = (
-            <div className="flex items-center gap-2">
-              <strong className="text-slate-600 dark:text-slate-300 font-medium">{key}</strong>:
-              <code className="text-purple-800 dark:text-purple-300 bg-purple-100 dark:bg-purple-900/50 font-semibold px-2 py-0.5 rounded-md text-xs">{type}</code>
-            </div>
-        );
-
-        if ((type === 'Object' || type.startsWith('Array<Object>')) && value && (Array.isArray(value) ? value.length > 0 : Object.keys(value).length > 0)) {
-           const nestedData = Array.isArray(value) ? value[0] : value;
-           return (
-            <div key={key} style={padStyle}>
-              {renderField}
-              <SchemaRenderer data={nestedData} indent={indent + 1} />
-            </div>
-          );
-        }
-
-        return (
-          <div key={key} style={padStyle}>
-            {renderField}
+      return (
+        <div key={key} style={{ paddingLeft: indent * 16 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11.5, color: 'var(--fg)', fontWeight: 500 }}>{key}</span>
+            <span style={{ color: 'var(--muted)', fontSize: 10.5 }}>:</span>
+            <span style={{
+              fontFamily: 'var(--font-mono)', fontSize: 10.5,
+              color: typeColor(type),
+              background: `color-mix(in oklch, ${typeColor(type)} 10%, var(--bg))`,
+              padding: '1px 6px', borderRadius: 4,
+            }}>{type}</span>
           </div>
-        );
-      })}
-    </div>
-  );
-};
+          {isNested && <SchemaRenderer data={nestedData} indent={indent + 1} />}
+        </div>
+      );
+    })}
+  </div>
+);
 
-
-// --- Main CollectionActionPanel Component ---
 
 interface CollectionActionPanelProps {
   info: CollectionInfo;
@@ -83,91 +74,97 @@ interface CollectionActionPanelProps {
 const CollectionActionPanel: React.FC<CollectionActionPanelProps> = ({ info, onClose }) => {
   const [isSchemaOpen, setIsSchemaOpen] = useState(true);
 
-  useEffect(() => {
-    // Whenever a new collection is selected, default the schema view to open.
-    setIsSchemaOpen(true);
-  }, [info.name]);
-  
+  useEffect(() => { setIsSchemaOpen(true); }, [info.name]);
+
   const sampleDocument = info.sampleDocument || {};
 
   return (
-    <div className="bg-slate-100 dark:bg-slate-800/50 rounded-lg p-4 mt-4 border border-slate-200 dark:border-slate-700 animate-fade-in space-y-6">
-      <header className="flex justify-between items-center">
-        <h3 className="text-lg font-bold text-blue-600 dark:text-blue-400">
-          Collection Details: <span className="font-mono bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-300 px-2 py-1 rounded">{info.name}</span>
-        </h3>
-        <button
-          onClick={onClose}
-          className="p-1 rounded-full text-slate-500 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700 hover:text-slate-800 dark:hover:text-slate-200 transition-colors"
-          aria-label="Close panel"
-          title="Close collection details"
-        >
-          <XIcon className="w-5 h-5" />
-        </button>
-      </header>
-      
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-        <div className="bg-white dark:bg-slate-700/50 p-3 rounded-lg flex items-center gap-3 border border-slate-200 dark:border-slate-600">
-            <InfoIcon className="w-5 h-5 text-slate-400 flex-shrink-0" />
-            <div>
-                <p className="text-slate-500 dark:text-slate-400">Documents</p>
-                <p className="text-slate-800 dark:text-slate-200 font-semibold">{info.documentCount.toLocaleString()}</p>
-            </div>
+    <div style={{ padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+
+      {/* Stats row */}
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+        <div style={{ background: 'var(--soft)', borderRadius: 'var(--radius-sm)', padding: '8px 10px' }}>
+          <div style={{ fontSize: 10.5, color: 'var(--muted)', marginBottom: 2 }}>Documents</div>
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 13, fontWeight: 600, color: 'var(--fg)' }}>
+            {info.documentCount.toLocaleString()}
+          </div>
         </div>
-         <div className="bg-white dark:bg-slate-700/50 p-3 rounded-lg flex items-center gap-3 border border-slate-200 dark:border-slate-600">
-            <InfoIcon className="w-5 h-5 text-slate-400 flex-shrink-0" />
-            <div>
-                <p className="text-slate-500 dark:text-slate-400">Avg. Doc Size</p>
-                <p className="text-slate-800 dark:text-slate-200 font-semibold">{info.averageDocumentSize}</p>
-            </div>
+        <div style={{ background: 'var(--soft)', borderRadius: 'var(--radius-sm)', padding: '8px 10px' }}>
+          <div style={{ fontSize: 10.5, color: 'var(--muted)', marginBottom: 2 }}>Avg. doc size</div>
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 13, fontWeight: 600, color: 'var(--fg)' }}>
+            {info.averageDocumentSize}
+          </div>
         </div>
       </div>
 
-      <div className="space-y-2">
-        <p className="text-slate-600 dark:text-slate-300 flex items-center gap-2 font-semibold"><IndexIcon className="w-5 h-5" /> Indexes</p>
-        <div className="flex flex-wrap gap-2">
+      {/* Indexes */}
+      {info.indexes.length > 0 && (
+        <div>
+          <div style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)', marginBottom: 6 }}>
+            Indexes
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
             {info.indexes.map(idx => (
-                <span key={idx} className="bg-purple-100 dark:bg-purple-900/50 text-purple-800 dark:text-purple-300 text-xs font-mono px-2 py-1 rounded-full">{idx}</span>
+              <span key={idx} style={{
+                fontFamily: 'var(--font-mono)', fontSize: 10.5,
+                background: 'var(--accent-soft)', color: 'var(--accent)',
+                padding: '2px 7px', borderRadius: 4,
+              }}>{idx}</span>
             ))}
+          </div>
         </div>
-      </div>
-      
-       <div className="space-y-2">
+      )}
+
+      {/* Schema */}
+      <div>
         <button
           onClick={() => setIsSchemaOpen(!isSchemaOpen)}
-          className="w-full flex items-center gap-2 text-left text-slate-600 dark:text-slate-300 font-semibold p-1 -ml-1 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+          style={{
+            width: '100%', display: 'flex', alignItems: 'center', gap: 6,
+            background: 'none', border: 'none', cursor: 'pointer',
+            color: 'var(--fg)', fontFamily: 'var(--font-body)', padding: '0 0 6px',
+          }}
           aria-expanded={isSchemaOpen}
-          aria-controls={`schema-content-${info.name}`}
-          title={isSchemaOpen ? 'Collapse schema view' : 'Expand schema view'}
         >
-          <FileJsonIcon className="w-5 h-5" />
-          <span>Inferred Schema (from sample)</span>
-          <ChevronDownIcon className={`w-5 h-5 ml-auto transition-transform duration-300 ${isSchemaOpen ? 'rotate-180' : 'rotate-0'}`} />
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+            <rect x="2" y="2" width="12" height="12" rx="2"/>
+            <path d="M5 6h6M5 9h4"/>
+          </svg>
+          <span style={{ fontSize: 11.5, fontWeight: 500 }}>Inferred schema</span>
+          <ChevronDownIcon
+            className="w-3 h-3"
+            style={{ marginLeft: 'auto', color: 'var(--muted)', transition: 'transform 0.2s', transform: isSchemaOpen ? 'rotate(180deg)' : 'none' }}
+          />
         </button>
 
         {isSchemaOpen && (
-          <div
-            id={`schema-content-${info.name}`}
-            className="bg-white dark:bg-slate-700/50 p-4 rounded-md text-sm ring-1 ring-slate-200 dark:ring-slate-600 overflow-x-auto animate-fade-in-short"
-          >
+          <div style={{
+            background: 'var(--bg)', border: '1px solid var(--border)',
+            borderRadius: 'var(--radius-sm)', padding: '10px 12px',
+            overflow: 'auto', maxHeight: 280,
+          }}>
             {Object.keys(sampleDocument).length > 0 ? (
               <SchemaRenderer data={sampleDocument} />
             ) : (
-              <p className="font-sans text-slate-500 dark:text-slate-400">No sample document available to infer a schema.</p>
+              <span style={{ fontSize: 12, color: 'var(--muted)' }}>No sample document available.</span>
             )}
           </div>
         )}
       </div>
 
-      <style>{`
-        @keyframes fade-in-short {
-          from { opacity: 0; transform: translateY(-5px); }
-          to { opacity: 1; transform: translateY(0); }
-        }
-        .animate-fade-in-short {
-          animation: fade-in-short 0.3s ease-out forwards;
-        }
-      `}</style>
+      {/* Close / deselect */}
+      <button
+        onClick={onClose}
+        style={{
+          alignSelf: 'flex-start', display: 'flex', alignItems: 'center', gap: 5,
+          background: 'none', border: 'none', cursor: 'pointer',
+          color: 'var(--muted)', fontSize: 11.5, fontFamily: 'var(--font-body)', padding: 0,
+        }}
+        title="Deselect collection"
+      >
+        <XIcon className="w-3 h-3" />
+        Deselect {info.name}
+      </button>
     </div>
   );
 };

--- a/frontend/components/CommandPalette.tsx
+++ b/frontend/components/CommandPalette.tsx
@@ -256,7 +256,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
           ),
           action: () => {
             onCollectionSelect?.(col.name);
-            if (explorerHref) navigate(explorerHref);
+            if (explorerHref) navigate(explorerHref, { state: { initialCollection: col.name } });
           },
         });
       });

--- a/frontend/components/CommandPalette.tsx
+++ b/frontend/components/CommandPalette.tsx
@@ -1,0 +1,484 @@
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTheme } from '../contexts/ThemeContext';
+import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
+import { CollectionSummary, DbInfo, CosmosDBAccount } from '../types';
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+  accountId?: string;
+  databaseName?: string;
+  collections?: CollectionSummary[];
+  availableDbs?: DbInfo[];
+  availableAccounts?: CosmosDBAccount[];
+  onSwitchDatabase?: (db: DbInfo) => void;
+  onSwitchAccount?: (account: CosmosDBAccount) => void;
+  onCollectionSelect?: (name: string) => void;
+  onNewQuery?: () => void;
+}
+
+interface Command {
+  id: string;
+  label: string;
+  description?: string;
+  group: string;
+  icon: React.ReactNode;
+  action: () => void;
+  keywords?: string;
+  shortcut?: string[];
+}
+
+const NavIcon = ({ d }: { d: string }) => (
+  <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+    <path d={d} />
+  </svg>
+);
+
+const Kbd: React.FC<{ keys: string[] }> = ({ keys }) => (
+  <span style={{ display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0 }}>
+    {keys.map((k, i) => (
+      <kbd key={i} style={{
+        display: 'inline-block',
+        padding: '1px 5px', borderRadius: 4,
+        background: 'var(--soft)', border: '1px solid var(--border)',
+        fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--muted)',
+        lineHeight: 1.6,
+      }}>{k}</kbd>
+    ))}
+  </span>
+);
+
+const CommandPalette: React.FC<CommandPaletteProps> = ({
+  open,
+  onClose,
+  accountId,
+  databaseName,
+  collections,
+  availableDbs,
+  availableAccounts,
+  onSwitchDatabase,
+  onSwitchAccount,
+  onCollectionSelect,
+  onNewQuery,
+}) => {
+  const navigate = useNavigate();
+  const { theme, toggleTheme } = useTheme();
+  const { logout } = useUnifiedAuth();
+
+  const [query, setQuery] = useState('');
+  const [activeIdx, setActiveIdx] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const explorerHref = accountId && databaseName
+    ? `/data-explorer/${encodeURIComponent(accountId)}/${encodeURIComponent(databaseName)}`
+    : null;
+
+  const run = useCallback((action: () => void) => {
+    onClose();
+    action();
+  }, [onClose]);
+
+  const commands = useMemo<Command[]>(() => {
+    const cmds: Command[] = [];
+
+    // Navigation
+    cmds.push({
+      id: 'nav-workspace',
+      label: 'Workspace',
+      description: 'Query generator & AI assistant',
+      group: 'Navigate',
+      keywords: 'query generator ai',
+      shortcut: ['⌘', '⇧', '1'],
+      icon: <NavIcon d="M2 2h5v5H2zM9 2h5v5H9zM2 9h5v5H2zM9 9h5v5H9z" />,
+      action: () => navigate('/query-generator'),
+    });
+
+    cmds.push({
+      id: 'nav-explorer',
+      label: 'Explorer',
+      description: explorerHref ? `Browse ${databaseName}` : 'Connect to a database first',
+      group: 'Navigate',
+      keywords: 'data browse documents',
+      shortcut: ['⌘', '⇧', '2'],
+      icon: (
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+          <path d="M2 3h12v3H2zM2 7h12v3H2zM2 11h12v3H2z" />
+        </svg>
+      ),
+      action: () => { if (explorerHref) navigate(explorerHref); },
+    });
+
+    cmds.push({
+      id: 'nav-analytics',
+      label: 'Analytics',
+      description: 'Database audit & insights',
+      group: 'Navigate',
+      keywords: 'charts insights audit schema',
+      shortcut: ['⌘', '⇧', '3'],
+      icon: <NavIcon d="M2 13h12M4 11V6M7 11V3M10 11V8M13 11V5" />,
+      action: () => navigate('/analytics'),
+    });
+
+    cmds.push({
+      id: 'nav-audit',
+      label: 'Audit Log',
+      description: 'Document change history',
+      group: 'Navigate',
+      keywords: 'history changes log',
+      shortcut: ['⌘', '⇧', '4'],
+      icon: <NavIcon d="M3 2h7l3 3v9H3zM6 7h5M6 9h5M6 11h3" />,
+      action: () => navigate('/audit'),
+    });
+
+    // Actions
+    if (onNewQuery) {
+      cmds.push({
+        id: 'action-new-query',
+        label: 'New query',
+        description: 'Start a blank AI query',
+        group: 'Actions',
+        keywords: 'new blank query generate',
+        shortcut: ['⌘', 'N'],
+        icon: (
+          <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8">
+            <path d="M8 3v10M3 8h10" />
+          </svg>
+        ),
+        action: onNewQuery,
+      });
+    }
+
+    cmds.push({
+      id: 'action-saved-queries',
+      label: 'Saved queries',
+      description: 'Open saved queries panel',
+      group: 'Actions',
+      keywords: 'saved bookmarks history',
+      shortcut: ['⌘', '⇧', 'S'],
+      icon: (
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+          <path d="M4 2h6l3 3v9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1z" />
+          <path d="M6 7h5M6 10h3" />
+        </svg>
+      ),
+      action: () => navigate('/query-generator?panel=saved'),
+    });
+
+    cmds.push({
+      id: 'action-theme',
+      label: theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode',
+      group: 'Actions',
+      keywords: 'theme dark light appearance',
+      icon: theme === 'light' ? (
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      ) : (
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+        </svg>
+      ),
+      action: toggleTheme,
+    });
+
+    cmds.push({
+      id: 'action-signout',
+      label: 'Sign out',
+      group: 'Actions',
+      keywords: 'logout sign out',
+      icon: (
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <path d="M6 2H3a1 1 0 00-1 1v10a1 1 0 001 1h3M11 11l3-3-3-3M14 8H6" />
+        </svg>
+      ),
+      action: logout,
+    });
+
+    // Switch database
+    if (availableDbs && availableDbs.length > 1) {
+      availableDbs.forEach(db => {
+        const isCurrent = db.name === databaseName;
+        cmds.push({
+          id: `db-${db.name}`,
+          label: db.name,
+          description: isCurrent ? 'Current database' : `Switch to ${db.name}`,
+          group: 'Switch database',
+          keywords: db.name,
+          icon: (
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3">
+              <ellipse cx="8" cy="4" rx="6" ry="2" />
+              <path d="M2 4v8c0 1.1 2.7 2 6 2s6-.9 6-2V4M2 8c0 1.1 2.7 2 6 2s6-.9 6-2" />
+            </svg>
+          ),
+          action: () => { if (!isCurrent) onSwitchDatabase?.(db); },
+        });
+      });
+    }
+
+    // Switch account
+    if (availableAccounts && availableAccounts.length > 1) {
+      availableAccounts.forEach(acc => {
+        const isCurrent = acc.id === accountId;
+        cmds.push({
+          id: `acc-${acc.id}`,
+          label: acc.name,
+          description: isCurrent ? 'Current account' : `Switch to ${acc.name}`,
+          group: 'Switch account',
+          keywords: acc.name,
+          icon: (
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+              <rect x="1" y="3" width="14" height="10" rx="2" />
+              <path d="M1 7h14" />
+            </svg>
+          ),
+          action: () => { if (!isCurrent) onSwitchAccount?.(acc); },
+        });
+      });
+    }
+
+    // Collections
+    if (collections && collections.length > 0) {
+      collections.forEach(col => {
+        cmds.push({
+          id: `col-${col.name}`,
+          label: col.name,
+          description: `${col.count.toLocaleString()} documents`,
+          group: 'Jump to collection',
+          keywords: col.name,
+          icon: (
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3">
+              <ellipse cx="8" cy="4" rx="6" ry="2" />
+              <path d="M2 4v8c0 1.1 2.7 2 6 2s6-.9 6-2V4M2 8c0 1.1 2.7 2 6 2s6-.9 6-2" />
+            </svg>
+          ),
+          action: () => {
+            onCollectionSelect?.(col.name);
+            if (explorerHref) navigate(explorerHref);
+          },
+        });
+      });
+    }
+
+    return cmds;
+  }, [navigate, explorerHref, databaseName, accountId, theme, toggleTheme, logout, onNewQuery, availableDbs, availableAccounts, collections, onSwitchDatabase, onSwitchAccount, onCollectionSelect]);
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return commands;
+    const q = query.toLowerCase();
+    return commands.filter(c =>
+      c.label.toLowerCase().includes(q) ||
+      (c.description?.toLowerCase().includes(q)) ||
+      (c.keywords?.toLowerCase().includes(q)) ||
+      c.group.toLowerCase().includes(q)
+    );
+  }, [commands, query]);
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, Command[]>();
+    filtered.forEach(cmd => {
+      if (!map.has(cmd.group)) map.set(cmd.group, []);
+      map.get(cmd.group)!.push(cmd);
+    });
+    return map;
+  }, [filtered]);
+
+  const flat = useMemo(() => filtered, [filtered]);
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setActiveIdx(0);
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    setActiveIdx(i => Math.min(i, Math.max(flat.length - 1, 0)));
+  }, [flat.length]);
+
+  useEffect(() => {
+    if (!listRef.current) return;
+    const el = listRef.current.querySelector(`[data-cmd-idx="${activeIdx}"]`) as HTMLElement | null;
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [activeIdx]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { onClose(); return; }
+      if (e.key === 'ArrowDown') { e.preventDefault(); setActiveIdx(i => Math.min(i + 1, flat.length - 1)); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); setActiveIdx(i => Math.max(i - 1, 0)); return; }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const cmd = flat[activeIdx];
+        if (cmd) run(cmd.action);
+      }
+    };
+    window.addEventListener('keydown', handle);
+    return () => window.removeEventListener('keydown', handle);
+  }, [open, flat, activeIdx, onClose, run]);
+
+  if (!open) return null;
+
+  let globalIdx = 0;
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, zIndex: 1000,
+        background: 'rgba(0,0,0,0.35)',
+        display: 'flex', alignItems: 'flex-start', justifyContent: 'center',
+        paddingTop: 80,
+        backdropFilter: 'blur(2px)',
+      }}
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        style={{
+          width: '100%', maxWidth: 560,
+          background: 'var(--panel)', borderRadius: 12,
+          border: '1px solid var(--border)',
+          boxShadow: '0 16px 48px rgba(0,0,0,0.18)',
+          display: 'flex', flexDirection: 'column',
+          overflow: 'hidden', maxHeight: 'calc(100vh - 160px)',
+          fontFamily: 'var(--font-body)',
+        }}
+      >
+        {/* Search input */}
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 10,
+          padding: '12px 14px',
+          borderBottom: '1px solid var(--border)',
+        }}>
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="var(--muted)" strokeWidth="1.5" style={{ flexShrink: 0 }}>
+            <circle cx="7" cy="7" r="4.5" />
+            <path d="M10.5 10.5l3 3" />
+          </svg>
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={e => { setQuery(e.target.value); setActiveIdx(0); }}
+            placeholder="Search commands…"
+            style={{
+              flex: 1, border: 'none', outline: 'none', background: 'transparent',
+              fontSize: 13.5, color: 'var(--fg)', fontFamily: 'var(--font-body)',
+            }}
+          />
+          {query && (
+            <button
+              onClick={() => setQuery('')}
+              style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex', padding: 2 }}
+            >
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M3 3l10 10M13 3L3 13" />
+              </svg>
+            </button>
+          )}
+          <kbd style={kbdStyle}>esc</kbd>
+        </div>
+
+        {/* Results */}
+        <div ref={listRef} style={{ overflowY: 'auto', padding: '6px 0' }}>
+          {flat.length === 0 ? (
+            <div style={{ padding: '24px 0', textAlign: 'center', color: 'var(--muted)', fontSize: 13 }}>
+              No results for &ldquo;{query}&rdquo;
+            </div>
+          ) : (
+            Array.from(grouped.entries()).map(([group, cmds]) => (
+              <div key={group}>
+                <div style={{
+                  padding: '6px 14px 3px',
+                  fontSize: 10.5, fontWeight: 500,
+                  textTransform: 'uppercase', letterSpacing: '0.07em',
+                  color: 'var(--muted)',
+                }}>
+                  {group}
+                </div>
+                {cmds.map(cmd => {
+                  const idx = globalIdx++;
+                  const isActive = idx === activeIdx;
+                  const isCurrent =
+                    (cmd.id === 'nav-workspace' && location.pathname === '/query-generator') ||
+                    (cmd.id === 'nav-explorer' && location.pathname.startsWith('/data-explorer')) ||
+                    (cmd.id === 'nav-analytics' && location.pathname === '/analytics') ||
+                    (cmd.id === 'nav-audit' && location.pathname === '/audit') ||
+                    (cmd.id.startsWith('db-') && cmd.description === 'Current database') ||
+                    (cmd.id.startsWith('acc-') && cmd.description === 'Current account');
+                  return (
+                    <button
+                      key={cmd.id}
+                      data-cmd-idx={idx}
+                      onClick={() => run(cmd.action)}
+                      onMouseEnter={() => setActiveIdx(idx)}
+                      style={{
+                        width: '100%', display: 'flex', alignItems: 'center', gap: 10,
+                        padding: '7px 14px', border: 'none', cursor: 'pointer', textAlign: 'left',
+                        background: isActive ? 'var(--soft)' : 'transparent',
+                        color: isCurrent ? 'var(--accent)' : 'var(--fg)',
+                        fontSize: 13,
+                      }}
+                    >
+                      <span style={{
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                        width: 26, height: 26, borderRadius: 7, flexShrink: 0,
+                        background: isActive ? 'var(--panel)' : 'var(--soft)',
+                        color: isCurrent ? 'var(--accent)' : 'var(--muted)',
+                        border: '1px solid var(--border)',
+                      }}>
+                        {cmd.icon}
+                      </span>
+                      <span style={{ flex: 1, minWidth: 0 }}>
+                        <span style={{ display: 'block', fontWeight: isCurrent ? 500 : 400, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {cmd.label}
+                        </span>
+                        {cmd.description && (
+                          <span style={{ display: 'block', fontSize: 11.5, color: 'var(--muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginTop: 1 }}>
+                            {cmd.description}
+                          </span>
+                        )}
+                      </span>
+                      {/* Right-side: shortcut badges + current checkmark */}
+                      <span style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
+                        {cmd.shortcut && <Kbd keys={cmd.shortcut} />}
+                        {isCurrent && (
+                          <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ color: 'var(--accent)' }}>
+                            <path d="M3 8l4 4 6-6" />
+                          </svg>
+                        )}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Footer hint */}
+        <div style={{
+          padding: '8px 14px', borderTop: '1px solid var(--border)',
+          display: 'flex', alignItems: 'center', gap: 12,
+          fontSize: 11, color: 'var(--muted)', fontFamily: 'var(--font-mono)',
+        }}>
+          <span><kbd style={kbdStyle}>↑</kbd><kbd style={kbdStyle}>↓</kbd> navigate</span>
+          <span><kbd style={kbdStyle}>↵</kbd> select</span>
+          <span><kbd style={kbdStyle}>esc</kbd> close</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const kbdStyle: React.CSSProperties = {
+  display: 'inline-block',
+  padding: '1px 4px', borderRadius: 4,
+  background: 'var(--soft)', border: '1px solid var(--border)',
+  fontSize: 10, fontFamily: 'var(--font-mono)',
+  marginRight: 3,
+};
+
+export default CommandPalette;

--- a/frontend/components/CreateDocumentDialog.tsx
+++ b/frontend/components/CreateDocumentDialog.tsx
@@ -1,10 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import Dialog from '@mui/material/Dialog';
-import DialogTitle from '@mui/material/DialogTitle';
-import DialogContent from '@mui/material/DialogContent';
-import DialogActions from '@mui/material/DialogActions';
-import Button from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
 import MonacoEditor from '@monaco-editor/react';
 import { useTheme } from '../contexts/ThemeContext';
 
@@ -18,13 +12,11 @@ interface CreateDocumentDialogProps {
 }
 
 const CreateDocumentDialog: React.FC<CreateDocumentDialogProps> = ({ open, initialDoc, onClose, onSave, loading, collectionName }) => {
-  const [doc, setDoc] = useState<Record<string, any>>(initialDoc || {});
   const [editorValue, setEditorValue] = useState<string>(JSON.stringify(initialDoc || {}, null, 2));
   const [error, setError] = useState<string | null>(null);
   const { theme } = useTheme();
 
   useEffect(() => {
-    setDoc(initialDoc || {});
     setEditorValue(JSON.stringify(initialDoc || {}, null, 2));
     setError(null);
   }, [initialDoc, open]);
@@ -33,73 +25,124 @@ const CreateDocumentDialog: React.FC<CreateDocumentDialogProps> = ({ open, initi
     try {
       const parsed = JSON.parse(editorValue);
       onSave(parsed);
-    } catch (e) {
+    } catch {
       setError('Invalid JSON. Please fix errors before saving.');
     }
   };
 
+  if (!open) return null;
+
   return (
-    <Dialog 
-      open={open} 
-      onClose={onClose} 
-      maxWidth="lg" 
-      fullWidth
-      PaperProps={{
-        style: {
-          backgroundColor: theme === 'dark' ? '#1e293b' : undefined,
-          color: theme === 'dark' ? '#f1f5f9' : undefined,
-        },
-      }}
-    >
-      <DialogTitle 
-        style={{
-          backgroundColor: theme === 'dark' ? '#1e293b' : undefined,
-          color: theme === 'dark' ? '#f1f5f9' : undefined,
-        }}
-      >
-        Create New Document in {collectionName}
-      </DialogTitle>
-      <DialogContent 
-        style={{
-          backgroundColor: theme === 'dark' ? '#1e293b' : undefined,
-          color: theme === 'dark' ? '#f1f5f9' : undefined,
-        }}
-      >
-        <div style={{ minHeight: 480, minWidth: 600 }}>
-          <MonacoEditor
-            height="480px"
-            defaultLanguage="json"
-            theme={theme === 'dark' ? 'vs-dark' : 'vs-light'}
-            value={editorValue}
-            onChange={v => setEditorValue(v || '')}
-            options={{
-              minimap: { enabled: false },
-              folding: true,
-              scrollBeyondLastLine: false,
-              fontSize: 14,
-              wordWrap: 'on',
-              readOnly: !!loading,
-              lineNumbers: 'on',
-              formatOnPaste: true,
-              formatOnType: true,
-              automaticLayout: true,
+    <div style={{
+      position: 'fixed', inset: 0, zIndex: 60,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      background: 'rgba(0,0,0,0.35)', backdropFilter: 'blur(2px)',
+    }}>
+      <div style={{
+        background: 'var(--panel)', borderRadius: 12, boxShadow: '0 8px 40px rgba(0,0,0,0.18)',
+        width: '90vw', maxWidth: 780, maxHeight: '90vh',
+        display: 'flex', flexDirection: 'column', overflow: 'hidden',
+        border: '1px solid var(--border)',
+      }}>
+        {/* Header */}
+        <div style={{
+          padding: '14px 20px', borderBottom: '1px solid var(--border)',
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0,
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <div style={{
+              width: 30, height: 30, borderRadius: 7,
+              background: 'var(--accent-soft)', display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}>
+              <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.5">
+                <rect x="2" y="2" width="12" height="12" rx="2"/>
+                <path d="M8 5v6M5 8h6"/>
+              </svg>
+            </div>
+            <div>
+              <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
+                New Document
+              </div>
+              <div style={{ fontSize: 11.5, color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>
+                {collectionName}
+              </div>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={!!loading}
+            style={{
+              background: 'none', border: 'none', cursor: 'pointer',
+              color: 'var(--muted)', padding: 4, borderRadius: 5, display: 'flex',
             }}
-          />
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M4 4l8 8M12 4l-8 8"/>
+            </svg>
+          </button>
         </div>
-        {error && <div className="text-red-600 mt-2">{error}</div>}
-      </DialogContent>
-      <DialogActions 
-        style={{
-          backgroundColor: theme === 'dark' ? '#1e293b' : undefined,
-          color: theme === 'dark' ? '#f1f5f9' : undefined,
-        }}
-      >
-        <Button onClick={onClose} disabled={loading} style={theme === 'dark' ? { color: '#f1f5f9' } : {}}>Cancel</Button>
-        <Button onClick={handleSave} color="primary" variant="contained" disabled={loading} startIcon={loading ? <CircularProgress size={18} /> : null} style={theme === 'dark' ? { color: '#f1f5f9' } : {}}>
-          Save
-        </Button>
-      </DialogActions>
-    </Dialog>
+
+        {/* Editor */}
+        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          <div style={{
+            flex: 1, border: 'none', minHeight: 480,
+          }}>
+            <MonacoEditor
+              height="480px"
+              defaultLanguage="json"
+              theme={theme === 'dark' ? 'vs-dark' : 'vs-light'}
+              value={editorValue}
+              onChange={v => setEditorValue(v || '')}
+              options={{
+                minimap: { enabled: false },
+                folding: true,
+                scrollBeyondLastLine: false,
+                fontSize: 13,
+                wordWrap: 'on',
+                readOnly: !!loading,
+                lineNumbers: 'on',
+                formatOnPaste: true,
+                formatOnType: true,
+                automaticLayout: true,
+              }}
+            />
+          </div>
+          {error && (
+            <div style={{
+              margin: '0 16px 0', padding: '8px 12px', borderRadius: 6,
+              background: 'color-mix(in oklch, var(--status-err) 10%, var(--panel))',
+              border: '1px solid color-mix(in oklch, var(--status-err) 25%, var(--border))',
+              color: 'var(--status-err)', fontSize: 12.5, fontFamily: 'var(--font-body)',
+            }}>
+              {error}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          padding: '12px 20px', borderTop: '1px solid var(--border)',
+          display: 'flex', justifyContent: 'flex-end', gap: 8, flexShrink: 0,
+        }}>
+          <button className="qa-btn" onClick={onClose} disabled={!!loading} style={{ fontSize: 13 }}>
+            Cancel
+          </button>
+          <button
+            className="qa-btn primary"
+            onClick={handleSave}
+            disabled={!!loading}
+            style={{ fontSize: 13, display: 'flex', alignItems: 'center', gap: 7, opacity: loading ? 0.7 : 1 }}
+          >
+            {loading && (
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ animation: 'qp-spin 0.7s linear infinite' }}>
+                <circle cx="8" cy="8" r="6" strokeOpacity="0.3"/><path d="M8 2a6 6 0 0 1 6 6"/>
+              </svg>
+            )}
+            {loading ? 'Saving…' : 'Create Document'}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/frontend/components/DocumentDetailView.tsx
+++ b/frontend/components/DocumentDetailView.tsx
@@ -1,11 +1,9 @@
 import { useState, forwardRef, useImperativeHandle } from 'react';
 import { useTheme } from '../contexts/ThemeContext';
-import { Button, CircularProgress } from '@mui/material';
 import MonacoEditor from '@monaco-editor/react';
 import { updateDocument, getSingleDocument } from '../services/dbService';
 import { isEqual, omit } from 'lodash';
 import SaveConflictDialog from './SaveConflictDialog';
-
 
 interface DocumentEditViewProps {
   accountId?: string;
@@ -23,86 +21,81 @@ export interface DocumentEditViewRef {
   setCurrentValue: (val: string) => void;
 }
 
-const DocumentEditView = forwardRef<DocumentEditViewRef, DocumentEditViewProps>(({ accountId, databaseName, document, collection, docId, loading, onCancel, onSave }, ref) => {
-  const [jsonValue, setJsonValue] = useState(JSON.stringify(document, null, 2));
-  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
-  const { theme } = useTheme();
-  const [isSaving, setIsSaving] = useState(false);
-  const [isConflictDialogOpen, setIsConflictDialogOpen] = useState(false);
-  const [conflictServerDocStr, setConflictServerDocStr] = useState<string>('');
+const DocumentEditView = forwardRef<DocumentEditViewRef, DocumentEditViewProps>(
+  ({ accountId, databaseName, document, collection, docId, loading, onCancel, onSave }, ref) => {
+    const [jsonValue, setJsonValue] = useState(JSON.stringify(document, null, 2));
+    const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+    const { theme } = useTheme();
+    const [isSaving, setIsSaving] = useState(false);
+    const [isConflictDialogOpen, setIsConflictDialogOpen] = useState(false);
+    const [conflictServerDocStr, setConflictServerDocStr] = useState<string>('');
 
-  useImperativeHandle(ref, () => ({
-    getCurrentValue: () => jsonValue,
-    setCurrentValue: (val: string) => setJsonValue(val)
-  }));
+    useImperativeHandle(ref, () => ({
+      getCurrentValue: () => jsonValue,
+      setCurrentValue: (val: string) => setJsonValue(val),
+    }));
 
-  const handleSave = async (forceSave = false) => {
-    setIsSaving(true);
-    try {
-      const parsed = JSON.parse(jsonValue);
-      if (!accountId || !databaseName || !collection || !docId) throw new Error('Missing DB info');
+    const handleSave = async (forceSave = false) => {
+      setIsSaving(true);
+      try {
+        const parsed = JSON.parse(jsonValue);
+        if (!accountId || !databaseName || !collection || !docId) throw new Error('Missing DB info');
 
-      if (!forceSave) {
-        // Fetch the latest document from DB
-        const refreshed = await getSingleDocument(accountId, databaseName, collection, docId);
-        
-        // Compare with the original document prop
-        const ignoredKeys = ['_id', 'datetime_creation', 'datetime_last_modified'];
-        const oldWithoutIgnored = omit(document, ignoredKeys);
-        const newWithoutIgnored = omit(refreshed, ignoredKeys);
-        
-        if (!isEqual(oldWithoutIgnored, newWithoutIgnored)) {
-          // Sync ignored fields to match user's expected view without highlighting them
-          const displayServerDoc = { ...refreshed };
-          ignoredKeys.forEach(key => {
-            if (key in parsed) {
-              displayServerDoc[key] = parsed[key];
-            } else {
-              delete displayServerDoc[key];
-            }
-          });
-          
-          setConflictServerDocStr(JSON.stringify(displayServerDoc, null, 2));
-          setIsConflictDialogOpen(true);
-          setIsSaving(false);
-          return;
+        if (!forceSave) {
+          const refreshed = await getSingleDocument(accountId, databaseName, collection, docId);
+          const ignoredKeys = ['_id', 'datetime_creation', 'datetime_last_modified'];
+          const oldWithoutIgnored = omit(document, ignoredKeys);
+          const newWithoutIgnored = omit(refreshed, ignoredKeys);
+
+          if (!isEqual(oldWithoutIgnored, newWithoutIgnored)) {
+            const displayServerDoc = { ...refreshed };
+            ignoredKeys.forEach(key => {
+              if (key in parsed) displayServerDoc[key] = parsed[key];
+              else delete displayServerDoc[key];
+            });
+            setConflictServerDocStr(JSON.stringify(displayServerDoc, null, 2));
+            setIsConflictDialogOpen(true);
+            setIsSaving(false);
+            return;
+          }
         }
+
+        await updateDocument(accountId, databaseName, collection, docId, parsed);
+        const refreshed = await getSingleDocument(accountId, databaseName, collection, docId);
+        setJsonValue(JSON.stringify(refreshed, null, 2));
+        setFeedback({ type: 'success', message: 'Document saved.' });
+        if (onSave) await onSave();
+        if (onCancel) onCancel();
+      } catch (e: any) {
+        setFeedback({ type: 'error', message: e?.message || 'Invalid JSON or failed to save.' });
+      } finally {
+        setIsSaving(false);
       }
+    };
 
-      await updateDocument(accountId, databaseName, collection, docId, parsed);
-      // Fetch the latest document after update
-      const refreshed = await getSingleDocument(accountId, databaseName, collection, docId);
-      setJsonValue(JSON.stringify(refreshed, null, 2));
-      setFeedback({ type: 'success', message: 'Document saved and refreshed.' });
-      if (onSave) await onSave();
-      if (onCancel) onCancel();
-    } catch (e: any) {
-      setFeedback({ type: 'error', message: e?.message || 'Invalid JSON or failed to save.' });
-    } finally {
-      setIsSaving(false);
-    }
-  };
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, flex: 1 }}>
 
-  return (
-    <div className="relative p-4 rounded-lg shadow bg-white dark:bg-slate-900">
-      <div className="flex items-center justify-between mb-2">
-        <h3 className="text-lg font-bold text-slate-800 dark:text-slate-100">Edit Document</h3>
-        <div className="flex gap-2">
-          <Button variant="contained" color="success" size="small" onClick={() => handleSave(false)} disabled={loading || isSaving} startIcon={isSaving ? <CircularProgress size={18} color="inherit" /> : undefined}>
-            {isSaving ? 'Saving...' : 'Save'}
-          </Button>
+        {/* Edit mode banner */}
+        <div style={{
+          padding: '8px 14px', borderRadius: 7,
+          background: 'var(--accent-soft)', border: '1px solid color-mix(in oklch, var(--accent) 25%, var(--border))',
+          fontSize: 12.5, color: 'var(--accent)', fontFamily: 'var(--font-body)',
+          display: 'flex', alignItems: 'center', gap: 8,
+        }}>
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ flexShrink: 0 }}>
+            <circle cx="8" cy="8" r="6"/><path d="M8 7v4M8 5.5v.5"/>
+          </svg>
+          <span>Edit mode — changes are not saved until you click <strong>Save</strong>.</span>
         </div>
-      </div>
-      <div className="mb-2">
-        <div className="w-full py-2 px-3 rounded bg-blue-50 dark:bg-blue-900/40 text-blue-700 dark:text-blue-200 font-semibold text-center border border-blue-200 dark:border-blue-700 mb-2">
-          You are in <b>Edit Mode</b>. Changes are not saved until you click Save.
-        </div>
-      </div>
-      <div>
-        <div className="mb-1 text-xs text-slate-500 dark:text-slate-400 font-semibold">Edit JSON</div>
-        <div className="border border-slate-200 dark:border-slate-700 rounded overflow-hidden" style={{ minHeight: 400, height: 600, width: '100%', display: 'flex' }}>
+
+        {/* Monaco editor */}
+        <div style={{
+          flex: 1, border: '1px solid var(--border)', borderRadius: 8,
+          overflow: 'hidden', minHeight: 400, display: 'flex', flexDirection: 'column',
+        }}>
           <MonacoEditor
-            height="100%"
+            height="560px"
             width="100%"
             defaultLanguage="json"
             value={jsonValue}
@@ -112,7 +105,7 @@ const DocumentEditView = forwardRef<DocumentEditViewRef, DocumentEditViewProps>(
               minimap: { enabled: false },
               folding: true,
               scrollBeyondLastLine: false,
-              fontSize: 14,
+              fontSize: 13,
               wordWrap: 'on',
               readOnly: !!loading,
               lineNumbers: 'on',
@@ -122,24 +115,58 @@ const DocumentEditView = forwardRef<DocumentEditViewRef, DocumentEditViewProps>(
             }}
           />
         </div>
-      </div>
-      {feedback && (
-        <div className={`fixed left-1/2 -translate-x-1/2 bottom-6 px-4 py-2 rounded shadow text-sm font-semibold z-50 ${feedback.type === 'error' ? 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300' : 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'}`}>
-          {feedback.message}
+
+        {/* Footer actions */}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, flexShrink: 0 }}>
+          <button
+            className="qa-btn"
+            onClick={onCancel}
+            disabled={isSaving || !!loading}
+            style={{ fontSize: 13 }}
+          >
+            Cancel
+          </button>
+          <button
+            className="qa-btn primary"
+            onClick={() => handleSave(false)}
+            disabled={isSaving || !!loading}
+            style={{ fontSize: 13, display: 'flex', alignItems: 'center', gap: 7, opacity: (isSaving || loading) ? 0.7 : 1 }}
+          >
+            {isSaving && (
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ animation: 'qp-spin 0.7s linear infinite' }}>
+                <circle cx="8" cy="8" r="6" strokeOpacity="0.3"/><path d="M8 2a6 6 0 0 1 6 6"/>
+              </svg>
+            )}
+            {isSaving ? 'Saving…' : 'Save'}
+          </button>
         </div>
-      )}
-      <SaveConflictDialog
-        open={isConflictDialogOpen}
-        serverValue={conflictServerDocStr}
-        localValue={jsonValue}
-        onClose={() => setIsConflictDialogOpen(false)}
-        onOverwrite={() => {
-          setIsConflictDialogOpen(false);
-          handleSave(true);
-        }}
-      />
-    </div>
-  );
-});
+
+        {/* Feedback toast */}
+        {feedback && (
+          <div style={{
+            position: 'fixed', left: '50%', bottom: 24, transform: 'translateX(-50%)',
+            padding: '9px 18px', borderRadius: 8, fontSize: 13, fontWeight: 600,
+            zIndex: 50, fontFamily: 'var(--font-body)', boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+            background: feedback.type === 'error'
+              ? 'color-mix(in oklch, var(--status-err) 12%, var(--panel))'
+              : 'color-mix(in oklch, var(--status-ok) 12%, var(--panel))',
+            color: feedback.type === 'error' ? 'var(--status-err)' : 'var(--status-ok)',
+            border: `1px solid ${feedback.type === 'error' ? 'color-mix(in oklch, var(--status-err) 30%, var(--border))' : 'color-mix(in oklch, var(--status-ok) 30%, var(--border))'}`,
+          }}>
+            {feedback.message}
+          </div>
+        )}
+
+        <SaveConflictDialog
+          open={isConflictDialogOpen}
+          serverValue={conflictServerDocStr}
+          localValue={jsonValue}
+          onClose={() => setIsConflictDialogOpen(false)}
+          onOverwrite={() => { setIsConflictDialogOpen(false); handleSave(true); }}
+        />
+      </div>
+    );
+  }
+);
 
 export default DocumentEditView;

--- a/frontend/components/JsonDisplay.tsx
+++ b/frontend/components/JsonDisplay.tsx
@@ -2,16 +2,29 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { CheckIcon, ChevronDownIcon, ClipboardIcon, SearchIcon, XIcon, ArrowUpwardIcon, ArrowDownwardIcon, CaseSensitiveIcon, WholeWordIcon, RegexIcon, ImageIcon } from './icons/material-icons-imports';
 
-// Removed unused SearchState interface
+// ── Design-token colour constants ────────────────────────────────────────────
+// All syntax colours chosen to read clearly on var(--soft) = #f3f0eb background.
+const C = {
+  key:     '#7c6fa0',          // object keys, BSON type labels
+  str:     'var(--accent)',    // string values  (#3a8c5f green)
+  num:     '#b07838',          // numbers (warm amber)
+  bool:    '#2b6cb0',          // booleans (blue)
+  nil:     'var(--status-err)',// null (#c94250 red)
+  link:    '#2b6cb0',          // ObjectId clickable link (blue)
+  muted:   'var(--muted)',     // collapsed counts, chevron, icons
+  fg:      'var(--fg)',        // default / wrapper text
+  border:  'var(--border)',    // tree-indent lines
+  panel:   'var(--panel)',     // popup backgrounds
+  soft:    'var(--soft)',      // hover backgrounds
+  ok:      'var(--status-ok)', // copied-check icon
+  accent:  'var(--accent)',
+  accentSoft: 'var(--accent-soft)',
+};
 
-// Helper function to highlight search matches in text
-// Helper function to highlight search matches in text
+// ── Helper: highlight search matches ────────────────────────────────────────
 const highlightText = (text: string, searchRegex: RegExp | null): React.ReactNode => {
-  if (!searchRegex || !text) {
-    return text;
-  }
+  if (!searchRegex || !text) return text;
 
-  // Create a local regex with 'g' flag to find all matches in this string
   let localRegex: RegExp;
   try {
     localRegex = new RegExp(searchRegex.source, searchRegex.flags.includes('g') ? searchRegex.flags : searchRegex.flags + 'g');
@@ -25,7 +38,7 @@ const highlightText = (text: string, searchRegex: RegExp | null): React.ReactNod
 
   while ((match = localRegex.exec(text)) !== null) {
     matches.push({ start: match.index, end: match.index + match[0].length, text: match[0] });
-    if (match[0].length === 0) localRegex.lastIndex++; // Avoid infinite loop
+    if (match[0].length === 0) localRegex.lastIndex++;
   }
 
   if (matches.length === 0) return text;
@@ -34,29 +47,20 @@ const highlightText = (text: string, searchRegex: RegExp | null): React.ReactNod
   let lastIndex = 0;
 
   matches.forEach((m, index) => {
-    if (m.start > lastIndex) {
-      nodes.push(text.substring(lastIndex, m.start));
-    }
+    if (m.start > lastIndex) nodes.push(text.substring(lastIndex, m.start));
     nodes.push(
-      <mark
-        key={`match-${index}`}
-        className="px-0.5 rounded text-black bg-yellow-200"
-        data-search-match="true"
-      >
+      <mark key={`match-${index}`} className="px-0.5 rounded text-black bg-yellow-200" data-search-match="true">
         {m.text}
       </mark>
     );
     lastIndex = m.end;
   });
 
-  if (lastIndex < text.length) {
-    nodes.push(text.substring(lastIndex));
-  }
-
+  if (lastIndex < text.length) nodes.push(text.substring(lastIndex));
   return <>{nodes}</>;
 };
 
-// Component to render ObjectId with both click navigation and copy functionality
+// ── ObjectId with navigation + copy ─────────────────────────────────────────
 const ObjectIdDisplay: React.FC<{
   objectId: string;
   onObjectIdClick?: (id: string, keyContext?: string, openInNewTab?: boolean, openToSide?: boolean) => void;
@@ -72,14 +76,12 @@ const ObjectIdDisplay: React.FC<{
     navigator.clipboard.writeText(objectId).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
-    }).catch(err => {
-      console.error("Failed to copy ObjectId:", err);
-    });
+    }).catch(err => console.error('Failed to copy ObjectId:', err));
   };
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    setShowContextMenu(false); // Hide context menu if clicking normally
+    setShowContextMenu(false);
     onObjectIdClick?.(objectId, keyContext, false);
   };
 
@@ -92,37 +94,21 @@ const ObjectIdDisplay: React.FC<{
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
-      if (e.ctrlKey || e.metaKey) {
-        // Ctrl+Enter or Cmd+Enter opens in new tab
-        onObjectIdClick?.(objectId, keyContext, true);
-      } else {
-        // Regular Enter navigates in same tab
-        onObjectIdClick?.(objectId, keyContext, false);
-      }
+      if (e.ctrlKey || e.metaKey) onObjectIdClick?.(objectId, keyContext, true);
+      else onObjectIdClick?.(objectId, keyContext, false);
     }
   };
 
-  const handleOpenInNewTab = () => {
-    setShowContextMenu(false);
-    onObjectIdClick?.(objectId, keyContext, true);
-  };
-
-  const handleOpenInCurrentTab = () => {
-    setShowContextMenu(false);
-    onObjectIdClick?.(objectId, keyContext, false);
-  };
-
+  const handleOpenInNewTab = () => { setShowContextMenu(false); onObjectIdClick?.(objectId, keyContext, true); };
+  const handleOpenInCurrentTab = () => { setShowContextMenu(false); onObjectIdClick?.(objectId, keyContext, false); };
   const handleCopyFromMenu = () => {
     setShowContextMenu(false);
     navigator.clipboard.writeText(objectId).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
-    }).catch(err => {
-      console.error("Failed to copy ObjectId:", err);
-    });
+    }).catch(err => console.error('Failed to copy ObjectId:', err));
   };
 
-  // Close context menu when clicking outside
   React.useEffect(() => {
     const handleClickOutside = () => setShowContextMenu(false);
     if (showContextMenu) {
@@ -131,6 +117,13 @@ const ObjectIdDisplay: React.FC<{
     }
   }, [showContextMenu]);
 
+  const menuItemStyle: React.CSSProperties = {
+    width: '100%', textAlign: 'left', padding: '6px 12px', fontSize: 12.5,
+    border: 'none', background: 'none', cursor: 'pointer',
+    display: 'flex', alignItems: 'center', gap: 8,
+    color: C.fg, fontFamily: 'var(--font-body)',
+  };
+
   return (
     <span className="inline-flex items-center relative group/objectid">
       {showAsLink ? (
@@ -138,72 +131,69 @@ const ObjectIdDisplay: React.FC<{
           onClick={handleClick}
           onContextMenu={handleRightClick}
           onKeyDown={handleKeyDown}
-          className="text-blue-600 dark:text-blue-400 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 rounded"
-          title={`Find document with ID: ${objectId} • Click to navigate in current tab • Right-click for options • Ctrl+Enter (⌘+Enter on Mac) to open in new tab`}
+          style={{ color: C.link, background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'inherit', fontSize: 'inherit', padding: 0, textDecoration: 'none' }}
+          onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.textDecoration = 'underline'; }}
+          onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.textDecoration = 'none'; }}
+          title={`Find document with ID: ${objectId} • Click to navigate • Right-click for options • Ctrl+Enter to open in new tab`}
         >
           "{objectId}"
         </button>
       ) : (
-        <span className="text-emerald-700 dark:text-emerald-300">"{objectId}"</span>
+        <span style={{ color: C.str }}>"{objectId}"</span>
       )}
 
-      {/* Context Menu */}
+      {/* Context menu */}
       {showContextMenu && (
         <div
-          className="fixed z-50 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-md shadow-lg py-1 min-w-[180px]"
-          style={{
-            left: `${contextMenuPosition.x}px`,
-            top: `${contextMenuPosition.y}px`,
-            transform: 'translate(-50%, 0)'
-          }}
+          className="fixed z-50 rounded-md shadow-lg py-1 min-w-[180px]"
+          style={{ left: contextMenuPosition.x, top: contextMenuPosition.y, transform: 'translate(-50%,0)', background: C.panel, border: `1px solid ${C.border}` }}
         >
-          <button
-            onClick={handleOpenInCurrentTab}
-            className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-700 flex items-center gap-2"
-          >
-            <span>Open in Current Tab</span>
-          </button>
-          <button
-            onClick={handleOpenInNewTab}
-            className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-700 flex items-center gap-2"
-          >
-            <span>Open in New Tab</span>
-          </button>
-          <button
-            onClick={() => {
-              setShowContextMenu(false);
-              onObjectIdClick?.(objectId, keyContext, false, true);
-            }}
-            className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-700 flex items-center gap-2"
-          >
-            <span>Open to Side</span>
-          </button>
-          <div className="border-t border-slate-200 dark:border-slate-600 my-1"></div>
+          {[
+            { label: 'Open in current view', fn: handleOpenInCurrentTab },
+            { label: 'Open in new tab', fn: handleOpenInNewTab },
+            { label: 'Open to side', fn: () => { setShowContextMenu(false); onObjectIdClick?.(objectId, keyContext, false, true); } },
+          ].map(({ label, fn }) => (
+            <button
+              key={label}
+              onClick={fn}
+              style={menuItemStyle}
+              onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = C.soft; }}
+              onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'none'; }}
+            >
+              {label}
+            </button>
+          ))}
+          <div style={{ borderTop: `1px solid ${C.border}`, margin: '3px 0' }} />
           <button
             onClick={handleCopyFromMenu}
-            className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-700 flex items-center gap-2"
+            style={menuItemStyle}
+            onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = C.soft; }}
+            onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'none'; }}
           >
-            <span>Copy ObjectId</span>
+            Copy ObjectId
           </button>
         </div>
       )}
 
+      {/* Inline copy button (appears on hover) */}
       <button
         onClick={handleCopy}
-        className="absolute -right-5 top-1/2 -translate-y-1/2 p-0.5 rounded opacity-0 group-hover/objectid:opacity-100 hover:bg-slate-200 dark:hover:bg-slate-600 transition-all duration-200 focus:opacity-100 z-10"
+        className="absolute -right-5 top-1/2 -translate-y-1/2 p-0.5 rounded opacity-0 group-hover/objectid:opacity-100 transition-all duration-200 focus:opacity-100 z-10"
+        style={{ background: 'none', border: 'none', cursor: 'pointer' }}
+        onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = C.soft; }}
+        onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'none'; }}
         title={copied ? 'Copied!' : 'Copy ObjectId'}
         aria-label="Copy ObjectId"
       >
-        {copied ? (
-          <CheckIcon className="w-3 h-3 text-green-500" />
-        ) : (
-          <ClipboardIcon className="w-3 h-3 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200" />
-        )}
+        {copied
+          ? <CheckIcon className="w-3 h-3" style={{ color: C.ok }} />
+          : <ClipboardIcon className="w-3 h-3" style={{ color: C.muted }} />}
       </button>
     </span>
   );
 };
 
+// ── Image preview (hover tooltip + expand) ───────────────────────────────────
 const ImagePreview: React.FC<{
   imageUrl: string;
   searchRegex: RegExp | null;
@@ -215,42 +205,29 @@ const ImagePreview: React.FC<{
   const handleMouseEnter = () => {
     if (iconRef.current) {
       const rect = iconRef.current.getBoundingClientRect();
-      const previewHeight = 220; // Approx max height
-      const previewWidth = 220; // Approx max width
-
-      // Default to showing above
+      const previewHeight = 220;
+      const previewWidth = 220;
       let top = rect.top - previewHeight - 8;
       let left = rect.left;
-
-      // If not enough space on top, show below
-      if (top < 10) {
-        top = rect.bottom + 8;
-      }
-
-      // Prevent right overflow
-      if (left + previewWidth > window.innerWidth) {
-        left = window.innerWidth - previewWidth - 10;
-      }
-
-      // Prevent left overflow
+      if (top < 10) top = rect.bottom + 8;
+      if (left + previewWidth > window.innerWidth) left = window.innerWidth - previewWidth - 10;
       if (left < 10) left = 10;
-
       setPreviewPos({ x: left, y: top });
     }
   };
 
-  const handleMouseLeave = () => {
-    setPreviewPos(null);
-  };
+  const handleMouseLeave = () => setPreviewPos(null);
 
   if (isExpanded) {
     return (
       <span
-        className="cursor-pointer hover:bg-slate-100 dark:hover:bg-slate-700 rounded px-1 -ml-1 transition-colors"
+        className="cursor-pointer rounded px-1 -ml-1 transition-colors"
         onClick={() => setIsExpanded(false)}
         title="Click to collapse back to icon"
+        onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = C.soft; }}
+        onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'none'; }}
       >
-        <span className="text-emerald-700 dark:text-emerald-300">"
+        <span style={{ color: C.str }}>"
           {searchRegex ? highlightText(imageUrl, searchRegex) : imageUrl}"
         </span>
       </span>
@@ -258,73 +235,60 @@ const ImagePreview: React.FC<{
   }
 
   return (
-    <span
-      className="inline-flex items-center gap-2 group relative select-none"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
-      <span
-        ref={iconRef}
-        className="cursor-pointer"
-        onClick={() => {
-          setIsExpanded(true);
-          setPreviewPos(null);
-        }}
-      >
-        <ImageIcon className="w-5 h-5 text-purple-600 dark:text-purple-400 hover:text-purple-800 dark:hover:text-purple-300 transition-colors" />
+    <span className="inline-flex items-center gap-2 group relative select-none" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+      <span ref={iconRef} className="cursor-pointer" onClick={() => { setIsExpanded(true); setPreviewPos(null); }}>
+        <ImageIcon className="w-5 h-5 transition-colors" style={{ color: C.key }} />
       </span>
-
-      {/* Tooltip Image Preview - Uses fixed positioning to escape container clipping */}
       {previewPos && (
         <div
-          className="fixed z-[9999] bg-white dark:bg-slate-800 p-2 rounded-lg shadow-xl border border-slate-200 dark:border-slate-600 pointer-events-none"
-          style={{
-            left: `${previewPos.x}px`,
-            top: `${previewPos.y}px`
-          }}
+          className="fixed z-[9999] p-2 rounded-lg shadow-xl pointer-events-none"
+          style={{ left: previewPos.x, top: previewPos.y, background: C.panel, border: `1px solid ${C.border}` }}
         >
-          <img
-            src={imageUrl}
-            alt="Preview"
-            className="max-w-[200px] max-h-[200px] object-contain rounded bg-slate-100 dark:bg-slate-900"
-          />
+          <img src={imageUrl} alt="Preview" className="max-w-[200px] max-h-[200px] object-contain rounded" style={{ background: C.soft }} />
         </div>
       )}
     </span>
   );
 };
 
-// A single, recursive component to render all parts of the JSON object.
+// ── Recursive JSON node renderer ─────────────────────────────────────────────
 const JsonNode: React.FC<{
   nodeValue: any;
-  nodeKey?: string; // The key of this node, if it's in an object
-  isRoot?: boolean; // The top-level object is not collapsible
+  nodeKey?: string;
+  isRoot?: boolean;
   onObjectIdClick?: (id: string, keyContext?: string, openInNewTab?: boolean, openToSide?: boolean) => void;
-  parentKeyContext?: string; // The key of the parent, used for context in clicks
-  searchRegex?: RegExp | null; // Regex for highlighting
-  currentMatchIndex?: number; // Current match index for highlighting
+  parentKeyContext?: string;
+  searchRegex?: RegExp | null;
+  currentMatchIndex?: number;
 }> = ({ nodeValue, nodeKey, isRoot = false, onObjectIdClick, parentKeyContext, searchRegex = null, currentMatchIndex = -1 }) => {
-  // All nodes are expanded by default.
   const [isExpanded, setIsExpanded] = useState(true);
 
+  const KeyLabel = nodeKey ? (
+    <span style={{ color: C.key }}>
+      "{searchRegex ? highlightText(nodeKey, searchRegex) : nodeKey}":&nbsp;
+    </span>
+  ) : null;
+
   const renderHeader = (prefix: string, suffix: string, count: number) => {
-    // Collapsing is disabled for the root element.
     const canCollapse = !isRoot;
     return (
       <span onClick={() => canCollapse && setIsExpanded(!isExpanded)} className={canCollapse ? 'cursor-pointer' : ''}>
-        {nodeKey && <span className="text-purple-600 dark:text-purple-400">"
-          {searchRegex ? highlightText(nodeKey, searchRegex) : nodeKey}"
-        </span>}
-        {nodeKey && <span className="mr-1">:</span>}
+        {KeyLabel}
         {canCollapse && (
           <ChevronDownIcon
-            className={`w-3 h-3 inline-block mr-1 text-slate-500 transition-transform duration-200 ${isExpanded ? 'rotate-0' : '-rotate-90'}`}
+            className={`w-3 h-3 inline-block mr-1 transition-transform duration-200 ${isExpanded ? 'rotate-0' : '-rotate-90'}`}
+            style={{ color: C.muted }}
           />
         )}
         {prefix}
         {!isExpanded && (
           <>
-            <span className="text-slate-500 dark:text-slate-400 hover:underline"> ... {count} {count === 1 ? (prefix === '[' ? 'item' : 'key') : (prefix === '[' ? 'items' : 'keys')} ... </span>
+            <span
+              className="hover:underline"
+              style={{ color: C.muted }}
+            >
+              {' '}...{count} {count === 1 ? (prefix === '[' ? 'item' : 'key') : (prefix === '[' ? 'items' : 'keys')}...{' '}
+            </span>
             {suffix}
           </>
         )}
@@ -332,54 +296,42 @@ const JsonNode: React.FC<{
     );
   };
 
-  // --- Value Rendering Logic ---
-
+  // null
   if (nodeValue === null) {
     return (
       <div className="inline-block">
-        {nodeKey && <span className="text-purple-600 dark:text-purple-400">"
-          {searchRegex ? highlightText(nodeKey, searchRegex) : nodeKey}":
-        </span>}
-        <span className="text-rose-500 dark:text-rose-400">null</span>
+        {KeyLabel}
+        <span style={{ color: C.nil }}>null</span>
       </div>
     );
   }
 
-  // BSON Types: ObjectId, Date
-  if (typeof nodeValue === 'object' && nodeValue !== null) {
-    if (nodeValue.$oid && Object.keys(nodeValue).length === 1 && typeof nodeValue.$oid === 'string') {
-      const objectId = nodeValue.$oid;
-      return (
-        <div className="inline-block">
-          {nodeKey && <span className="text-purple-600 dark:text-purple-400">"
-            {searchRegex ? highlightText(nodeKey, searchRegex) : nodeKey}":
-          </span>}
-          <span className="text-slate-700 dark:text-slate-300">
-            <span className="text-purple-600 dark:text-purple-400">ObjectId</span>(
-            <ObjectIdDisplay
-              objectId={objectId}
-              onObjectIdClick={onObjectIdClick}
-              keyContext={parentKeyContext}
-              showAsLink={!!onObjectIdClick}
-            />
-            )
-          </span>
-        </div>
-      );
-    }
-    if (nodeValue.$date && Object.keys(nodeValue).length === 1) {
-      return (
-        <div className="inline-block">
-          {nodeKey && <span className="text-purple-600 dark:text-purple-400">"
-            {searchRegex ? highlightText(nodeKey, searchRegex) : nodeKey}":
-          </span>}
-          <span className="text-slate-700 dark:text-slate-300">
-            <span className="text-purple-600 dark:text-purple-400">ISODate</span>("
-            {searchRegex ? highlightText(new Date(nodeValue.$date).toISOString(), searchRegex) : new Date(nodeValue.$date).toISOString()}")
-          </span>
-        </div>
-      );
-    }
+  // BSON ObjectId
+  if (typeof nodeValue === 'object' && nodeValue.$oid && Object.keys(nodeValue).length === 1 && typeof nodeValue.$oid === 'string') {
+    return (
+      <div className="inline-block">
+        {KeyLabel}
+        <span style={{ color: C.fg }}>
+          <span style={{ color: C.key }}>ObjectId</span>(
+          <ObjectIdDisplay objectId={nodeValue.$oid} onObjectIdClick={onObjectIdClick} keyContext={parentKeyContext} showAsLink={!!onObjectIdClick} />
+          )
+        </span>
+      </div>
+    );
+  }
+
+  // BSON Date
+  if (typeof nodeValue === 'object' && nodeValue.$date && Object.keys(nodeValue).length === 1) {
+    return (
+      <div className="inline-block">
+        {KeyLabel}
+        <span style={{ color: C.fg }}>
+          <span style={{ color: C.key }}>ISODate</span>("
+          {searchRegex ? highlightText(new Date(nodeValue.$date).toISOString(), searchRegex) : new Date(nodeValue.$date).toISOString()}
+          ")
+        </span>
+      </div>
+    );
   }
 
   // Arrays
@@ -387,9 +339,7 @@ const JsonNode: React.FC<{
     if (nodeValue.length === 0) {
       return (
         <span>
-          {nodeKey && <span className="text-purple-600 dark:text-purple-400">"
-            {searchRegex ? highlightText(nodeKey, searchRegex) : nodeKey}":
-          </span>}
+          {KeyLabel}
           []
         </span>
       );
@@ -399,16 +349,10 @@ const JsonNode: React.FC<{
         {renderHeader('[', ']', nodeValue.length)}
         {isExpanded && (
           <>
-            <div className="pl-6 border-l border-slate-200 dark:border-slate-700 ml-2">
+            <div className="pl-6 border-l ml-2" style={{ borderColor: C.border }}>
               {nodeValue.map((item, index) => (
                 <div key={index}>
-                  <JsonNode
-                    nodeValue={item}
-                    onObjectIdClick={onObjectIdClick}
-                    parentKeyContext={parentKeyContext}
-                    searchRegex={searchRegex}
-                    currentMatchIndex={currentMatchIndex}
-                  />
+                  <JsonNode nodeValue={item} onObjectIdClick={onObjectIdClick} parentKeyContext={parentKeyContext} searchRegex={searchRegex} currentMatchIndex={currentMatchIndex} />
                   {index < nodeValue.length - 1 && ','}
                 </div>
               ))}
@@ -424,31 +368,17 @@ const JsonNode: React.FC<{
   if (typeof nodeValue === 'object') {
     const keys = Object.keys(nodeValue);
     if (keys.length === 0) {
-      return (
-        <span>
-          {nodeKey && <span className="text-purple-600 dark:text-purple-400">"
-            {searchRegex ? highlightText(nodeKey, searchRegex) : nodeKey}":
-          </span>}
-          {`{}`}
-        </span>
-      );
+      return <span>{KeyLabel}{'{}'}</span>;
     }
     return (
       <div>
         {renderHeader('{', '}', keys.length)}
         {isExpanded && (
           <>
-            <div className="pl-6 border-l border-slate-200 dark:border-slate-700 ml-2">
+            <div className="pl-6 border-l ml-2" style={{ borderColor: C.border }}>
               {keys.map((key, index) => (
                 <div key={key}>
-                  <JsonNode
-                    nodeValue={nodeValue[key]}
-                    nodeKey={key}
-                    onObjectIdClick={onObjectIdClick}
-                    parentKeyContext={key}
-                    searchRegex={searchRegex}
-                    currentMatchIndex={currentMatchIndex}
-                  />
+                  <JsonNode nodeValue={nodeValue[key]} nodeKey={key} onObjectIdClick={onObjectIdClick} parentKeyContext={key} searchRegex={searchRegex} currentMatchIndex={currentMatchIndex} />
                   {index < keys.length - 1 && ','}
                 </div>
               ))}
@@ -467,56 +397,38 @@ const JsonNode: React.FC<{
         const isObjectIdLike = /^[0-9a-fA-F]{24}$/.test(nodeValue);
         if (isObjectIdLike && onObjectIdClick) {
           return (
-            <span className="text-emerald-700 dark:text-emerald-300">
-              <ObjectIdDisplay
-                objectId={nodeValue}
-                onObjectIdClick={onObjectIdClick}
-                keyContext={parentKeyContext}
-                showAsLink={true}
-              />
+            <span style={{ color: C.str }}>
+              <ObjectIdDisplay objectId={nodeValue} onObjectIdClick={onObjectIdClick} keyContext={parentKeyContext} showAsLink={true} />
             </span>
           );
         }
-
-        const isBase64Image = nodeValue.startsWith("data:image/");
+        const isBase64Image = nodeValue.startsWith('data:image/');
         const isUrlImage = /^https?:\/\/.+\.(png|jpe?g|gif|svg|webp)(\?.*)?$/i.test(nodeValue);
-
-        if (isBase64Image || isUrlImage) {
-          return <ImagePreview imageUrl={nodeValue} searchRegex={searchRegex} />;
-        }
-
-        return <span className="text-emerald-700 dark:text-emerald-300">"
-          {searchRegex ? highlightText(nodeValue, searchRegex) : nodeValue}"
-        </span>;
+        if (isBase64Image || isUrlImage) return <ImagePreview imageUrl={nodeValue} searchRegex={searchRegex} />;
+        return (
+          <span style={{ color: C.str }}>"
+            {searchRegex ? highlightText(nodeValue, searchRegex) : nodeValue}"
+          </span>
+        );
       }
       case 'number':
-        const numberStr = String(nodeValue);
-        return <span className="text-amber-600 dark:text-amber-400">
-          {searchRegex ? highlightText(numberStr, searchRegex) : numberStr}
-        </span>;
+        return <span style={{ color: C.num }}>{searchRegex ? highlightText(String(nodeValue), searchRegex) : String(nodeValue)}</span>;
       case 'boolean':
-        const boolStr = String(nodeValue);
-        return <span className="text-sky-600 dark:text-sky-400">
-          {searchRegex ? highlightText(boolStr, searchRegex) : boolStr}
-        </span>;
+        return <span style={{ color: C.bool }}>{searchRegex ? highlightText(String(nodeValue), searchRegex) : String(nodeValue)}</span>;
       default:
-        const defaultStr = String(nodeValue);
-        return <span>
-          {searchRegex ? highlightText(defaultStr, searchRegex) : defaultStr}
-        </span>;
+        return <span>{searchRegex ? highlightText(String(nodeValue), searchRegex) : String(nodeValue)}</span>;
     }
   };
 
   return (
     <div className="inline-block">
-      {nodeKey && <span className="text-purple-600 dark:text-purple-400">"
-        {searchRegex ? highlightText(nodeKey, searchRegex) : nodeKey}":
-      </span>}
+      {KeyLabel}
       {renderPrimitive()}
     </div>
   );
 };
 
+// ── Public component ─────────────────────────────────────────────────────────
 interface JsonDisplayProps {
   data: any;
   onObjectIdClick?: (id: string, keyContext?: string, openInNewTab?: boolean, openToSide?: boolean) => void;
@@ -529,89 +441,49 @@ const JsonDisplay: React.FC<JsonDisplayProps> = ({ data, onObjectIdClick }) => {
   const [matchWholeWord, setMatchWholeWord] = useState(false);
   const [useRegex, setUseRegex] = useState(false);
   const [searchRegex, setSearchRegex] = useState<RegExp | null>(null);
-
   const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
   const [totalMatches, setTotalMatches] = useState(0);
   const [isSearchVisible, setIsSearchVisible] = useState(false);
   const containerRef = useRef<HTMLPreElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  // Update regex and count matches when inputs change
+  // Build regex + count matches
   useEffect(() => {
-    if (!searchQuery) {
-      setSearchRegex(null);
-      setTotalMatches(0);
-      setCurrentMatchIndex(0);
-      return;
-    }
-
+    if (!searchQuery) { setSearchRegex(null); setTotalMatches(0); setCurrentMatchIndex(0); return; }
     try {
       let pattern = searchQuery;
       let flags = 'g';
-
-      if (!useRegex) {
-        pattern = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      }
-
-      if (matchWholeWord) {
-        pattern = `\\b${pattern}\\b`;
-      }
-
-      if (!matchCase) {
-        flags += 'i';
-      }
-
+      if (!useRegex) pattern = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      if (matchWholeWord) pattern = `\\b${pattern}\\b`;
+      if (!matchCase) flags += 'i';
       const regex = new RegExp(pattern, flags);
       setSearchRegex(regex);
-
       const jsonString = JSON.stringify(data, null, 2);
       const matches = jsonString.match(regex);
       const count = matches ? matches.length : 0;
-
       setTotalMatches(count);
-      if (count === 0) {
-        setCurrentMatchIndex(0);
-      } else if (currentMatchIndex >= count) {
-        setCurrentMatchIndex(0);
-      }
-    } catch (e) {
-      setSearchRegex(null);
-      setTotalMatches(0);
-    }
-  }, [searchQuery, matchCase, matchWholeWord, useRegex, data]); // removed currentMatchIndex dependency to prevent loop, added data
+      if (count === 0) setCurrentMatchIndex(0);
+      else if (currentMatchIndex >= count) setCurrentMatchIndex(0);
+    } catch (e) { setSearchRegex(null); setTotalMatches(0); }
+  }, [searchQuery, matchCase, matchWholeWord, useRegex, data]);
 
-  // Navigate to current match
+  // Scroll to current match
   const scrollToMatch = useCallback(() => {
     if (!containerRef.current || totalMatches === 0) return;
-
-    // allow a tick for DOM to update with highlights
-    // but useEffect is post-render, so DOM should be ready if nodes rendered.
-    // However, JsonNode is recursive, might take time? No, sync render.
-
     const matches = containerRef.current.querySelectorAll('[data-search-match]');
     if (matches.length === 0) return;
-
-    // Remove previous highlight
-    matches.forEach(match => {
-      match.classList.remove('bg-yellow-300', 'ring-2', 'ring-yellow-400');
-      match.classList.add('bg-yellow-200');
-    });
-
-    // Highlight current match
-    const currentMatch = matches[currentMatchIndex];
-    if (currentMatch) {
-      currentMatch.classList.remove('bg-yellow-200');
-      currentMatch.classList.add('bg-yellow-300', 'ring-2', 'ring-yellow-400');
-      currentMatch.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    matches.forEach(m => { m.classList.remove('bg-yellow-300', 'ring-2', 'ring-yellow-400'); m.classList.add('bg-yellow-200'); });
+    const current = matches[currentMatchIndex];
+    if (current) {
+      current.classList.remove('bg-yellow-200');
+      current.classList.add('bg-yellow-300', 'ring-2', 'ring-yellow-400');
+      current.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
   }, [currentMatchIndex, totalMatches]);
 
-  // Scroll to match when current index changes
-  useEffect(() => {
-    scrollToMatch();
-  }, [scrollToMatch]);
+  useEffect(() => { scrollToMatch(); }, [scrollToMatch]);
 
-  // Handle keyboard shortcuts
+  // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
@@ -622,112 +494,82 @@ const JsonDisplay: React.FC<JsonDisplayProps> = ({ data, onObjectIdClick }) => {
         setIsSearchVisible(false);
         setSearchQuery('');
         setCurrentMatchIndex(0);
-      } else if (isSearchVisible && searchQuery && totalMatches > 0) {
-        if (e.key === 'Enter') {
-          e.preventDefault();
-          if (e.shiftKey) {
-            // Previous match
-            setCurrentMatchIndex(prev => prev === 0 ? totalMatches - 1 : prev - 1);
-          } else {
-            // Next match
-            setCurrentMatchIndex(prev => (prev + 1) % totalMatches);
-          }
-        }
+      } else if (isSearchVisible && searchQuery && totalMatches > 0 && e.key === 'Enter') {
+        e.preventDefault();
+        if (e.shiftKey) setCurrentMatchIndex(prev => prev === 0 ? totalMatches - 1 : prev - 1);
+        else setCurrentMatchIndex(prev => (prev + 1) % totalMatches);
       }
     };
-
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [isSearchVisible, searchQuery, totalMatches]);
 
   const handleCopy = () => {
-    const jsonString = JSON.stringify(data, null, 2);
-    navigator.clipboard.writeText(jsonString).then(() => {
+    navigator.clipboard.writeText(JSON.stringify(data, null, 2)).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    }).catch(err => {
-      console.error("Failed to copy JSON:", err);
-    });
+    }).catch(err => console.error('Failed to copy JSON:', err));
   };
 
-  const handleNextMatch = () => {
-    if (totalMatches > 0) {
-      setCurrentMatchIndex(prev => (prev + 1) % totalMatches);
-    }
-  };
+  const handleNextMatch = () => { if (totalMatches > 0) setCurrentMatchIndex(prev => (prev + 1) % totalMatches); };
+  const handlePrevMatch = () => { if (totalMatches > 0) setCurrentMatchIndex(prev => prev === 0 ? totalMatches - 1 : prev - 1); };
+  const handleSearchClose = () => { setIsSearchVisible(false); setSearchQuery(''); setCurrentMatchIndex(0); };
 
-  const handlePrevMatch = () => {
-    if (totalMatches > 0) {
-      setCurrentMatchIndex(prev => prev === 0 ? totalMatches - 1 : prev - 1);
-    }
-  };
+  // Shared icon-button style for the search toolbar option toggles
+  const searchOptBtn = (active: boolean): React.CSSProperties => ({
+    padding: '3px 5px', borderRadius: 5, border: 'none', cursor: 'pointer',
+    background: active ? C.accentSoft : 'transparent',
+    color: active ? C.accent : C.muted,
+    display: 'flex', alignItems: 'center',
+  });
 
-  const handleSearchClose = () => {
-    setIsSearchVisible(false);
-    setSearchQuery('');
-    setCurrentMatchIndex(0);
-  };
+  // Shared top-right action button
+  const actionBtnCls = 'p-2 rounded-md opacity-0 group-hover:opacity-100 focus:opacity-100 transition-all duration-200';
 
   return (
-    <div className="bg-white dark:bg-slate-800 rounded-md relative group ring-1 ring-slate-200 dark:ring-slate-700">
-      {/* Search Bar */}
+    <div className="rounded-md relative group" style={{ color: C.fg }}>
+
+      {/* Search bar */}
       {isSearchVisible && (
-        <div className="absolute top-2 left-2 right-12 z-10 bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-md shadow-lg p-2 flex items-center gap-2">
-          <SearchIcon className="w-4 h-4 text-slate-400" />
+        <div
+          className="absolute top-2 left-2 right-12 z-10 rounded-md shadow-lg p-2 flex items-center gap-2"
+          style={{ background: C.panel, border: `1px solid ${C.border}` }}
+        >
+          <SearchIcon className="w-4 h-4" style={{ color: C.muted, flexShrink: 0 }} />
           <input
             ref={searchInputRef}
             type="text"
-            placeholder="Search in JSON... (Enter: next, Shift+Enter: previous)"
+            placeholder="Search… (Enter: next, Shift+Enter: prev, Esc: close)"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="flex-1 px-2 py-1 text-sm bg-transparent border-none focus:outline-none text-slate-900 dark:text-slate-100"
-            title="Use Enter to go to next match, Shift+Enter for previous match, Esc to close"
+            className="flex-1 bg-transparent border-none focus:outline-none text-sm"
+            style={{ color: C.fg, fontFamily: 'var(--font-body)', minWidth: 0 }}
             onKeyDown={(e) => {
-              if (e.key === 'Escape') {
-                handleSearchClose();
-              } else if (e.key === 'Enter') {
-                e.preventDefault();
-                if (e.shiftKey) {
-                  handlePrevMatch();
-                } else {
-                  handleNextMatch();
-                }
-              }
+              if (e.key === 'Escape') handleSearchClose();
+              else if (e.key === 'Enter') { e.preventDefault(); e.shiftKey ? handlePrevMatch() : handleNextMatch(); }
             }}
           />
-          <div className="flex items-center gap-0.5 border-r border-slate-300 dark:border-slate-600 pr-2 mr-2">
-            <button
-              onClick={() => setMatchCase(!matchCase)}
-              className={`p-1 rounded ${matchCase ? 'bg-blue-100 text-blue-600 dark:bg-blue-900/50 dark:text-blue-400' : 'text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300'}`}
-              title="Match Case"
-            >
-              <CaseSensitiveIcon className="w-4 h-4" />
-            </button>
-            <button
-              onClick={() => setMatchWholeWord(!matchWholeWord)}
-              className={`p-1 rounded ${matchWholeWord ? 'bg-blue-100 text-blue-600 dark:bg-blue-900/50 dark:text-blue-400' : 'text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300'}`}
-              title="Match Whole Word"
-            >
-              <WholeWordIcon className="w-4 h-4" />
-            </button>
-            <button
-              onClick={() => setUseRegex(!useRegex)}
-              className={`p-1 rounded ${useRegex ? 'bg-blue-100 text-blue-600 dark:bg-blue-900/50 dark:text-blue-400' : 'text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300'}`}
-              title="Use Regular Expression"
-            >
-              <RegexIcon className="w-4 h-4" />
-            </button>
+
+          {/* Search options */}
+          <div className="flex items-center gap-0.5 pr-2 mr-1" style={{ borderRight: `1px solid ${C.border}` }}>
+            <button onClick={() => setMatchCase(!matchCase)} style={searchOptBtn(matchCase)} title="Match case"><CaseSensitiveIcon className="w-4 h-4" /></button>
+            <button onClick={() => setMatchWholeWord(!matchWholeWord)} style={searchOptBtn(matchWholeWord)} title="Whole word"><WholeWordIcon className="w-4 h-4" /></button>
+            <button onClick={() => setUseRegex(!useRegex)} style={searchOptBtn(useRegex)} title="Regular expression"><RegexIcon className="w-4 h-4" /></button>
           </div>
 
+          {/* Match navigation */}
           {searchQuery && (
             <div className="flex items-center gap-1">
-              <span className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+              <span className="text-xs whitespace-nowrap" style={{ color: C.muted }}>
                 {totalMatches > 0 ? `${currentMatchIndex + 1}/${totalMatches}` : 'No matches'}
               </span>
               <button
                 onClick={handlePrevMatch}
                 disabled={totalMatches === 0}
-                className="p-1 rounded hover:bg-slate-200 dark:hover:bg-slate-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="p-1 rounded disabled:opacity-40 disabled:cursor-not-allowed"
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: C.muted }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = C.soft; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'none'; }}
                 title="Previous match (Shift+Enter)"
               >
                 <ArrowUpwardIcon className="w-3 h-3" />
@@ -735,24 +577,36 @@ const JsonDisplay: React.FC<JsonDisplayProps> = ({ data, onObjectIdClick }) => {
               <button
                 onClick={handleNextMatch}
                 disabled={totalMatches === 0}
-                className="p-1 rounded hover:bg-slate-200 dark:hover:bg-slate-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="p-1 rounded disabled:opacity-40 disabled:cursor-not-allowed"
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: C.muted }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = C.soft; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'none'; }}
                 title="Next match (Enter)"
               >
                 <ArrowDownwardIcon className="w-3 h-3" />
               </button>
             </div>
           )}
+
           <button
             onClick={handleSearchClose}
-            className="p-1 rounded hover:bg-slate-200 dark:hover:bg-slate-600"
-            title="Close search (Esc)"
+            className="p-1 rounded"
+            style={{ background: 'none', border: 'none', cursor: 'pointer', color: C.muted }}
+            onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = C.soft; }}
+            onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'none'; }}
+            title="Close (Esc)"
           >
             <XIcon className="w-4 h-4" />
           </button>
         </div>
       )}
 
-      <pre className="text-sm p-4 overflow-x-auto font-mono text-slate-900 dark:text-slate-100" ref={containerRef}>
+      {/* JSON content */}
+      <pre
+        className="text-sm p-4 overflow-x-auto"
+        style={{ fontFamily: 'var(--font-mono)', color: C.fg, margin: 0, lineHeight: 1.7 }}
+        ref={containerRef}
+      >
         <code>
           <JsonNode
             nodeValue={data}
@@ -764,14 +618,15 @@ const JsonDisplay: React.FC<JsonDisplayProps> = ({ data, onObjectIdClick }) => {
         </code>
       </pre>
 
+      {/* Top-right action buttons */}
       <div className="absolute top-2 right-2 flex items-center gap-1">
         {!isSearchVisible && (
           <button
-            onClick={() => {
-              setIsSearchVisible(true);
-              setTimeout(() => searchInputRef.current?.focus(), 100);
-            }}
-            className="p-2 bg-slate-100/80 dark:bg-slate-700/80 rounded-md text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 hover:text-slate-800 dark:hover:text-white transition-all duration-200 opacity-0 group-hover:opacity-100 focus:opacity-100"
+            onClick={() => { setIsSearchVisible(true); setTimeout(() => searchInputRef.current?.focus(), 100); }}
+            className={actionBtnCls}
+            style={{ background: C.soft, border: 'none', cursor: 'pointer', color: C.muted }}
+            onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = C.fg; }}
+            onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = C.muted; }}
             aria-label="Search in JSON (Ctrl+F / Cmd+F)"
             title="Search in JSON (Ctrl+F / Cmd+F)"
           >
@@ -780,11 +635,16 @@ const JsonDisplay: React.FC<JsonDisplayProps> = ({ data, onObjectIdClick }) => {
         )}
         <button
           onClick={handleCopy}
-          className="p-2 bg-slate-100/80 dark:bg-slate-700/80 rounded-md text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 hover:text-slate-800 dark:hover:text-white transition-all duration-200 opacity-0 group-hover:opacity-100 focus:opacity-100"
-          aria-label="Copy JSON result"
+          className={actionBtnCls}
+          style={{ background: C.soft, border: 'none', cursor: 'pointer', color: C.muted }}
+          onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = C.fg; }}
+          onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = C.muted; }}
+          aria-label="Copy JSON"
           title={copied ? 'Copied!' : 'Copy raw JSON'}
         >
-          {copied ? <CheckIcon className="w-4 h-4 text-blue-500" /> : <ClipboardIcon className="w-4 h-4" />}
+          {copied
+            ? <CheckIcon className="w-4 h-4" style={{ color: C.ok }} />
+            : <ClipboardIcon className="w-4 h-4" />}
         </button>
       </div>
     </div>

--- a/frontend/components/QueryDisplay.tsx
+++ b/frontend/components/QueryDisplay.tsx
@@ -1,13 +1,5 @@
 
 import React, { useState, useMemo, useEffect } from 'react';
-import { 
-  CheckIcon,
-  ClipboardIcon,
-  PlayIcon,
-  ArrowLeftIcon,
-  ArrowRightIcon,
-  BookmarkIcon,
- } from './icons/material-icons-imports';
 
 interface QueryDisplayProps {
   code: string;
@@ -20,164 +12,176 @@ interface QueryDisplayProps {
   onNavigateHistory: (direction: 'prev' | 'next') => void;
 }
 
-// This regex is more reliable for detecting MongoDB write methods.
 const WRITE_OPERATION_REGEX = /\.(insert_one|insert_many|update_one|update_many|replace_one|delete_one|delete_many|bulk_write|drop|drop_index|drop_indexes|create_index|create_indexes|rename_collection)\s*\(/i;
 
+const detectQueryType = (code: string): string => {
+  if (/\.aggregate\s*\(/.test(code)) {
+    const stageMatches = code.match(/\{\s*\$[a-z]+/g);
+    const stageCount = stageMatches ? stageMatches.length : 0;
+    return stageCount > 0 ? `aggregate · ${stageCount} stage${stageCount !== 1 ? 's' : ''}` : 'aggregate';
+  }
+  if (/\.find\s*\(/.test(code)) return 'find';
+  if (/\.count\s*\(|\.countDocuments\s*\(/.test(code)) return 'count';
+  if (/\.distinct\s*\(/.test(code)) return 'distinct';
+  if (WRITE_OPERATION_REGEX.test(code)) return 'write';
+  return 'query';
+};
 
-const QueryDisplay: React.FC<QueryDisplayProps> = ({ code, onCodeChange, onRunQuery, onSaveQuery, isExecuting, historyCount, historyIndex, onNavigateHistory }) => {
+const QueryDisplay: React.FC<QueryDisplayProps> = ({
+  code, onCodeChange, onRunQuery, onSaveQuery,
+  isExecuting, historyCount, historyIndex, onNavigateHistory,
+}) => {
   const [copied, setCopied] = useState(false);
   const [allowWrite, setAllowWrite] = useState(false);
 
-  const isWriteOperation = useMemo(() => {
-    return WRITE_OPERATION_REGEX.test(code);
-  }, [code]);
+  const isWriteOperation = useMemo(() => WRITE_OPERATION_REGEX.test(code), [code]);
+  const queryType = useMemo(() => detectQueryType(code), [code]);
 
-  // Reset the toggle if the code changes to a new write operation
   useEffect(() => {
-    if (isWriteOperation) {
-      setAllowWrite(false);
-    }
+    if (isWriteOperation) setAllowWrite(false);
   }, [code, isWriteOperation]);
 
   const handleCopy = () => {
     navigator.clipboard.writeText(code).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    }).catch(err => {
-        console.error("Failed to copy text:", err);
-    });
+    }).catch(err => console.error('Failed to copy:', err));
   };
 
-  const isRunButtonDisabled = isExecuting || (isWriteOperation && !allowWrite);
+  const isRunDisabled = isExecuting || (isWriteOperation && !allowWrite);
 
   const handleEditorKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    // Run query on Cmd/Ctrl + Enter
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
       e.preventDefault();
-      if (!isRunButtonDisabled) {
-        onRunQuery();
-        setAllowWrite(false);
-      }
+      if (!isRunDisabled) { onRunQuery(); setAllowWrite(false); }
     }
   };
 
   return (
-    <div id="query-display-panel" className="bg-white dark:bg-slate-800 rounded-lg p-6 space-y-4 animate-fade-in border border-slate-200 dark:border-slate-700">
-      <div className="space-y-4">
-        {/* New Two-Row Header Layout */}
-        <div className="flex flex-col gap-3">
-          {/* Top Row: Title and primary actions */}
-          <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3">
-            <h3 className="text-sm font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wider">
-              Generated & Editable Code
-            </h3>
-            <div className="flex items-center gap-3 flex-shrink-0">
-               <button
-                    id="tutorial-save-button"
-                    onClick={onSaveQuery}
-                    disabled={!code}
-                    className="flex items-center gap-2 px-4 py-2 border border-slate-300 dark:border-slate-600 text-sm font-medium rounded-md text-slate-600 dark:text-slate-300 bg-white dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                    title="Save query"
-                >
-                    <BookmarkIcon className="w-4 h-4" />
-                    <span>Save</span>
-                </button>
-                <button
-                    onClick={() => {
-                      onRunQuery();
-                      setAllowWrite(false);
-                    }}
-                    disabled={isRunButtonDisabled}
-                    className="flex items-center gap-2 px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-slate-300 dark:disabled:bg-slate-600 disabled:text-slate-500 dark:disabled:text-slate-400 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-slate-800 focus:ring-blue-500 transition-colors"
-                    title="Run the code against the connected database (⌘ + Enter)"
-                >
-                    <PlayIcon className="w-4 h-4" />
-                    {isExecuting ? 'Running...' : 'Run Query'}
-                </button>
-            </div>
-          </div>
-
-          {/* Bottom Row: History and warnings */}
-          <div className="flex flex-col sm:flex-row justify-between items-center gap-3 min-h-[2rem]">
-            {/* Left side: History Navigator */}
-            <div className="w-full sm:w-auto flex justify-start">
-              {historyCount > 1 && (
-                <div className="flex items-center gap-2 text-slate-500 bg-slate-100 dark:bg-slate-700 dark:text-slate-400 px-2 py-1 rounded-full">
-                  <button
-                    onClick={() => onNavigateHistory('prev')}
-                    disabled={historyIndex <= 0}
-                    className="p-1 rounded-full hover:bg-slate-200 dark:hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                    aria-label="Previous query version"
-                    title="Previous query version"
-                  >
-                    <ArrowLeftIcon className="w-4 h-4" />
-                  </button>
-                  <span className="text-xs font-medium tabular-nums">Version {historyIndex + 1} of {historyCount}</span>
-                  <button
-                    onClick={() => onNavigateHistory('next')}
-                    disabled={historyIndex >= historyCount - 1}
-                    className="p-1 rounded-full hover:bg-slate-200 dark:hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                    aria-label="Next query version"
-                    title="Next query version"
-                  >
-                    <ArrowRightIcon className="w-4 h-4" />
-                  </button>
-                </div>
-              )}
-            </div>
-            
-            {/* Right side: Warnings */}
-            <div className="w-full sm:w-auto flex justify-end">
-              {isWriteOperation ? (
-                  <div className="text-xs text-red-800 dark:text-red-200 bg-red-100 dark:bg-red-900/50 border border-red-200 dark:border-red-500/30 px-2 py-1 rounded-md">
-                    <strong>Warning:</strong> Write operation detected.
-                  </div>
-              ) : (
-                <div className="text-xs text-yellow-800 dark:text-yellow-200 bg-yellow-100 dark:bg-yellow-900/50 border border-yellow-200 dark:border-yellow-500/30 px-2 py-1 rounded-md">
-                    <strong>Warning:</strong> Review code before execution.
-                </div>
-              )}
-            </div>
-          </div>
+    <div id="query-display-panel" className="qa-card animate-fade-in" style={{ padding: '10px 14px 12px' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg)' }}>// generated query</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--muted)', background: 'var(--soft)', padding: '2px 8px', borderRadius: 4 }}>
+            {queryType}
+          </span>
+          {historyCount > 1 && (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, background: 'var(--soft)', borderRadius: 99, padding: '1px 6px' }}>
+              <button
+                onClick={() => onNavigateHistory('prev')}
+                disabled={historyIndex <= 0}
+                aria-label="Previous query version"
+                style={{ background: 'none', border: 'none', cursor: historyIndex <= 0 ? 'default' : 'pointer', color: historyIndex <= 0 ? 'var(--border)' : 'var(--muted)', fontSize: 12, padding: '0 2px', lineHeight: 1 }}
+                title="Previous version"
+              >‹</button>
+              <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--muted)', minWidth: 36, textAlign: 'center' }}>
+                v{historyIndex + 1}/{historyCount}
+              </span>
+              <button
+                onClick={() => onNavigateHistory('next')}
+                disabled={historyIndex >= historyCount - 1}
+                aria-label="Next query version"
+                style={{ background: 'none', border: 'none', cursor: historyIndex >= historyCount - 1 ? 'default' : 'pointer', color: historyIndex >= historyCount - 1 ? 'var(--border)' : 'var(--muted)', fontSize: 12, padding: '0 2px', lineHeight: 1 }}
+                title="Next version"
+              >›</button>
+            </span>
+          )}
+          {isWriteOperation && (
+            <span style={{ fontSize: 10.5, padding: '2px 8px', borderRadius: 4, background: 'color-mix(in oklch, #c94250 12%, var(--bg))', color: '#c94250', fontFamily: 'var(--font-mono)' }}>
+              write op
+            </span>
+          )}
         </div>
-        
-        <div className="bg-slate-800 dark:bg-black/30 rounded-md relative group">
-          <textarea
-            value={code}
-            onChange={(e) => onCodeChange(e.target.value)}
-            onKeyDown={handleEditorKeyDown}
-            className="w-full h-48 bg-transparent text-cyan-300 p-4 font-mono text-sm overflow-x-auto resize-y border-2 border-slate-600 dark:border-slate-700 focus:border-blue-500 focus:ring-blue-500 rounded-md transition-colors"
-            spellCheck="false"
-          />
-          <button
-            onClick={handleCopy}
-            className="absolute top-2 right-2 p-2 bg-slate-600/80 dark:bg-slate-700/80 rounded-md text-slate-300 hover:bg-slate-500 dark:hover:bg-slate-600 hover:text-white transition-all duration-200 opacity-0 group-hover:opacity-100 focus:opacity-100"
-            aria-label="Copy code"
-            title={copied ? 'Copied!' : 'Copy code'}
+      </div>
+
+      {/* Code editor */}
+      <div style={{ position: 'relative', borderRadius: 'var(--radius-sm)', overflow: 'hidden' }}>
+        <textarea
+          value={code}
+          onChange={(e) => onCodeChange(e.target.value)}
+          onKeyDown={handleEditorKeyDown}
+          style={{
+            width: '100%', minHeight: 160, padding: '12px 14px',
+            background: '#0f0e0d', color: '#c8c4bc',
+            fontFamily: 'var(--font-mono)', fontSize: 12, lineHeight: 1.65,
+            border: 'none', outline: 'none', resize: 'vertical',
+            boxSizing: 'border-box', borderRadius: 'var(--radius-sm)',
+            display: 'block',
+          }}
+          spellCheck={false}
+        />
+        <button
+          onClick={handleCopy}
+          title={copied ? 'Copied!' : 'Copy'}
+          style={{
+            position: 'absolute', top: 8, right: 8,
+            padding: '3px 9px', borderRadius: 4, cursor: 'pointer',
+            background: 'rgba(255,255,255,0.07)', border: '1px solid rgba(255,255,255,0.12)',
+            color: copied ? '#4aab73' : '#8a8580', fontSize: 11,
+            fontFamily: 'var(--font-mono)', transition: 'color 0.15s',
+          }}
+        >
+          {copied ? '✓ copied' : 'copy'}
+        </button>
+      </div>
+
+      {/* Write acknowledge */}
+      {isWriteOperation && (
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 10, marginTop: 8,
+          padding: '8px 12px', borderRadius: 'var(--radius-sm)',
+          background: 'color-mix(in oklch, #c94250 8%, var(--bg))',
+          border: '1px solid color-mix(in oklch, #c94250 22%, var(--border))',
+        }}>
+          <span style={{ fontSize: 12, color: '#c94250', flex: 1 }}>
+            Write operation detected — acknowledge to enable Run
+          </span>
+          <div
+            onClick={() => setAllowWrite(!allowWrite)}
+            role="switch"
+            aria-checked={allowWrite}
+            id="allow-write-toggle"
+            title="Toggle to acknowledge write operation"
+            style={{
+              width: 36, height: 20, borderRadius: 99, cursor: 'pointer', flexShrink: 0,
+              background: allowWrite ? 'var(--accent)' : 'var(--border)',
+              position: 'relative', transition: 'background 0.2s',
+            }}
           >
-            {copied ? <CheckIcon className="w-4 h-4 text-blue-400" /> : <ClipboardIcon className="w-4 h-4" />}
-          </button>
+            <span style={{
+              position: 'absolute', top: 2,
+              left: allowWrite ? 18 : 2,
+              width: 16, height: 16, borderRadius: 99,
+              background: 'white', transition: 'left 0.2s',
+            }} />
+          </div>
         </div>
+      )}
 
-        {isWriteOperation && (
-            <div className="flex items-center justify-end gap-3 p-2 bg-red-50/50 dark:bg-red-900/20 rounded-md border border-red-200/60 dark:border-red-500/30 mt-2">
-                <label htmlFor="allow-write-toggle" className="text-sm font-medium text-red-700 dark:text-red-300">
-                  Acknowledge & Allow Write Operation
-                </label>
-                <div 
-                    onClick={() => setAllowWrite(!allowWrite)}
-                    id="allow-write-toggle"
-                    role="switch"
-                    aria-checked={allowWrite}
-                    className={`relative inline-flex items-center h-6 rounded-full w-11 cursor-pointer transition-colors duration-200 ease-in-out ${allowWrite ? 'bg-blue-600' : 'bg-slate-300 dark:bg-slate-600'}`}
-                    title="Toggle to enable or disable execution of write operations"
-                >
-                    <span
-                        className={`inline-block w-4 h-4 transform bg-white dark:bg-slate-300 rounded-full transition-transform duration-200 ease-in-out ${allowWrite ? 'translate-x-6' : 'translate-x-1'}`}
-                    />
-                </div>
-            </div>
-        )}
+      {/* Footer */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10 }}>
+        <button
+          id="tutorial-save-button"
+          onClick={onSaveQuery}
+          disabled={!code}
+          className="qa-btn"
+          style={{ fontSize: 12 }}
+        >
+          Save
+        </button>
+        <button
+          onClick={() => { onRunQuery(); setAllowWrite(false); }}
+          disabled={isRunDisabled}
+          className="qa-btn primary"
+          aria-label={isExecuting ? 'Running' : 'Run query'}
+          style={{ fontSize: 12 }}
+        >
+          {isExecuting ? 'Running' : 'Run'}
+        </button>
+        <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--muted)', fontFamily: 'var(--font-mono)' }}>
+          ⌘↩ run
+        </span>
       </div>
     </div>
   );

--- a/frontend/components/QueryDisplay.tsx
+++ b/frontend/components/QueryDisplay.tsx
@@ -10,6 +10,8 @@ interface QueryDisplayProps {
   historyCount: number;
   historyIndex: number;
   onNavigateHistory: (direction: 'prev' | 'next') => void;
+  isTransferable?: boolean;
+  onOpenInExplorer?: () => void;
 }
 
 const WRITE_OPERATION_REGEX = /\.(insert_one|insert_many|update_one|update_many|replace_one|delete_one|delete_many|bulk_write|drop|drop_index|drop_indexes|create_index|create_indexes|rename_collection)\s*\(/i;
@@ -30,6 +32,7 @@ const detectQueryType = (code: string): string => {
 const QueryDisplay: React.FC<QueryDisplayProps> = ({
   code, onCodeChange, onRunQuery, onSaveQuery,
   isExecuting, historyCount, historyIndex, onNavigateHistory,
+  isTransferable, onOpenInExplorer,
 }) => {
   const [copied, setCopied] = useState(false);
   const [allowWrite, setAllowWrite] = useState(false);
@@ -91,6 +94,34 @@ const QueryDisplay: React.FC<QueryDisplayProps> = ({
             <span style={{ fontSize: 10.5, padding: '2px 8px', borderRadius: 4, background: 'color-mix(in oklch, #c94250 12%, var(--bg))', color: '#c94250', fontFamily: 'var(--font-mono)' }}>
               write op
             </span>
+          )}
+          {onOpenInExplorer && (
+            <button
+              onClick={isTransferable ? onOpenInExplorer : undefined}
+              disabled={!isTransferable}
+              title={
+                isTransferable
+                  ? 'Open in Data Explorer'
+                  : 'This query can\'t be opened in Explorer (only find() queries are supported). Your result will be saved if you switch tabs.'
+              }
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: 4,
+                background: isTransferable ? 'var(--accent-soft)' : 'var(--soft)',
+                border: `1px solid ${isTransferable ? 'color-mix(in oklch, var(--accent) 30%, transparent)' : 'var(--border)'}`,
+                color: isTransferable ? 'var(--accent)' : 'var(--muted)',
+                borderRadius: 4, cursor: isTransferable ? 'pointer' : 'default',
+                fontSize: 11, padding: '2px 8px', fontFamily: 'var(--font-body)',
+                opacity: isTransferable ? 1 : 0.55,
+              }}
+            >
+              <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <rect x="1" y="1" width="6" height="6" rx="1" />
+                <rect x="9" y="1" width="6" height="6" rx="1" />
+                <rect x="1" y="9" width="6" height="6" rx="1" />
+                <path d="M11.5 11.5h3m-1.5-1.5v3" strokeLinecap="round" />
+              </svg>
+              Open in Explorer
+            </button>
           )}
         </div>
       </div>

--- a/frontend/components/QueryResult.tsx
+++ b/frontend/components/QueryResult.tsx
@@ -9,237 +9,182 @@ import DebuggingSuggestion from './DebuggingSuggestion';
 import { AnalysisResult } from '../types';
 import AnalysisResultDisplay from './AnalysisResultDisplay';
 import {
-  JsonIcon,
-  TableIcon,
-  ChevronDownIcon,
   GraphIcon,
   XIcon,
-  InfoIcon,
   AiSparkleIcon,
-  SpinnerIcon,
   PinIcon,
   DownloadIcon,
   BarChartIcon,
   EditIcon,
   UndoIcon,
   RedoIcon,
-  RestoreIcon
+  RestoreIcon,
+  ChevronDownIcon,
 } from './icons/material-icons-imports';
 
 interface QueryResultProps {
   isExecuting: boolean;
   executionError: string | null;
   executionResult: any | null;
-  // Props for debugging
   onDebug: () => void;
   isDebugging: boolean;
   debuggingResult: { suggestion: string } | null;
   debugError: string | null;
-  // Props for multi-step context queries
   sourceCollection: string | null;
   onSetIntermediateContext: (data: any, source: string) => void;
   intermediateContext: { data: any; source: string; } | null;
-  // Props for AI analysis
   onAnalyze: (dataToAnalyze: any) => void;
   isAnalyzing: boolean;
   analysisResult: AnalysisResult | null;
   analysisError: string | null;
-  // Props for write evaluation
   onEvaluateWrite?: () => void;
   isEvaluatingWrite?: boolean;
   writeEvaluationResult?: { evaluation: string } | null;
   writeEvaluationError?: string | null;
-  // Props for tutorial
   isTutorialActive?: boolean;
   tutorialStepIndex?: number;
 }
 
-// Helper to check if data can be displayed as a table/is analyzable
-const isTableCompatible = (data: any): data is Record<string, any>[] => {
-  return Array.isArray(data) && data.length > 0 && typeof data[0] === 'object' && data[0] !== null;
-};
+const isTableCompatible = (data: any): data is Record<string, any>[] =>
+  Array.isArray(data) && data.length > 0 && typeof data[0] === 'object' && data[0] !== null;
 
-// Helper to check if data can be used as query context (any non-empty array)
-const isContextCompatible = (data: any): boolean => {
-  return Array.isArray(data) && data.length > 0;
-};
+const isContextCompatible = (data: any): boolean =>
+  Array.isArray(data) && data.length > 0;
 
-// Helper to detect if the result is a summary of a write operation
 const isWriteSummary = (data: any): boolean => {
-  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
-    return false;
-  }
-  const keys = Object.keys(data);
-  const writeSummaryKeys = [
-    'acknowledged',
-    'matchedCount', 'matched_count',
-    'modifiedCount', 'modified_count',
-    'upsertedId', 'upserted_id',
-    'upsertedCount', 'upserted_count',
-    'deletedCount', 'deleted_count',
-    'insertedId', 'inserted_id',
-    'insertedCount',
-    'insertedIds',
-  ];
-
-  // If at least one of these keys is present, we'll consider it a write summary.
-  return keys.some(key => writeSummaryKeys.includes(key));
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) return false;
+  const writeSummaryKeys = ['acknowledged','matchedCount','matched_count','modifiedCount','modified_count','upsertedId','upserted_id','upsertedCount','upserted_count','deletedCount','deleted_count','insertedId','inserted_id','insertedCount','insertedIds'];
+  return Object.keys(data).some(k => writeSummaryKeys.includes(k));
 };
 
+// Segmented control tab
+const Tab: React.FC<{ label: string; active: boolean; disabled?: boolean; onClick: () => void }> = ({ label, active, disabled, onClick }) => (
+  <button
+    onClick={onClick}
+    disabled={disabled || active}
+    style={{
+      padding: '2px 10px', fontSize: 11.5, borderRadius: 4, border: 'none', cursor: disabled ? 'not-allowed' : active ? 'default' : 'pointer',
+      background: active ? 'var(--panel)' : 'transparent',
+      boxShadow: active ? '0 0 0 1px var(--border)' : 'none',
+      color: active ? 'var(--fg)' : disabled ? 'var(--border)' : 'var(--muted)',
+      fontWeight: active ? 500 : 400,
+      transition: 'color 0.15s, background 0.15s',
+      fontFamily: 'var(--font-body)',
+    }}
+  >
+    {label}
+  </button>
+);
 
-const QueryResult: React.FC<QueryResultProps> = ({ 
-    isExecuting, executionError, executionResult, 
-    onDebug, isDebugging, debuggingResult, debugError,
-    sourceCollection, onSetIntermediateContext, intermediateContext,
-    onAnalyze, isAnalyzing, analysisResult, analysisError,
-    onEvaluateWrite, isEvaluatingWrite, writeEvaluationResult, writeEvaluationError,
-    isTutorialActive, tutorialStepIndex
+// Icon button
+const IconBtn: React.FC<{ id?: string; title: string; disabled?: boolean; active?: boolean; onClick: () => void; children: React.ReactNode }> = ({ id, title, disabled, active, onClick, children }) => (
+  <button
+    id={id}
+    onClick={onClick}
+    disabled={disabled}
+    title={title}
+    style={{
+      width: 26, height: 26, display: 'flex', alignItems: 'center', justifyContent: 'center',
+      border: active ? '1px solid var(--accent)' : '1px solid var(--border)',
+      borderRadius: 6, cursor: disabled ? 'not-allowed' : 'pointer',
+      background: active ? 'var(--accent-soft)' : 'var(--soft)',
+      color: active ? 'var(--accent)' : disabled ? 'var(--border)' : 'var(--muted)',
+      transition: 'border-color 0.15s, background 0.15s, color 0.15s',
+    }}
+  >
+    {children}
+  </button>
+);
+
+const QueryResult: React.FC<QueryResultProps> = ({
+  isExecuting, executionError, executionResult,
+  onDebug, isDebugging, debuggingResult, debugError,
+  sourceCollection, onSetIntermediateContext, intermediateContext,
+  onAnalyze, isAnalyzing, analysisResult, analysisError,
+  onEvaluateWrite, isEvaluatingWrite, writeEvaluationResult, writeEvaluationError,
+  isTutorialActive, tutorialStepIndex,
 }) => {
   const [viewMode, setViewMode] = useState<'json' | 'table' | 'summary'>('json');
   const [isJsonCollapsed, setIsJsonCollapsed] = useState(false);
   const [isGraphVisible, setIsGraphVisible] = useState(false);
   const [isTableEditMode, setIsTableEditMode] = useState(false);
-  
-  // --- State for Table Column Editing ---
   const [columnHistory, setColumnHistory] = useState<string[][]>([]);
   const [historyIndex, setHistoryIndex] = useState<number>(0);
-  
-  // --- State for Download Menu ---
   const [isDownloadMenuOpen, setIsDownloadMenuOpen] = useState(false);
   const downloadButtonRef = useRef<HTMLDivElement>(null);
 
-
-  // Memoize checks on the execution result
   const isWriteOpSummary = useMemo(() => isWriteSummary(executionResult), [executionResult]);
   const canBeTable = useMemo(() => isTableCompatible(executionResult), [executionResult]);
   const canBeContext = useMemo(() => isContextCompatible(executionResult), [executionResult]);
   const isAnalyzable = useMemo(() => isTableCompatible(executionResult), [executionResult]);
-  
+
   const allTableHeaders = useMemo(() => {
     if (!canBeTable) return [];
     const keySet = new Set<string>();
     (executionResult as Record<string, any>[]).forEach(row => {
-        if (typeof row === 'object' && row !== null) {
-            Object.keys(row).forEach(key => keySet.add(key));
-        }
+      if (typeof row === 'object' && row !== null) Object.keys(row).forEach(k => keySet.add(k));
     });
     return Array.from(keySet);
   }, [executionResult, canBeTable]);
 
   const visibleHeaders = useMemo(() => columnHistory[historyIndex] || [], [columnHistory, historyIndex]);
 
-  // Reset history whenever a new, table-compatible result comes in
   useEffect(() => {
-    if (canBeTable) {
-      setColumnHistory([allTableHeaders]);
-      setHistoryIndex(0);
-    }
-  }, [allTableHeaders, canBeTable]); // Depends on allTableHeaders to rerun when data changes
+    if (canBeTable) { setColumnHistory([allTableHeaders]); setHistoryIndex(0); }
+  }, [allTableHeaders, canBeTable]);
 
-  // Create a version of the execution result that is filtered based on table edits.
   const processedDataForActions = useMemo(() => {
-    if (!isTableCompatible(executionResult) || visibleHeaders.length === 0) {
-        return executionResult;
-    }
+    if (!isTableCompatible(executionResult) || visibleHeaders.length === 0) return executionResult;
     return executionResult.map(row => {
-        const newRow: Record<string, any> = {};
-        for (const header of visibleHeaders) {
-            if (Object.prototype.hasOwnProperty.call(row, header)) {
-                newRow[header] = row[header];
-            }
-        }
-        return newRow;
+      const newRow: Record<string, any> = {};
+      for (const h of visibleHeaders) { if (Object.prototype.hasOwnProperty.call(row, h)) newRow[h] = row[h]; }
+      return newRow;
     });
   }, [executionResult, visibleHeaders]);
-  
-  const isCurrentResultInContext = useMemo(() => {
-    return intermediateContext?.data === executionResult;
-  }, [intermediateContext, executionResult]);
-  
+
+  const isCurrentResultInContext = useMemo(() => intermediateContext?.data === executionResult, [intermediateContext, executionResult]);
+
   useEffect(() => {
-    if (isWriteOpSummary) {
-      setViewMode('summary');
-    } else {
-      setViewMode('json');
-    }
-    setIsJsonCollapsed(false);
-    setIsGraphVisible(false);
-    setIsTableEditMode(false);
+    if (isWriteOpSummary) setViewMode('summary'); else setViewMode('json');
+    setIsJsonCollapsed(false); setIsGraphVisible(false); setIsTableEditMode(false);
   }, [executionResult, isWriteOpSummary]);
 
-  // Effect to control view mode during tutorial
   useEffect(() => {
     if (isTutorialActive) {
-        // Step 10 "View Your Results" (index 9) introduces the table.
-        // Step 11 "Customize Your Table" (index 10) MUST show the table for its target element to be visible.
-        if (tutorialStepIndex === 9 || tutorialStepIndex === 10) {
-            setViewMode('table');
-        } else {
-            setViewMode('json');
-        }
+      if (tutorialStepIndex === 9 || tutorialStepIndex === 10) setViewMode('table');
+      else setViewMode('json');
     }
   }, [isTutorialActive, tutorialStepIndex]);
 
-  // Effect to handle closing the download context menu from outside clicks or Esc key.
   useEffect(() => {
     if (!isDownloadMenuOpen) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-        if (event.key === 'Escape') {
-            setIsDownloadMenuOpen(false);
-        }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setIsDownloadMenuOpen(false); };
+    const onClickOutside = (e: MouseEvent) => {
+      if (downloadButtonRef.current && !downloadButtonRef.current.contains(e.target as Node)) setIsDownloadMenuOpen(false);
     };
-
-    const handleClickOutside = (event: MouseEvent) => {
-        if (downloadButtonRef.current && !downloadButtonRef.current.contains(event.target as Node)) {
-            setIsDownloadMenuOpen(false);
-        }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-        document.removeEventListener('mousedown', handleClickOutside);
-        document.removeEventListener('keydown', handleKeyDown);
-    };
+    document.addEventListener('mousedown', onClickOutside);
+    document.addEventListener('keydown', onKey);
+    return () => { document.removeEventListener('mousedown', onClickOutside); document.removeEventListener('keydown', onKey); };
   }, [isDownloadMenuOpen]);
 
-
-  // --- Handlers for Table Editing ---
   const updateHistory = (newHeaders: string[]) => {
-      const newHistory = columnHistory.slice(0, historyIndex + 1);
-      newHistory.push(newHeaders);
-      setColumnHistory(newHistory);
-      setHistoryIndex(newHistory.length - 1);
+    const newHistory = columnHistory.slice(0, historyIndex + 1);
+    newHistory.push(newHeaders);
+    setColumnHistory(newHistory);
+    setHistoryIndex(newHistory.length - 1);
   };
-  
-  const handleDeleteColumn = (headerToDelete: string) => {
-      const newHeaders = visibleHeaders.filter(h => h !== headerToDelete);
-      updateHistory(newHeaders);
-  };
-  
-  const handleResetColumns = () => {
-      updateHistory(allTableHeaders);
-  };
-
-  const handleUndo = () => {
-    if (historyIndex > 0) setHistoryIndex(prev => prev - 1);
-  };
-  
-  const handleRedo = () => {
-    if (historyIndex < columnHistory.length - 1) setHistoryIndex(prev => prev + 1);
-  };
+  const handleDeleteColumn = (h: string) => updateHistory(visibleHeaders.filter(v => v !== h));
+  const handleResetColumns = () => updateHistory(allTableHeaders);
+  const handleUndo = () => { if (historyIndex > 0) setHistoryIndex(p => p - 1); };
+  const handleRedo = () => { if (historyIndex < columnHistory.length - 1) setHistoryIndex(p => p + 1); };
 
   const handleSetContextClick = () => {
     if (executionResult) {
-      // The source collection could be null if the query was DB-wide.
-      // We create a descriptive source name for the UI.
-      const sourceName = sourceCollection ? `'${sourceCollection}' collection` : 'the previous query';
-      onSetIntermediateContext(processedDataForActions, sourceName);
+      const src = sourceCollection ? `'${sourceCollection}' collection` : 'the previous query';
+      onSetIntermediateContext(processedDataForActions, src);
     }
   };
-  
+
   const handleAnalyzeClick = () => {
     if (!isAnalyzable || isAnalyzing || !!analysisResult) return;
     onAnalyze(processedDataForActions);
@@ -247,248 +192,244 @@ const QueryResult: React.FC<QueryResultProps> = ({
 
   const handleDownloadCSV = useCallback((separator: ',' | ';') => {
     if (!canBeTable) return;
-
-    // Special case for single-line semicolon export for email lists
     if (separator === ';') {
-        const firstHeader = visibleHeaders[0];
-        if (!firstHeader) {
-            console.error("No visible columns to export for single-line format.");
-            return;
-        }
-        
-        const dataToExport = processedDataForActions as Record<string, any>[];
-        const singleLineData = dataToExport
-            .map(row => row[firstHeader])
-            .filter(value => value !== null && value !== undefined && String(value).trim() !== '')
-            .join(';');
-
-        const blob = new Blob([singleLineData], { type: 'text/plain;charset=utf-8;' });
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(blob);
-        link.download = `query_export_${new Date().toISOString().split('T')[0]}.txt`;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        URL.revokeObjectURL(link.href);
-        setIsDownloadMenuOpen(false);
-        return; 
+      const firstHeader = visibleHeaders[0];
+      if (!firstHeader) return;
+      const data = (processedDataForActions as Record<string, any>[]).map(r => r[firstHeader]).filter(v => v !== null && v !== undefined && String(v).trim() !== '').join(';');
+      const blob = new Blob([data], { type: 'text/plain;charset=utf-8;' });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = `query_export_${new Date().toISOString().split('T')[0]}.txt`;
+      document.body.appendChild(link); link.click(); document.body.removeChild(link);
+      URL.revokeObjectURL(link.href); setIsDownloadMenuOpen(false); return;
     }
-    
-    // Original logic for standard CSV export
-    const headers = visibleHeaders;
     const escapeCell = (cell: any): string => {
-        if (cell === null || cell === undefined) return '';
-        const str = (typeof cell === 'object') ? JSON.stringify(cell) : String(cell);
-        const needsQuotes = str.includes(separator) || str.includes('"') || str.includes('\n');
-
-        if (needsQuotes) {
-            const escapedStr = str.replace(/"/g, '""');
-            return `"${escapedStr}"`;
-        }
-        return str;
+      if (cell === null || cell === undefined) return '';
+      const str = typeof cell === 'object' ? JSON.stringify(cell) : String(cell);
+      return (str.includes(separator) || str.includes('"') || str.includes('\n')) ? `"${str.replace(/"/g, '""')}"` : str;
     };
-    
-    const csvRows = [headers.map(h => escapeCell(h)).join(separator)];
-    const dataToExport = processedDataForActions as Record<string, any>[];
-    for (const row of dataToExport) {
-        const values = headers.map(header => escapeCell(row[header]));
-        csvRows.push(values.join(separator));
-    }
-
-    const csvString = csvRows.join('\n');
-    const blob = new Blob([`\uFEFF${csvString}`], { type: 'text/csv;charset=utf-8;' });
+    const csvRows = [visibleHeaders.map(h => escapeCell(h)).join(separator)];
+    for (const row of processedDataForActions as Record<string, any>[]) csvRows.push(visibleHeaders.map(h => escapeCell(row[h])).join(separator));
+    const blob = new Blob([`﻿${csvRows.join('\n')}`], { type: 'text/csv;charset=utf-8;' });
     const link = document.createElement('a');
-    
     link.href = URL.createObjectURL(blob);
     link.download = `query_result_${new Date().toISOString().split('T')[0]}.csv`;
-    
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(link.href);
-
-    setIsDownloadMenuOpen(false);
+    document.body.appendChild(link); link.click(); document.body.removeChild(link);
+    URL.revokeObjectURL(link.href); setIsDownloadMenuOpen(false);
   }, [canBeTable, visibleHeaders, processedDataForActions]);
 
+  // --- Render: executing ---
   if (isExecuting) {
     return (
-        <div className="flex justify-center items-center p-8">
-            <SpinnerIcon className="h-8 w-8 text-blue-500" />
-            <span className="text-slate-600 dark:text-slate-400 text-lg ml-3">Running query...</span>
-        </div>
+      <div className="qa-card" style={{ padding: '24px 14px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 10, color: 'var(--muted)', fontSize: 13 }}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ animation: 'spin 1s linear infinite' }}>
+          <path d="M21 12a9 9 0 1 1-6.219-8.56" strokeLinecap="round" />
+        </svg>
+        Running query…
+        <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+      </div>
     );
   }
 
+  // --- Render: error ---
   if (executionError) {
     return (
-      <div className="space-y-4 animate-fade-in">
-        <div className="bg-red-100 border border-red-400 text-red-700 dark:bg-red-900/50 dark:border-red-500/50 dark:text-red-300 px-4 py-3 rounded-lg" role="alert">
-          <strong className="font-bold">Execution Error: </strong>
-          <span className="block sm:inline">{executionError}</span>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, animation: 'fadeIn 0.2s' }}>
+        <div className="qa-card" style={{ padding: '10px 14px', background: 'color-mix(in oklch, #c94250 8%, var(--bg))', border: '1px solid color-mix(in oklch, #c94250 22%, var(--border))' }}>
+          <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em', color: '#c94250', marginBottom: 4 }}>Execution error</div>
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: '#c94250', lineHeight: 1.5 }}>{executionError}</div>
         </div>
-
-        <div className="flex flex-col items-start gap-4">
-            <button
-                onClick={onDebug}
-                disabled={isDebugging}
-                className="flex items-center gap-2 px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-gradient-to-r from-blue-500 to-violet-500 hover:from-blue-600 hover:to-violet-600 disabled:from-slate-400 disabled:to-slate-500 disabled:bg-gradient-to-r disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-slate-800 focus:ring-violet-500 transition-all duration-200 transform hover:scale-[1.03] active:scale-[1]"
-                title="Ask the AI to analyze the error and suggest a fix"
-            >
-                <AiSparkleIcon className="w-5 h-5" />
-                {isDebugging ? 'Debugging with AI...' : 'Debug with AI'}
-            </button>
-            {isDebugging && <div className="text-slate-500 dark:text-slate-400 flex items-center gap-2"><SpinnerIcon className="h-5 w-5 text-blue-500" /><span>The AI is analyzing your query...</span></div>}
-            {debugError && <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg w-full" role="alert"><strong className="font-bold">Debugging Error: </strong><span className="block sm:inline">{debugError}</span></div>}
-            {debuggingResult && <div className="w-full"><DebuggingSuggestion suggestion={debuggingResult.suggestion} /></div>}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <button
+            onClick={onDebug}
+            disabled={isDebugging}
+            className="qa-btn primary"
+            style={{ alignSelf: 'flex-start', display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}
+          >
+            <AiSparkleIcon className="w-4 h-4" />
+            {isDebugging ? 'Debugging…' : 'Debug with AI'}
+          </button>
+          {isDebugging && (
+            <div style={{ fontSize: 12, color: 'var(--muted)', display: 'flex', alignItems: 'center', gap: 6 }}>
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ animation: 'spin 1s linear infinite' }}>
+                <path d="M21 12a9 9 0 1 1-6.219-8.56" strokeLinecap="round" />
+              </svg>
+              Analyzing error…
+            </div>
+          )}
+          {debugError && (
+            <div style={{ fontSize: 12, color: '#c94250' }}>Debugging failed: {debugError}</div>
+          )}
+          {debuggingResult && <DebuggingSuggestion suggestion={debuggingResult.suggestion} />}
         </div>
       </div>
     );
   }
-  
+
+  // --- Render: result ---
   if (executionResult) {
-      const graphDrawer = isGraphVisible ? createPortal(
-        <>
-          <div onClick={() => setIsGraphVisible(false)} className="fixed inset-0 bg-black bg-opacity-60 z-40 animate-fade-in-fast" aria-hidden="true"></div>
-          <aside className="fixed top-0 right-0 h-full w-full md:w-3/4 lg:w-2/3 bg-slate-900 shadow-2xl z-50 flex flex-col animate-slide-in-drawer">
-            <header className="flex items-center justify-between p-4 border-b border-slate-700 flex-shrink-0">
-              <h3 className="text-lg font-semibold text-white flex items-center gap-3"><GraphIcon className="w-5 h-5 text-blue-400" />Interactive Graph View</h3>
-              <button onClick={() => setIsGraphVisible(false)} className="p-1.5 rounded-full text-slate-400 hover:bg-slate-700 hover:text-white transition-colors" aria-label="Close graph view" title="Close graph view"><XIcon className="w-5 h-5" /></button>
-            </header>
-            <div className="flex-grow overflow-hidden p-1"><JsonCrackViewer data={executionResult} /></div>
-          </aside>
-        </>,
-        document.body
-      ) : null;
+    const docCount = Array.isArray(executionResult) ? executionResult.length : 1;
 
-      const renderTableActionsToolbar = () => {
-        if (viewMode !== 'table' || !canBeTable) return null;
+    const graphDrawer = isGraphVisible ? createPortal(
+      <>
+        <div onClick={() => setIsGraphVisible(false)} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', zIndex: 40 }} />
+        <aside style={{ position: 'fixed', top: 0, right: 0, height: '100%', width: '75%', maxWidth: 900, background: 'var(--panel)', borderLeft: '1px solid var(--border)', zIndex: 50, display: 'flex', flexDirection: 'column', animation: 'slideInRight 0.35s cubic-bezier(0.16,1,0.3,1)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 16px', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
+            <span style={{ fontSize: 14, fontWeight: 500 }}>Graph View</span>
+            <button onClick={() => setIsGraphVisible(false)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex' }}>
+              <XIcon className="w-4 h-4" />
+            </button>
+          </div>
+          <div style={{ flex: 1, overflow: 'hidden', padding: 4 }}><JsonCrackViewer data={executionResult} /></div>
+        </aside>
+      </>,
+      document.body
+    ) : null;
 
-        return (
-            <div id="tutorial-table-actions" className="flex items-center justify-between bg-slate-100 dark:bg-slate-800 p-2 rounded-lg border border-slate-200 dark:border-slate-700">
-                {isTableEditMode ? (
-                     <div className="flex items-center gap-2">
-                        <button onClick={handleUndo} disabled={historyIndex <= 0} className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 disabled:opacity-50 disabled:cursor-not-allowed" title="Undo last column change"><UndoIcon className="w-4 h-4"/>Undo</button>
-                        <button onClick={handleRedo} disabled={historyIndex >= columnHistory.length - 1} className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 disabled:opacity-50 disabled:cursor-not-allowed" title="Redo last column change"><RedoIcon className="w-4 h-4"/>Redo</button>
-                        <button onClick={handleResetColumns} className="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600" title="Restore all original columns"><RestoreIcon className="w-4 h-4"/>Reset Columns</button>
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, animation: 'fadeIn 0.2s' }}>
+        <div className="qa-card" style={{ padding: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          {/* Card header */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '9px 14px', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
+            <span style={{ fontSize: 13, fontWeight: 500 }}>Results</span>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10.5, background: 'var(--soft)', color: 'var(--muted)', padding: '2px 8px', borderRadius: 4 }}>
+              {docCount} {docCount === 1 ? 'doc' : 'docs'}
+            </span>
+
+            {/* Segmented view switcher */}
+            <div id="tutorial-view-switcher" style={{ marginLeft: 'auto', display: 'flex', gap: 2, background: 'var(--soft)', padding: 2, borderRadius: 6 }}>
+              {isWriteOpSummary && <Tab label="Summary" active={viewMode === 'summary'} disabled={isTableEditMode} onClick={() => setViewMode('summary')} />}
+              <Tab label="JSON" active={viewMode === 'json'} disabled={isTableEditMode} onClick={() => setViewMode('json')} />
+              <Tab label="Table" active={viewMode === 'table'} disabled={!canBeTable || isTableEditMode} onClick={() => setViewMode('table')} />
+            </div>
+
+            {/* Icon actions */}
+            <div style={{ display: 'flex', gap: 5 }}>
+              <IconBtn title="Graph view" disabled={isTableEditMode} onClick={() => setIsGraphVisible(true)}>
+                <GraphIcon className="w-3 h-3" />
+              </IconBtn>
+              <IconBtn id="tutorial-analyze-button" title={isAnalyzing ? 'Analyzing…' : analysisResult ? 'Analyzed' : 'Analyze with AI'} disabled={!isAnalyzable || isAnalyzing || !!analysisResult || isTableEditMode} active={!!analysisResult} onClick={handleAnalyzeClick}>
+                <BarChartIcon className="w-3 h-3" />
+              </IconBtn>
+              <IconBtn title={isCurrentResultInContext ? 'Context set' : 'Use as context'} disabled={!canBeContext || isTableEditMode} active={isCurrentResultInContext} onClick={handleSetContextClick}>
+                <PinIcon className="w-3 h-3" />
+              </IconBtn>
+              {viewMode === 'json' && (
+                <IconBtn title={isJsonCollapsed ? 'Expand' : 'Collapse'} onClick={() => setIsJsonCollapsed(!isJsonCollapsed)}>
+                  <ChevronDownIcon className="w-3 h-3" style={{ transform: isJsonCollapsed ? 'none' : 'rotate(180deg)', transition: 'transform 0.2s' }} />
+                </IconBtn>
+              )}
+              {isWriteOpSummary && onEvaluateWrite && (
+                <IconBtn title={isEvaluatingWrite ? 'Evaluating…' : writeEvaluationResult ? 'Evaluated' : 'Evaluate with AI'} disabled={isEvaluatingWrite || !!writeEvaluationResult || isTableEditMode} active={!!writeEvaluationResult} onClick={onEvaluateWrite}>
+                  <AiSparkleIcon className="w-3 h-3" />
+                </IconBtn>
+              )}
+            </div>
+          </div>
+
+          {/* Table actions toolbar */}
+          {viewMode === 'table' && canBeTable && (
+            <div id="tutorial-table-actions" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '7px 14px', borderBottom: '1px solid var(--border)', background: 'var(--soft)', flexShrink: 0 }}>
+              {isTableEditMode ? (
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <button onClick={handleUndo} disabled={historyIndex <= 0} className="qa-btn" style={{ fontSize: 11, display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <UndoIcon className="w-3 h-3" /> Undo
+                  </button>
+                  <button onClick={handleRedo} disabled={historyIndex >= columnHistory.length - 1} className="qa-btn" style={{ fontSize: 11, display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <RedoIcon className="w-3 h-3" /> Redo
+                  </button>
+                  <button onClick={handleResetColumns} className="qa-btn" style={{ fontSize: 11, display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <RestoreIcon className="w-3 h-3" /> Reset
+                  </button>
+                </div>
+              ) : (
+                <div ref={downloadButtonRef} style={{ position: 'relative', display: 'inline-flex' }}>
+                  <button
+                    onClick={() => handleDownloadCSV(',')}
+                    className="qa-btn"
+                    style={{ fontSize: 11, borderRadius: '4px 0 0 4px', display: 'flex', alignItems: 'center', gap: 4 }}
+                    disabled={isTableEditMode}
+                    title="Download CSV"
+                  >
+                    <DownloadIcon className="w-3 h-3" /> CSV
+                  </button>
+                  <button
+                    onClick={() => setIsDownloadMenuOpen(!isDownloadMenuOpen)}
+                    className="qa-btn"
+                    style={{ fontSize: 11, borderRadius: '0 4px 4px 0', borderLeft: '1px solid var(--border)', padding: '4px 6px' }}
+                    disabled={isTableEditMode}
+                    title="More export options"
+                  >
+                    <ChevronDownIcon className="w-3 h-3" />
+                  </button>
+                  {isDownloadMenuOpen && (
+                    <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', zIndex: 20, minWidth: 200, boxShadow: '0 4px 16px rgba(0,0,0,0.1)' }}>
+                      <button onClick={() => handleDownloadCSV(',')} style={{ width: '100%', textAlign: 'left', padding: '8px 12px', fontSize: 12, color: 'var(--fg)', background: 'none', border: 'none', cursor: 'pointer' }}>CSV (comma-separated)</button>
+                      <button onClick={() => handleDownloadCSV(';')} style={{ width: '100%', textAlign: 'left', padding: '8px 12px', fontSize: 12, color: 'var(--fg)', background: 'none', border: 'none', cursor: 'pointer' }}>TXT (semicolon-separated)</button>
                     </div>
-                ) : (
-                   <div ref={downloadButtonRef} className="relative inline-flex rounded-md shadow-sm">
-                        <button
-                            type="button"
-                            onClick={() => handleDownloadCSV(',')}
-                            className="relative inline-flex items-center gap-2 px-3 py-1.5 rounded-l-md text-sm font-medium transition-colors border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-600 disabled:opacity-50 disabled:cursor-not-allowed focus:z-10 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-                            title="Download as CSV (comma-separated)"
-                            disabled={isTableEditMode}
-                        >
-                            <DownloadIcon className="w-4 h-4" />
-                            <span>Download CSV</span>
-                        </button>
-                        <button
-                            type="button"
-                            onClick={() => setIsDownloadMenuOpen(!isDownloadMenuOpen)}
-                            className="-ml-px relative inline-flex items-center px-2 py-1.5 rounded-r-md text-sm font-medium transition-colors border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-600 disabled:opacity-50 disabled:cursor-not-allowed focus:z-10 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-                            title="More download options"
-                            disabled={isTableEditMode}
-                        >
-                           <ChevronDownIcon className="w-4 h-4" />
-                        </button>
+                  )}
+                </div>
+              )}
+              <button
+                onClick={() => setIsTableEditMode(!isTableEditMode)}
+                className="qa-btn"
+                style={{ fontSize: 11, display: 'flex', alignItems: 'center', gap: 4, ...(isTableEditMode ? { background: 'var(--accent)', color: 'white', border: '1px solid transparent' } : {}) }}
+                title={isTableEditMode ? 'Done editing' : 'Edit columns'}
+              >
+                <EditIcon className="w-3 h-3" />
+                {isTableEditMode ? 'Done' : 'Edit'}
+              </button>
+            </div>
+          )}
 
-                        {isDownloadMenuOpen && (
-                             <div className="origin-top-left absolute left-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-slate-800 ring-1 ring-black ring-opacity-5 dark:ring-slate-600 focus:outline-none z-20">
-                                <div className="py-1" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
-                                    <button onClick={() => handleDownloadCSV(',')} className="w-full text-left flex items-center gap-2 px-4 py-2 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700" role="menuitem">
-                                        CSV (Comma-separated)
-                                    </button>
-                                    <button onClick={() => handleDownloadCSV(';')} className="w-full text-left flex items-center gap-2 px-4 py-2 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700" role="menuitem">
-                                        TXT (Semicolon-separated)
-                                    </button>
-                                </div>
-                            </div>
-                        )}
-                    </div>
+          {/* Content */}
+          <div style={{ padding: viewMode === 'table' ? 0 : '10px 14px', overflow: 'auto', maxHeight: 420 }}>
+            {viewMode === 'summary' && (
+              <div style={{ padding: '10px 14px' }}>
+                <WriteSummaryDisplay data={executionResult} />
+                {isEvaluatingWrite && (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10, fontSize: 12, color: 'var(--muted)' }}>
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ animation: 'spin 1s linear infinite' }}><path d="M21 12a9 9 0 1 1-6.219-8.56" strokeLinecap="round" /></svg>
+                    AI evaluating…
+                  </div>
                 )}
-                
-                <button onClick={() => setIsTableEditMode(!isTableEditMode)} className={`flex items-center gap-2 px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${isTableEditMode ? 'bg-blue-600 text-white hover:bg-blue-700' : 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-300 dark:border-slate-600'}`} title={isTableEditMode ? 'Finish editing columns' : 'Edit table columns'}>
-                    <EditIcon className="w-4 h-4" />
-                    {isTableEditMode ? 'Exit Edit Mode' : 'Edit Table'}
-                </button>
-            </div>
-        );
-      };
-
-      return (
-        <div className="space-y-4 animate-fade-in">
-            <h3 className="text-sm font-semibold text-slate-600 dark:text-slate-400 uppercase tracking-wider">Query Result</h3>
-            
-            <div id="tutorial-view-switcher" className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between bg-slate-100 dark:bg-slate-800 p-2 rounded-lg border border-slate-200 dark:border-slate-700">
-                <div className="flex items-center gap-1 flex-wrap">
-                    {isWriteOpSummary && (
-                       <>
-                         <button onClick={() => setViewMode('summary')} disabled={viewMode === 'summary' || isTableEditMode} className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors disabled:cursor-not-allowed ${viewMode === 'summary' ? 'bg-blue-500 text-white shadow' : 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 disabled:opacity-50'}`} title="View a summary of the write operation"><InfoIcon className="w-4 h-4" />Summary</button>
-                         {onEvaluateWrite && (
-                           <button onClick={onEvaluateWrite} disabled={isEvaluatingWrite || !!writeEvaluationResult || isTableEditMode} className="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-600 disabled:opacity-50 disabled:cursor-not-allowed" title="Evaluate write result with AI">
-                             <AiSparkleIcon className="w-4 h-4" />
-                             <span>{isEvaluatingWrite ? 'Evaluating...' : (writeEvaluationResult ? 'Evaluated' : 'Evaluate with AI')}</span>
-                           </button>
-                         )}
-                       </>
-                    )}
-                    <button onClick={() => setViewMode('json')} disabled={viewMode === 'json' || isTableEditMode} className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors disabled:cursor-not-allowed ${viewMode === 'json' ? 'bg-blue-500 text-white shadow' : 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 disabled:opacity-50'}`} title="View the raw JSON output"><JsonIcon className="w-4 h-4" />JSON</button>
-                    <button onClick={() => setViewMode('table')} disabled={!canBeTable || viewMode === 'table' || isTableEditMode} className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors disabled:cursor-not-allowed ${viewMode === 'table' ? 'bg-blue-500 text-white shadow' : 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 disabled:opacity-50'}`} title="View the results in a sortable table"><TableIcon className="w-4 h-4" />Table</button>
-                    <button onClick={() => setIsGraphVisible(true)} disabled={isTableEditMode} className={'flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 disabled:opacity-50 disabled:cursor-not-allowed'} title="View results in an interactive graph"><GraphIcon className="w-4 h-4" />Graph</button>
-                </div>
-
-                <div className="flex items-center gap-2 flex-wrap justify-end">
-                     <button id="tutorial-analyze-button" onClick={handleAnalyzeClick} disabled={!isAnalyzable || isAnalyzing || !!analysisResult || isTableEditMode} className="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-600 disabled:opacity-50 disabled:cursor-not-allowed" title="Analyze result with AI"><BarChartIcon className="w-4 h-4" /><span>{isAnalyzing ? 'Analyzing...' : (analysisResult ? 'Analyzed' : 'Analyze')}</span></button>
-                    <button onClick={handleSetContextClick} disabled={!canBeContext || isCurrentResultInContext || isTableEditMode} className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors border ${isCurrentResultInContext ? 'border-blue-500 bg-blue-500 text-white shadow' : 'border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-600'} disabled:opacity-50 disabled:cursor-not-allowed`} title="Use this result as context for the next query"><PinIcon className="w-4 h-4" /><span>{isCurrentResultInContext ? 'Context Set' : 'Use as Context'}</span></button>
-                    {viewMode === 'json' && (<button onClick={() => setIsJsonCollapsed(!isJsonCollapsed)} className="flex items-center gap-1 text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white p-1.5 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700" title={isJsonCollapsed ? 'Expand JSON view' : 'Collapse JSON view'}><ChevronDownIcon className={`w-4 h-4 transition-transform duration-200 ${!isJsonCollapsed && 'rotate-180'}`} /></button>)}
-                </div>
-            </div>
-
-            {/* Content Display */}
-            <div className="space-y-6">
-                {renderTableActionsToolbar()}
-
-                <div>
-                    {viewMode === 'summary' && (
-                      <div className="space-y-4">
-                        <WriteSummaryDisplay data={executionResult} />
-                        {isEvaluatingWrite && <div className="flex justify-center items-center p-4"><SpinnerIcon className="h-6 w-6 text-blue-500" /><span className="text-slate-600 dark:text-slate-400 text-sm ml-3">AI is evaluating the result...</span></div>}
-                        {writeEvaluationError && <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg"><strong className="font-bold">Evaluation Error: </strong><span>{writeEvaluationError}</span></div>}
-                        {writeEvaluationResult && (
-                          <div className="bg-blue-50/50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 p-4 rounded-lg">
-                            <h4 className="flex items-center gap-2 text-blue-800 dark:text-blue-300 font-semibold mb-2"><AiSparkleIcon className="w-5 h-5"/> AI Evaluation</h4>
-                            <p className="text-slate-700 dark:text-slate-300">{writeEvaluationResult.evaluation}</p>
-                          </div>
-                        )}
-                      </div>
-                    )}
-                    {viewMode === 'json' && !isJsonCollapsed && <JsonDisplay data={executionResult} />}
-                    {viewMode === 'table' && canBeTable && (
-                      <Table 
-                        data={executionResult} 
-                        isEditMode={isTableEditMode}
-                        visibleHeaders={visibleHeaders}
-                        onDeleteColumn={handleDeleteColumn}
-                      />
-                    )}
-                </div>
-                
-                {isAnalyzing && <div className="flex justify-center items-center p-8"><SpinnerIcon className="h-8 w-8 text-blue-500" /><span className="text-slate-600 dark:text-slate-400 text-lg ml-3">AI is analyzing the data...</span></div>}
-                {analysisError && <div className="bg-red-100 border border-red-400 text-red-700 dark:bg-red-900/50 dark:border-red-500/50 dark:text-red-300 px-4 py-3 rounded-lg animate-fade-in" role="alert"><strong className="font-bold">Analysis Error: </strong><span className="block sm:inline">{analysisError}</span></div>}
-                {analysisResult && <AnalysisResultDisplay result={analysisResult} />}
-            </div>
-
-            {graphDrawer}
-
-            <style>{`
-              @keyframes fade-in-fast { from { opacity: 0; } to { opacity: 1; } }
-              .animate-fade-in-fast { animation: fade-in-fast 0.3s ease-out forwards; }
-              @keyframes slide-in-drawer { from { transform: translateX(100%); } to { transform: translateX(0); } }
-              .animate-slide-in-drawer { animation: slide-in-drawer 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
-            `}</style>
+                {writeEvaluationError && <div style={{ marginTop: 10, fontSize: 12, color: '#c94250' }}>{writeEvaluationError}</div>}
+                {writeEvaluationResult && (
+                  <div style={{ marginTop: 10, padding: '10px 12px', background: 'var(--accent-soft)', border: '1px solid color-mix(in oklch, var(--accent) 20%, var(--border))', borderRadius: 'var(--radius-sm)' }}>
+                    <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--accent)', marginBottom: 4 }}>AI Evaluation</div>
+                    <div style={{ fontSize: 12.5, color: 'var(--fg)', lineHeight: 1.5 }}>{writeEvaluationResult.evaluation}</div>
+                  </div>
+                )}
+              </div>
+            )}
+            {viewMode === 'json' && !isJsonCollapsed && <JsonDisplay data={executionResult} />}
+            {viewMode === 'table' && canBeTable && (
+              <Table data={executionResult} isEditMode={isTableEditMode} visibleHeaders={visibleHeaders} onDeleteColumn={handleDeleteColumn} />
+            )}
+          </div>
         </div>
-      );
+
+        {/* Analysis */}
+        {isAnalyzing && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0', fontSize: 12, color: 'var(--muted)' }}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ animation: 'spin 1s linear infinite' }}><path d="M21 12a9 9 0 1 1-6.219-8.56" strokeLinecap="round" /></svg>
+            AI analyzing data…
+          </div>
+        )}
+        {analysisError && (
+          <div style={{ fontSize: 12, color: '#c94250', padding: '8px 0' }}>Analysis error: {analysisError}</div>
+        )}
+        {analysisResult && <AnalysisResultDisplay result={analysisResult} />}
+
+        {graphDrawer}
+
+        <style>{`
+          @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+          @keyframes spin { to { transform: rotate(360deg); } }
+          @keyframes slideInRight { from { transform: translateX(100%); } to { transform: translateX(0); } }
+        `}</style>
+      </div>
+    );
   }
 
   return null;

--- a/frontend/components/SaveConflictDialog.tsx
+++ b/frontend/components/SaveConflictDialog.tsx
@@ -1,70 +1,98 @@
 import React from 'react';
 import ReactDiffViewer from 'react-diff-viewer-continued';
 import { useTheme } from '../contexts/ThemeContext';
-import { WarningIcon } from './icons/material-icons-imports';
 
 interface SaveConflictDialogProps {
   open: boolean;
-  serverValue: string; // The newly fetched data from server
-  localValue: string; // The user's current edited value
+  serverValue: string;
+  localValue: string;
   onClose: () => void;
   onOverwrite: () => void;
 }
 
 const SaveConflictDialog: React.FC<SaveConflictDialogProps> = ({ open, serverValue, localValue, onClose, onOverwrite }) => {
   const { theme } = useTheme();
-  
+
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 dark:bg-black/70 backdrop-blur-sm animate-fade-in-fast">
-      <div className="bg-white dark:bg-slate-800 rounded-lg shadow-2xl max-w-5xl w-[90vw] flex flex-col overflow-hidden border border-slate-200 dark:border-slate-700 max-h-[90vh]">
-        <header className="px-6 py-4 border-b border-slate-200 dark:border-slate-700 bg-red-50 dark:bg-red-900/20 flex flex-col gap-1 flex-shrink-0">
-          <h2 className="text-xl font-bold text-red-600 dark:text-red-500 flex items-center gap-2">
-            <WarningIcon className="w-6 h-6" /> Save Conflict Detected
-          </h2>
-          <p className="text-sm text-slate-700 dark:text-slate-300 ml-8">
-            The document on the server has been modified since you started editing. 
-            If you save now, you will overwrite the server's changes with your own.
+    <div style={{
+      position: 'fixed', inset: 0, zIndex: 60,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      background: 'rgba(0,0,0,0.35)', backdropFilter: 'blur(2px)',
+    }}>
+      <div style={{
+        background: 'var(--panel)', borderRadius: 12, boxShadow: '0 8px 40px rgba(0,0,0,0.18)',
+        width: '90vw', maxWidth: 1000, maxHeight: '90vh',
+        display: 'flex', flexDirection: 'column', overflow: 'hidden',
+        border: '1px solid var(--border)',
+      }}>
+        {/* Header */}
+        <div style={{
+          padding: '14px 20px', borderBottom: '1px solid var(--border)',
+          background: 'color-mix(in oklch, var(--status-err) 8%, var(--panel))',
+          display: 'flex', flexDirection: 'column', gap: 4, flexShrink: 0,
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <svg width="17" height="17" viewBox="0 0 16 16" fill="none" stroke="var(--status-err)" strokeWidth="1.5">
+              <path d="M8 1L15 14H1L8 1z"/><path d="M8 6v4M8 11.5v.5"/>
+            </svg>
+            <span style={{ fontSize: 15, fontWeight: 700, color: 'var(--status-err)', fontFamily: 'var(--font-body)' }}>
+              Save Conflict Detected
+            </span>
+          </div>
+          <p style={{ fontSize: 12.5, color: 'var(--muted)', fontFamily: 'var(--font-body)', margin: 0, paddingLeft: 25 }}>
+            The document on the server has been modified since you started editing.
+            Saving now will overwrite the server's changes with your own.
           </p>
-        </header>
+        </div>
 
-        <div className="flex-1 overflow-auto p-4 bg-slate-50 dark:bg-slate-900">
+        {/* Diff viewer */}
+        <div style={{ flex: 1, overflow: 'auto', background: 'var(--soft)' }}>
           <ReactDiffViewer
-             oldValue={serverValue}
-             newValue={localValue}
-             splitView={true}
-             useDarkTheme={theme === 'dark'}
-             leftTitle="Server Document"
-             rightTitle="Your Edits"
-             extraLinesSurroundingDiff={3}
-             styles={{
-               variables: {
-                 light: { diffViewerBackground: '#fff', addedBackground: '#e6ffed', removedBackground: '#ffeef0' },
-                 dark: { diffViewerBackground: '#1e293b', addedBackground: '#044B53', removedBackground: '#632F34', wordAddedBackground: '#055d67', wordRemovedBackground: '#7d3840' }
-               },
-               line: {
-                 fontSize: '13px',
-                 fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace'
-               }
-             }}
+            oldValue={serverValue}
+            newValue={localValue}
+            splitView={true}
+            useDarkTheme={theme === 'dark'}
+            leftTitle="Server Document"
+            rightTitle="Your Edits"
+            extraLinesSurroundingDiff={3}
+            styles={{
+              variables: {
+                light: { diffViewerBackground: 'var(--soft)', addedBackground: '#e6ffed', removedBackground: '#ffeef0' },
+                dark: { diffViewerBackground: '#1e293b', addedBackground: '#044B53', removedBackground: '#632F34', wordAddedBackground: '#055d67', wordRemovedBackground: '#7d3840' },
+              },
+              line: {
+                fontSize: '13px',
+                fontFamily: 'var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace)',
+              },
+            }}
           />
         </div>
 
-        <footer className="px-6 py-4 border-t border-slate-200 dark:border-slate-700 flex justify-end gap-3 flex-shrink-0 bg-white dark:bg-slate-800">
-          <button
-            onClick={onClose}
-            className="px-5 py-2.5 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors font-medium"
-          >
+        {/* Footer */}
+        <div style={{
+          padding: '12px 20px', borderTop: '1px solid var(--border)',
+          display: 'flex', justifyContent: 'flex-end', gap: 8, flexShrink: 0,
+        }}>
+          <button className="qa-btn" onClick={onClose} style={{ fontSize: 13 }}>
             Cancel Save
           </button>
           <button
             onClick={onOverwrite}
-            className="px-5 py-2.5 rounded-md border border-red-500 bg-red-500 text-white font-semibold hover:bg-red-600 transition-colors flex items-center gap-2"
+            style={{
+              fontSize: 13, fontWeight: 600, padding: '6px 14px', borderRadius: 7,
+              background: 'var(--status-err)', color: '#fff',
+              border: '1px solid var(--status-err)', cursor: 'pointer',
+              display: 'flex', alignItems: 'center', gap: 6, fontFamily: 'var(--font-body)',
+            }}
           >
-            <WarningIcon className="w-5 h-5 text-red-100" /> Force Overwrite Server
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M8 1L15 14H1L8 1z"/><path d="M8 6v4M8 11.5v.5"/>
+            </svg>
+            Force Overwrite
           </button>
-        </footer>
+        </div>
       </div>
     </div>
   );

--- a/frontend/components/SaveQueryDialog.tsx
+++ b/frontend/components/SaveQueryDialog.tsx
@@ -2,17 +2,20 @@
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { SavedQuery } from '../types';
-import { SpinnerIcon, XIcon } from './icons/material-icons-imports';
+
+const fieldStyle: React.CSSProperties = {
+  width: '100%', padding: '8px 10px', background: 'var(--soft)',
+  border: '1px solid var(--border)', borderRadius: 6,
+  color: 'var(--fg)', fontFamily: 'var(--font-body)', fontSize: 13,
+  outline: 'none', boxSizing: 'border-box', transition: 'border-color 0.15s',
+};
 
 interface SaveQueryDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onSave: (data: Pick<SavedQuery, 'name' | 'prompt' | 'code'> | SavedQuery) => void;
   isSaving: boolean;
-  initialData: Partial<SavedQuery> & {
-    prompt: string;
-    code: string;
-  };
+  initialData: Partial<SavedQuery> & { prompt: string; code: string };
 }
 
 const SaveQueryDialog: React.FC<SaveQueryDialogProps> = ({ isOpen, onClose, onSave, isSaving, initialData }) => {
@@ -20,7 +23,7 @@ const SaveQueryDialog: React.FC<SaveQueryDialogProps> = ({ isOpen, onClose, onSa
   const [prompt, setPrompt] = useState('');
   const [code, setCode] = useState('');
   const [error, setError] = useState('');
-  
+
   const isEditMode = !!initialData.id;
 
   useEffect(() => {
@@ -34,117 +37,147 @@ const SaveQueryDialog: React.FC<SaveQueryDialogProps> = ({ isOpen, onClose, onSa
 
   const handleSave = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name.trim()) {
-      setError('Query name is required.');
-      return;
-    }
+    if (!name.trim()) { setError('Query name is required.'); return; }
     const saveData = isEditMode
       ? { ...(initialData as SavedQuery), name, prompt, code }
       : { name, prompt, code };
-      
     onSave(saveData);
   };
-  
+
   if (!isOpen) return null;
 
   return createPortal(
-    <div className="fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4 animate-fade-in-fast">
-      <div 
-        className="bg-white dark:bg-slate-800 rounded-xl shadow-2xl w-full max-w-2xl transform transition-all animate-scale-in"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="dialog-title"
-      >
-        <form onSubmit={handleSave}>
-          <header className="flex items-center justify-between p-4 sm:p-6 border-b border-slate-200 dark:border-slate-700">
-            <h2 id="dialog-title" className="text-xl font-bold text-slate-900 dark:text-slate-100">
-              {isEditMode ? 'Edit Saved Query' : 'Save Query'}
-            </h2>
-            <button
-              type="button"
-              onClick={onClose}
-              className="p-1.5 rounded-full text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
-              aria-label="Close dialog"
-              title="Close dialog"
-            >
-              <XIcon className="w-5 h-5" />
-            </button>
-          </header>
-
-          <main className="p-4 sm:p-6 space-y-4 max-h-[70vh] overflow-y-auto">
-            <div>
-              <label htmlFor="query-name" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-                Query Name
-              </label>
-              <input
-                id="query-name"
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                className="w-full p-2 bg-slate-50 dark:bg-slate-700/50 border border-slate-300 dark:border-slate-600 rounded-lg text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                placeholder="e.g., Active Canadian Users"
-                required
-              />
-              {error && <p className="text-red-500 text-xs mt-1">{error}</p>}
-            </div>
-            <div>
-              <label htmlFor="query-prompt" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-                Natural Language Prompt
-              </label>
-              <textarea
-                id="query-prompt"
-                value={prompt}
-                onChange={(e) => setPrompt(e.target.value)}
-                rows={3}
-                className="w-full p-2 bg-slate-50 dark:bg-slate-700/50 border border-slate-300 dark:border-slate-600 rounded-lg text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 resize-y"
-              />
-            </div>
-            <div>
-              <label htmlFor="query-code" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-                Query Code
-              </label>
-              <textarea
-                id="query-code"
-                value={code}
-                onChange={(e) => setCode(e.target.value)}
-                rows={6}
-                className="w-full p-3 bg-slate-900 dark:bg-black/40 border border-slate-600 dark:border-slate-700 rounded-lg text-cyan-300 font-mono text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 resize-y"
-                spellCheck="false"
-              />
-            </div>
-          </main>
-
-          <footer className="flex justify-end items-center gap-3 p-4 bg-slate-50 dark:bg-slate-800/50 border-t border-slate-200 dark:border-slate-700">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={isSaving}
-              className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-sm font-medium rounded-md text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-700 hover:bg-slate-50 dark:hover:bg-slate-600 transition-colors disabled:opacity-50"
-              title="Discard changes and close"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={isSaving}
-              className="w-28 flex justify-center items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-slate-400 dark:disabled:bg-slate-600 disabled:cursor-not-allowed transition-colors"
-              title={isEditMode ? 'Save changes' : 'Save the new query'}
-            >
-              {isSaving ? <SpinnerIcon className="w-5 h-5"/> : 'Save'}
-            </button>
-          </footer>
-        </form>
-      </div>
+    <>
       <style>{`
-          @keyframes scale-in {
-              from { opacity: 0; transform: scale(0.95); }
-              to { opacity: 1; transform: scale(1); }
-          }
-          .animate-scale-in {
-              animation: scale-in 0.2s ease-out forwards;
-          }
+        @keyframes qp-dialog-in {
+          from { opacity: 0; transform: scale(0.96) translateY(4px); }
+          to   { opacity: 1; transform: scale(1)    translateY(0);    }
+        }
+        .qp-dialog-box { animation: qp-dialog-in 0.18s cubic-bezier(0.16,1,0.3,1); }
+        .qp-field:focus { border-color: var(--accent) !important; }
       `}</style>
-    </div>,
+
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.35)', zIndex: 50, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16 }}
+      >
+        {/* Dialog */}
+        <div
+          className="qp-dialog-box"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="sqd-title"
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            background: 'var(--panel)', border: '1px solid var(--border)',
+            borderRadius: 12, width: '100%', maxWidth: 560,
+            boxShadow: '0 20px 60px rgba(0,0,0,0.14)',
+            fontFamily: 'var(--font-body)', display: 'flex', flexDirection: 'column',
+          }}
+        >
+          <form onSubmit={handleSave} style={{ display: 'flex', flexDirection: 'column' }}>
+            {/* Header */}
+            <div style={{ display: 'flex', alignItems: 'center', padding: '14px 18px', borderBottom: '1px solid var(--border)' }}>
+              <span id="sqd-title" style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)' }}>
+                {isEditMode ? 'Edit saved query' : 'Save query'}
+              </span>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close dialog"
+                style={{ marginLeft: 'auto', background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex', padding: 4, borderRadius: 5 }}
+              >
+                <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <path d="M3 3l10 10M13 3L3 13"/>
+                </svg>
+              </button>
+            </div>
+
+            {/* Body */}
+            <div style={{ padding: '16px 18px', display: 'flex', flexDirection: 'column', gap: 14, maxHeight: '70vh', overflowY: 'auto' }}>
+              <div>
+                <label htmlFor="sqd-name" style={{ fontSize: 11.5, fontWeight: 500, color: 'var(--fg)', display: 'block', marginBottom: 5 }}>
+                  Name
+                </label>
+                <input
+                  id="sqd-name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className="qp-field"
+                  style={fieldStyle}
+                  placeholder="e.g., Active Canadian Users"
+                  required
+                />
+                {error && <p style={{ fontSize: 11.5, color: 'var(--status-err)', marginTop: 4 }}>{error}</p>}
+              </div>
+
+              <div>
+                <label htmlFor="sqd-prompt" style={{ fontSize: 11.5, fontWeight: 500, color: 'var(--fg)', display: 'block', marginBottom: 5 }}>
+                  Natural language prompt
+                </label>
+                <textarea
+                  id="sqd-prompt"
+                  value={prompt}
+                  onChange={(e) => setPrompt(e.target.value)}
+                  className="qp-field"
+                  style={{ ...fieldStyle, resize: 'vertical', minHeight: 72, lineHeight: 1.55 }}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="sqd-code" style={{ fontSize: 11.5, fontWeight: 500, color: 'var(--fg)', display: 'block', marginBottom: 5 }}>
+                  Query code
+                </label>
+                <textarea
+                  id="sqd-code"
+                  value={code}
+                  onChange={(e) => setCode(e.target.value)}
+                  className="qp-field"
+                  style={{
+                    ...fieldStyle,
+                    background: '#0f0e0d', color: '#c8c4bc',
+                    fontFamily: 'var(--font-mono)', fontSize: 12,
+                    lineHeight: 1.65, resize: 'vertical', minHeight: 120,
+                  }}
+                  spellCheck={false}
+                />
+              </div>
+            </div>
+
+            {/* Footer */}
+            <div style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8,
+              padding: '12px 18px', borderTop: '1px solid var(--border)',
+              background: 'var(--soft)', borderRadius: '0 0 12px 12px',
+            }}>
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isSaving}
+                className="qa-btn"
+                style={{ fontSize: 13 }}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={isSaving}
+                className="qa-btn primary"
+                style={{ fontSize: 13, minWidth: 80, justifyContent: 'center', opacity: isSaving ? 0.6 : 1 }}
+              >
+                {isSaving ? (
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ animation: 'qp-spin 0.8s linear infinite' }}>
+                    <circle cx="8" cy="8" r="6" strokeOpacity="0.3"/><path d="M8 2a6 6 0 0 1 6 6"/>
+                  </svg>
+                ) : 'Save'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>,
     document.body
   );
 };

--- a/frontend/components/SavedQueriesPanel.tsx
+++ b/frontend/components/SavedQueriesPanel.tsx
@@ -7,10 +7,12 @@ interface SavedQueriesPanelProps {
     onClose: () => void;
     queries: SavedQuery[];
     onLoad: (query: SavedQuery) => void;
+    onLoadAndRun: (query: SavedQuery) => void;
     onEdit: (query: SavedQuery) => void;
     onDelete: (queryId: string) => void;
     onShare: (query: SavedQuery) => void;
     isLoading: boolean;
+    dbReady: boolean;
     currentUserEmail?: string | null;
 }
 
@@ -32,13 +34,15 @@ const PinIcon = () => (
 interface SavedQueryCardProps {
     query: SavedQuery;
     onLoad: (q: SavedQuery) => void;
+    onLoadAndRun: (q: SavedQuery) => void;
     onEdit: (q: SavedQuery) => void;
     onDelete: (id: string) => void;
     onShare: (q: SavedQuery) => void;
     isOwned: boolean;
+    dbReady: boolean;
 }
 
-const SavedQueryCard: React.FC<SavedQueryCardProps> = ({ query, onLoad, onEdit, onDelete, onShare, isOwned }) => {
+const SavedQueryCard: React.FC<SavedQueryCardProps> = ({ query, onLoad, onLoadAndRun, onEdit, onDelete, onShare, isOwned, dbReady }) => {
     const handleDelete = () => {
         if (window.confirm(`Delete "${query.name}"? This cannot be undone.`)) onDelete(query.id);
     };
@@ -79,10 +83,24 @@ const SavedQueryCard: React.FC<SavedQueryCardProps> = ({ query, onLoad, onEdit, 
             <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2 }}>
                 <button
                     onClick={() => onLoad(query)}
-                    className="qa-btn primary"
-                    style={{ fontSize: 12, padding: '4px 12px' }}
+                    disabled={!dbReady}
+                    className="qa-btn"
+                    title={!dbReady ? 'Connect to a database first' : 'Load query into editor'}
+                    style={{ fontSize: 12, padding: '4px 12px', opacity: dbReady ? 1 : 0.45, cursor: dbReady ? 'pointer' : 'not-allowed' }}
                 >
                     Load
+                </button>
+                <button
+                    onClick={() => onLoadAndRun(query)}
+                    disabled={!dbReady}
+                    className="qa-btn primary"
+                    title={!dbReady ? 'Connect to a database first' : 'Load query and run it immediately'}
+                    style={{ fontSize: 12, padding: '4px 12px', display: 'flex', alignItems: 'center', gap: 5, opacity: dbReady ? 1 : 0.45, cursor: dbReady ? 'pointer' : 'not-allowed' }}
+                >
+                    <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8">
+                        <path d="M5 3l9 5-9 5V3z" fill="currentColor" strokeLinejoin="round"/>
+                    </svg>
+                    Load & Run
                 </button>
                 <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 4 }}>
                     {isOwned && (
@@ -117,7 +135,7 @@ const SavedQueryCard: React.FC<SavedQueryCardProps> = ({ query, onLoad, onEdit, 
 };
 
 const SavedQueriesPanel: React.FC<SavedQueriesPanelProps> = ({
-    onClose, queries, onLoad, onEdit, onDelete, onShare, isLoading, currentUserEmail,
+    onClose, queries, onLoad, onLoadAndRun, onEdit, onDelete, onShare, isLoading, dbReady, currentUserEmail,
 }) => {
     const [activeTab, setActiveTab] = useState<'my_queries' | 'shared_with_me'>('my_queries');
 
@@ -151,10 +169,12 @@ const SavedQueriesPanel: React.FC<SavedQueriesPanelProps> = ({
                     key={q.id}
                     query={q}
                     onLoad={onLoad}
+                    onLoadAndRun={onLoadAndRun}
                     onEdit={onEdit}
                     onDelete={onDelete}
                     onShare={onShare}
                     isOwned={activeTab === 'my_queries'}
+                    dbReady={dbReady}
                 />
             ));
         }

--- a/frontend/components/SavedQueriesPanel.tsx
+++ b/frontend/components/SavedQueriesPanel.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState, useMemo } from 'react';
 import { SavedQuery } from '../types';
-import { XIcon, SpinnerIcon, EditIcon, BookmarkIcon, TrashIcon, ShareIcon } from './icons/material-icons-imports';
+import { EditIcon, TrashIcon, ShareIcon } from './icons/material-icons-imports';
 
 interface SavedQueriesPanelProps {
     onClose: () => void;
@@ -14,81 +14,111 @@ interface SavedQueriesPanelProps {
     currentUserEmail?: string | null;
 }
 
-const SavedQueryCard: React.FC<{
+const timeAgo = (dateString: string) => {
+    const seconds = Math.floor((Date.now() - new Date(dateString).getTime()) / 1000);
+    if (seconds < 60) return 'just now';
+    const m = Math.floor(seconds / 60); if (m < 60) return `${m}m ago`;
+    const h = Math.floor(m / 60); if (h < 24) return `${h}h ago`;
+    const d = Math.floor(h / 24); if (d < 30) return `${d}d ago`;
+    return `${Math.floor(d / 30)}mo ago`;
+};
+
+const PinIcon = () => (
+    <svg width="11" height="11" viewBox="0 0 16 16" fill="var(--accent)" stroke="var(--accent)" strokeWidth="1.2">
+        <path d="M5 2v6l-2 2v1h4v4h2v-4h4v-1l-2-2V2z"/>
+    </svg>
+);
+
+interface SavedQueryCardProps {
     query: SavedQuery;
-    onLoad: (query: SavedQuery) => void;
-    onEdit: (query: SavedQuery) => void;
-    onDelete: (queryId: string) => void;
-    onShare: (query: SavedQuery) => void;
+    onLoad: (q: SavedQuery) => void;
+    onEdit: (q: SavedQuery) => void;
+    onDelete: (id: string) => void;
+    onShare: (q: SavedQuery) => void;
     isOwned: boolean;
-}> = ({ query, onLoad, onEdit, onDelete, onShare, isOwned }) => {
-    
+}
+
+const SavedQueryCard: React.FC<SavedQueryCardProps> = ({ query, onLoad, onEdit, onDelete, onShare, isOwned }) => {
     const handleDelete = () => {
-        if (window.confirm(`Are you sure you want to delete "${query.name}"? This action cannot be undone.`)) {
-            onDelete(query.id);
-        }
+        if (window.confirm(`Delete "${query.name}"? This cannot be undone.`)) onDelete(query.id);
     };
-
-    const timeAgo = (dateString: string) => {
-        const date = new Date(dateString);
-        const now = new Date();
-        const seconds = Math.floor((now.getTime() - date.getTime()) / 1000);
-        let interval = seconds / 31536000;
-        if (interval > 1) return Math.floor(interval) + " years ago";
-        interval = seconds / 2592000;
-        if (interval > 1) return Math.floor(interval) + " months ago";
-        interval = seconds / 86400;
-        if (interval > 1) return Math.floor(interval) + " days ago";
-        interval = seconds / 3600;
-        if (interval > 1) return Math.floor(interval) + " hours ago";
-        interval = seconds / 60;
-        if (interval > 1) return Math.floor(interval) + " minutes ago";
-        return "just now";
-    };
-
     return (
-        <div className="bg-slate-800/70 p-4 rounded-lg border border-slate-700 space-y-3 group transition-all hover:border-slate-600 hover:bg-slate-800">
-            <div className="flex justify-between items-start gap-2">
-                <h4 className="font-bold text-slate-200 break-words">{query.name}</h4>
-                <div className="flex items-center gap-1 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+        <div
+            className="qa-card"
+            style={{ padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: 8, position: 'relative', cursor: 'default' }}
+        >
+            {/* Pin icon */}
+            {(query as any).pinned && (
+                <span style={{ position: 'absolute', top: 12, right: 12 }}><PinIcon /></span>
+            )}
+
+            {/* Name + tags row */}
+            <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6, paddingRight: 20 }}>
+                <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)', lineHeight: 1.3 }}>{query.name}</span>
+            </div>
+
+            {/* Prompt quote */}
+            <blockquote style={{
+                margin: 0, borderLeft: '2px solid var(--accent)',
+                paddingLeft: 10, fontSize: 12, fontStyle: 'italic',
+                color: 'var(--muted)', lineHeight: 1.5,
+                maxHeight: 60, overflow: 'hidden',
+            }}>
+                {query.prompt}
+            </blockquote>
+
+            {/* Shared-by info */}
+            {!isOwned && (
+                <div style={{ fontSize: 11, color: 'var(--muted)' }}>
+                    Shared by <strong style={{ color: 'var(--fg)' }}>{query.ownerEmail}</strong>
+                    {' · '}edited {timeAgo(query.updatedAt)} by {query.lastModifiedBy.split('@')[0]}
+                </div>
+            )}
+
+            {/* Footer row */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2 }}>
+                <button
+                    onClick={() => onLoad(query)}
+                    className="qa-btn primary"
+                    style={{ fontSize: 12, padding: '4px 12px' }}
+                >
+                    Load
+                </button>
+                <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 4 }}>
                     {isOwned && (
-                        <button onClick={() => onShare(query)} className="p-1.5 rounded-full text-slate-400 hover:bg-slate-600 hover:text-white" aria-label="Share query" title="Share and manage access">
-                            <ShareIcon className="w-4 h-4" />
+                        <button
+                            onClick={() => onShare(query)}
+                            aria-label="Share query"
+                            style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex', padding: 4, borderRadius: 4 }}
+                        >
+                            <ShareIcon className="w-4 h-4" style={{ width: 14, height: 14 }} />
                         </button>
                     )}
-                    <button onClick={() => onEdit(query)} className="p-1.5 rounded-full text-slate-400 hover:bg-slate-600 hover:text-white" aria-label="Edit query" title="Edit query name, prompt, or code">
-                        <EditIcon className="w-4 h-4" />
+                    <button
+                        onClick={() => onEdit(query)}
+                        aria-label="Edit query"
+                        style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex', padding: 4, borderRadius: 4 }}
+                    >
+                        <EditIcon className="w-4 h-4" style={{ width: 14, height: 14 }} />
                     </button>
                     {isOwned && (
-                        <button onClick={handleDelete} className="p-1.5 rounded-full text-slate-400 hover:bg-red-900/50 hover:text-red-400" aria-label="Delete query" title="Permanently delete this query">
-                            <TrashIcon className="w-4 h-4" />
+                        <button
+                            onClick={handleDelete}
+                            aria-label="Delete query"
+                            style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex', padding: 4, borderRadius: 4 }}
+                        >
+                            <TrashIcon className="w-4 h-4" style={{ width: 14, height: 14 }} />
                         </button>
                     )}
                 </div>
             </div>
-
-            <blockquote className="border-l-4 border-blue-400 pl-3 text-sm italic text-slate-400 max-h-20 overflow-y-auto">
-                {query.prompt}
-            </blockquote>
-
-             {!isOwned && (
-                <div className="text-xs text-slate-400">
-                    Shared by <strong className="text-slate-300">{query.ownerEmail}</strong> &middot; Edited {timeAgo(query.updatedAt)} by {query.lastModifiedBy.split('@')[0]}
-                </div>
-            )}
-            
-            <button
-                onClick={() => onLoad(query)}
-                className="w-full px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900 focus:ring-blue-500 transition-colors"
-                title="Load this query and prompt into the main editor"
-            >
-                Load Query
-            </button>
         </div>
     );
 };
 
-const SavedQueriesPanel: React.FC<SavedQueriesPanelProps> = ({ onClose, queries, onLoad, onEdit, onDelete, onShare, isLoading, currentUserEmail }) => {
+const SavedQueriesPanel: React.FC<SavedQueriesPanelProps> = ({
+    onClose, queries, onLoad, onEdit, onDelete, onShare, isLoading, currentUserEmail,
+}) => {
     const [activeTab, setActiveTab] = useState<'my_queries' | 'shared_with_me'>('my_queries');
 
     const { myQueries, sharedWithMe } = useMemo(() => {
@@ -96,11 +126,8 @@ const SavedQueriesPanel: React.FC<SavedQueriesPanelProps> = ({ onClose, queries,
         const myq: SavedQuery[] = [];
         const swm: SavedQuery[] = [];
         queries.forEach(q => {
-            if (q.ownerEmail === currentUserEmail) {
-                myq.push(q);
-            } else if (q.sharedWith.includes(currentUserEmail)) {
-                swm.push(q);
-            }
+            if (q.ownerEmail === currentUserEmail) myq.push(q);
+            else if (q.sharedWith.includes(currentUserEmail!)) swm.push(q);
         });
         return { myQueries: myq, sharedWithMe: swm };
     }, [queries, currentUserEmail]);
@@ -109,86 +136,122 @@ const SavedQueriesPanel: React.FC<SavedQueriesPanelProps> = ({ onClose, queries,
 
     const renderContent = () => {
         if (isLoading) {
-             return (
-                <div className="text-center text-slate-500 h-full flex flex-col items-center justify-center">
-                    <SpinnerIcon className="w-8 h-8 text-blue-500"/>
-                    <p className="mt-4 font-semibold">Loading your queries...</p>
+            return (
+                <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 10, color: 'var(--muted)' }}>
+                    <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.5" style={{ animation: 'qp-spin 0.8s linear infinite' }}>
+                        <circle cx="8" cy="8" r="6" strokeOpacity="0.3"/><path d="M8 2a6 6 0 0 1 6 6"/>
+                    </svg>
+                    <span style={{ fontSize: 13 }}>Loading queries…</span>
                 </div>
             );
         }
         if (queriesToDisplay.length > 0) {
-            return queriesToDisplay.map((query) => (
-              <SavedQueryCard 
-                key={query.id} 
-                query={query}
-                onLoad={onLoad}
-                onEdit={onEdit}
-                onDelete={onDelete}
-                onShare={onShare}
-                isOwned={activeTab === 'my_queries'}
-              />
+            return queriesToDisplay.map(q => (
+                <SavedQueryCard
+                    key={q.id}
+                    query={q}
+                    onLoad={onLoad}
+                    onEdit={onEdit}
+                    onDelete={onDelete}
+                    onShare={onShare}
+                    isOwned={activeTab === 'my_queries'}
+                />
             ));
         }
-        if (activeTab === 'my_queries') {
-            return (
-                <div className="text-center text-slate-500 h-full flex flex-col items-center justify-center p-4">
-                    <p className="font-semibold">No queries saved yet.</p>
-                    <p className="text-sm">Click the "Save" button on a generated query to add it here.</p>
-                </div>
-            );
-        }
         return (
-            <div className="text-center text-slate-500 h-full flex flex-col items-center justify-center p-4">
-                <p className="font-semibold">No queries shared with you.</p>
-                <p className="text-sm">When a colleague shares a query with you, it will appear here.</p>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 6, color: 'var(--muted)' }}>
+                <svg width="32" height="32" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1" opacity="0.4">
+                    <path d="M4 2h6l3 3v9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1z"/>
+                    <path d="M6 7h5M6 10h3"/>
+                </svg>
+                {activeTab === 'my_queries' ? (
+                    <>
+                        <p style={{ fontSize: 13, fontWeight: 500, margin: 0 }}>No saved queries yet</p>
+                        <p style={{ fontSize: 12, margin: 0, textAlign: 'center' }}>Click Save on a generated query to add it here.</p>
+                    </>
+                ) : (
+                    <>
+                        <p style={{ fontSize: 13, fontWeight: 500, margin: 0 }}>Nothing shared with you</p>
+                        <p style={{ fontSize: 12, margin: 0, textAlign: 'center' }}>When a colleague shares a query, it appears here.</p>
+                    </>
+                )}
             </div>
         );
     };
 
     return (
         <>
+            <style>{`@keyframes qp-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`}</style>
             <div
                 onClick={onClose}
-                className="fixed inset-0 bg-black bg-opacity-60 z-40 animate-fade-in-fast"
+                style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.35)', zIndex: 40 }}
                 aria-hidden="true"
-            ></div>
-            <aside 
+            />
+            <aside
                 id="tutorial-saved-queries-panel"
-                className="fixed top-0 right-0 h-full w-full md:w-[450px] bg-slate-900 shadow-2xl z-50 flex flex-col animate-slide-in-drawer"
+                className="qp-drawer"
+                style={{
+                    position: 'fixed', top: 0, right: 0, height: '100%', width: 460,
+                    maxWidth: '100vw', background: 'var(--panel)', borderLeft: '1px solid var(--border)',
+                    zIndex: 50, display: 'flex', flexDirection: 'column',
+                    fontFamily: 'var(--font-body)',
+                }}
             >
-                <header className="flex items-center justify-between p-4 border-b border-slate-700 flex-shrink-0">
-                    <h3 className="text-lg font-semibold text-white flex items-center gap-3">
-                        <BookmarkIcon className="w-5 h-5 text-blue-400" />
-                        Saved Queries
-                    </h3>
+                {/* Header */}
+                <div style={{
+                    display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px',
+                    borderBottom: '1px solid var(--border)', flexShrink: 0,
+                }}>
+                    <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.4">
+                        <path d="M4 2h6l3 3v9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1z"/>
+                        <path d="M6 7h5M6 10h3"/>
+                    </svg>
+                    <span style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--fg)' }}>Saved Queries</span>
+                    <span style={{ fontSize: 11, color: 'var(--muted)', marginLeft: 2 }}>· {queries.length}</span>
                     <button
                         onClick={onClose}
-                        className="p-1.5 rounded-full text-slate-400 hover:bg-slate-700 hover:text-white transition-colors"
                         aria-label="Close saved queries panel"
-                        title="Close saved queries"
+                        style={{
+                            marginLeft: 'auto', background: 'none', border: 'none', cursor: 'pointer',
+                            color: 'var(--muted)', display: 'flex', padding: 4, borderRadius: 5,
+                        }}
                     >
-                        <XIcon className="w-5 h-5" />
+                        <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                            <path d="M3 3l10 10M13 3L3 13"/>
+                        </svg>
                     </button>
-                </header>
+                </div>
 
-                <div className="flex-shrink-0 p-2 border-b border-slate-700">
-                    <div className="flex items-center gap-2 p-1 bg-slate-800 rounded-lg">
-                        <button
-                            onClick={() => setActiveTab('my_queries')}
-                            className={`flex-1 px-3 py-1.5 text-sm font-semibold rounded-md transition-colors ${activeTab === 'my_queries' ? 'bg-blue-600 text-white shadow-md' : 'text-slate-300 hover:bg-slate-700'}`}
-                        >
-                            My Queries
-                        </button>
-                        <button
-                            onClick={() => setActiveTab('shared_with_me')}
-                            className={`flex-1 px-3 py-1.5 text-sm font-semibold rounded-md transition-colors ${activeTab === 'shared_with_me' ? 'bg-blue-600 text-white shadow-md' : 'text-slate-300 hover:bg-slate-700'}`}
-                        >
-                            Shared With Me
-                        </button>
+                {/* Tabs */}
+                <div style={{ padding: '8px 10px', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
+                    <div style={{ display: 'flex', gap: 2, background: 'var(--soft)', borderRadius: 6, padding: 2 }}>
+                        {(['my_queries', 'shared_with_me'] as const).map((tab) => (
+                            <button
+                                key={tab}
+                                onClick={() => setActiveTab(tab)}
+                                style={{
+                                    flex: 1, padding: '4px 0', fontSize: 12, fontWeight: activeTab === tab ? 500 : 400,
+                                    border: 'none', borderRadius: 4, cursor: 'pointer',
+                                    background: activeTab === tab ? 'var(--panel)' : 'transparent',
+                                    boxShadow: activeTab === tab ? '0 0 0 1px var(--border)' : 'none',
+                                    color: activeTab === tab ? 'var(--fg)' : 'var(--muted)',
+                                    fontFamily: 'var(--font-body)',
+                                }}
+                            >
+                                {tab === 'my_queries' ? 'My queries' : 'Shared with me'}
+                                {tab === 'my_queries' && myQueries.length > 0 && (
+                                    <span style={{ marginLeft: 5, fontSize: 10.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)' }}>{myQueries.length}</span>
+                                )}
+                                {tab === 'shared_with_me' && sharedWithMe.length > 0 && (
+                                    <span style={{ marginLeft: 5, fontSize: 10.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)' }}>{sharedWithMe.length}</span>
+                                )}
+                            </button>
+                        ))}
                     </div>
                 </div>
 
-                <div className="flex-grow overflow-auto p-4 space-y-4">
+                {/* Content */}
+                <div style={{ flex: 1, overflowY: 'auto', padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: 8 }}>
                     {renderContent()}
                 </div>
             </aside>

--- a/frontend/components/SchemaRelationshipGraph.tsx
+++ b/frontend/components/SchemaRelationshipGraph.tsx
@@ -1,242 +1,199 @@
-
 import React, { useMemo, useState } from 'react';
 import { Relationship, SchemaRelationshipsResponse } from '../types';
 
 interface SchemaRelationshipGraphProps {
-    relationships: SchemaRelationshipsResponse;
-    selectedCollections: string[];
+  relationships: SchemaRelationshipsResponse;
+  selectedCollections: string[];
 }
 
-interface Node {
-    id: string;
-    x: number;
-    y: number;
-}
-
-interface Edge {
-    source: Node;
-    target: Node;
-    data: Relationship;
-}
+interface Node { id: string; x: number; y: number; }
+interface Edge { source: Node; target: Node; data: Relationship; }
 
 const SchemaRelationshipGraph: React.FC<SchemaRelationshipGraphProps> = ({ relationships, selectedCollections }) => {
-    const [hoveredNode, setHoveredNode] = useState<string | null>(null);
-    const [hoveredEdge, setHoveredEdge] = useState<number | null>(null);
+  const [hoveredNode, setHoveredNode] = useState<string | null>(null);
+  const [hoveredEdge, setHoveredEdge] = useState<number | null>(null);
 
-    // Filter collections to only those selected (or involved in relationships between selected)
-    // Actually, we should show all "selected" collections as nodes, even if isolated.
-    const nodes: Node[] = useMemo(() => {
-        const uniqueCols = Array.from(new Set(selectedCollections));
-        const count = uniqueCols.length;
-        const radius = 120; // Radius of the circle layout
-        const centerX = 200;
-        const centerY = 150; // Reduced height
+  const nodes: Node[] = useMemo(() => {
+    const cols = Array.from(new Set(selectedCollections));
+    const cx = 200, cy = 140, r = 100;
+    if (cols.length === 2) {
+      return [
+        { id: cols[0], x: 70,  y: cy },
+        { id: cols[1], x: 330, y: cy },
+      ];
+    }
+    return cols.map((col, i) => {
+      const angle = (i / cols.length) * 2 * Math.PI - Math.PI / 2;
+      return { id: col, x: cx + r * Math.cos(angle), y: cy + r * Math.sin(angle) };
+    });
+  }, [selectedCollections]);
 
-        if (count === 2) {
-            return [
-                { id: uniqueCols[0], x: 80, y: centerY },
-                { id: uniqueCols[1], x: 320, y: centerY }
-            ];
-        }
+  const edges: Edge[] = useMemo(() => (
+    relationships.relationships
+      .filter(rel =>
+        selectedCollections.includes(rel.source_collection) &&
+        selectedCollections.includes(rel.target_collection)
+      )
+      .map(rel => {
+        const src = nodes.find(n => n.id === rel.source_collection);
+        const tgt = nodes.find(n => n.id === rel.target_collection);
+        if (!src || !tgt) return null;
+        return { source: src, target: tgt, data: rel };
+      })
+      .filter((e): e is Edge => e !== null)
+  ), [relationships, nodes, selectedCollections]);
 
-        return uniqueCols.map((col, i) => {
-            const angle = (i / count) * 2 * Math.PI - Math.PI / 2; // Start from top
-            return {
-                id: col,
-                x: centerX + radius * Math.cos(angle),
-                y: centerY + radius * Math.sin(angle),
-            };
-        });
-    }, [selectedCollections]);
+  const getPath = (src: Node, tgt: Node, idx: number) => {
+    const dx = tgt.x - src.x, dy = tgt.y - src.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    const px = -dy / dist, py = dx / dist;
+    const curve = 28 + idx * 18;
+    const cx = (src.x + tgt.x) / 2 + px * curve;
+    const cy = (src.y + tgt.y) / 2 + py * curve;
+    const R = 34;
+    const aS = Math.atan2(cy - src.y, cx - src.x);
+    const aT = Math.atan2(cy - tgt.y, cx - tgt.x);
+    return `M ${src.x + R * Math.cos(aS)} ${src.y + R * Math.sin(aS)} Q ${cx} ${cy} ${tgt.x + R * Math.cos(aT)} ${tgt.y + R * Math.sin(aT)}`;
+  };
 
-    const edges: Edge[] = useMemo(() => {
-        return relationships.relationships
-            .filter(rel => selectedCollections.includes(rel.source_collection) && selectedCollections.includes(rel.target_collection))
-            .map(rel => {
-                const sourceNode = nodes.find(n => n.id === rel.source_collection);
-                const targetNode = nodes.find(n => n.id === rel.target_collection);
-                if (!sourceNode || !targetNode) return null;
-                return { source: sourceNode, target: targetNode, data: rel };
-            })
-            .filter((e): e is Edge => e !== null);
-    }, [relationships, nodes, selectedCollections]);
+  const activeEdge = hoveredEdge !== null ? edges[hoveredEdge] : null;
 
-    // Helper to calculate bezier curve control point
-    const getPath = (source: Node, target: Node, index: number) => {
-        const dx = target.x - source.x;
-        const dy = target.y - source.y;
-        const dist = Math.sqrt(dx * dx + dy * dy);
+  return (
+    <div style={{
+      width: '100%', position: 'relative',
+      background: 'var(--bg)', border: '1px solid var(--border)',
+      borderRadius: 'var(--radius-md)', overflow: 'hidden',
+    }}>
+      {/* Badge */}
+      <div style={{
+        position: 'absolute', top: 10, right: 10, zIndex: 2,
+        display: 'inline-flex', alignItems: 'center', gap: 5,
+        background: 'var(--accent-soft)', color: 'var(--accent)',
+        fontSize: 10, fontFamily: 'var(--font-body)', fontWeight: 500,
+        padding: '2px 8px', borderRadius: 99,
+      }}>
+        <span style={{ width: 5, height: 5, borderRadius: 99, background: 'var(--accent)', display: 'inline-block' }} />
+        AI inferred
+      </div>
 
-        // Curvature logic: Straight line if direct, curved if multiple or loops
-        let cx = (source.x + target.x) / 2;
-        let cy = (source.y + target.y) / 2;
+      <svg
+        width="400" height="280" viewBox="0 0 400 280"
+        style={{ width: '100%', maxWidth: 480, display: 'block', margin: '0 auto' }}
+      >
+        <defs>
+          <filter id="qp-node-glow">
+            <feGaussianBlur stdDeviation="3" result="blur" />
+            <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+          </filter>
+        </defs>
 
-        // Add offset for multiple edges or just for style
-        // If it's a bidirectional pair, we need curvature.
-        // Simple logic: curve upwards/downwards based on direction or index
+        {/* Edges */}
+        {edges.map((edge, i) => {
+          const hov = hoveredEdge === i;
+          const dim = hoveredEdge !== null && !hov;
+          const d = getPath(edge.source, edge.target, i);
+          return (
+            <g key={i} style={{ opacity: dim ? 0.2 : 1, transition: 'opacity 0.2s' }}
+              onMouseEnter={() => setHoveredEdge(i)}
+              onMouseLeave={() => setHoveredEdge(null)}
+            >
+              {/* hit area */}
+              <path d={d} stroke="transparent" strokeWidth={20} fill="none" style={{ cursor: 'pointer' }} />
+              <path
+                d={d} fill="none"
+                stroke={hov ? 'var(--accent)' : 'var(--border)'}
+                strokeWidth={hov ? 2 : 1.5}
+                style={{ transition: 'stroke 0.15s' }}
+              />
+              {hov && (
+                <circle r="3.5" fill="var(--accent)">
+                  <animateMotion dur="1.2s" repeatCount="indefinite" path={d} />
+                </circle>
+              )}
+            </g>
+          );
+        })}
 
-        // A simple consistent curve offset
-        // const offset = 40; // This variable was not used, removed.
-        // Calculate perpendicular vector
-        const px = -dy / dist;
-        const py = dx / dist;
+        {/* Nodes */}
+        {nodes.map(node => {
+          const hov = hoveredNode === node.id;
+          const edgeRelated = hoveredEdge !== null && (edges[hoveredEdge]?.source.id === node.id || edges[hoveredEdge]?.target.id === node.id);
+          const dim = hoveredEdge !== null && !edgeRelated;
+          const active = hov || edgeRelated;
+          // truncate long names
+          const label = node.id.length > 11 ? node.id.slice(0, 10) + '…' : node.id;
+          return (
+            <g
+              key={node.id}
+              transform={`translate(${node.x},${node.y})`}
+              style={{ cursor: 'default', opacity: dim ? 0.25 : 1, transition: 'opacity 0.2s' }}
+              onMouseEnter={() => setHoveredNode(node.id)}
+              onMouseLeave={() => setHoveredNode(null)}
+            >
+              <circle
+                r={32}
+                fill={active ? 'var(--accent-soft)' : 'var(--panel)'}
+                stroke={active ? 'var(--accent)' : 'var(--border)'}
+                strokeWidth={active ? 1.5 : 1}
+                filter={active ? 'url(#qp-node-glow)' : ''}
+                style={{ transition: 'fill 0.15s, stroke 0.15s' }}
+              />
+              <text
+                textAnchor="middle" dominantBaseline="middle"
+                style={{
+                  fontFamily: 'var(--font-mono)', fontSize: 10,
+                  fontWeight: 600, pointerEvents: 'none',
+                  fill: active ? 'var(--accent)' : 'var(--fg)',
+                  transition: 'fill 0.15s',
+                }}
+              >
+                {label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
 
-        // Small randomish offset based on data string hash or index to allow separate lines for multiple rels
-        const curveAmount = 30 + (index * 20);
-
-        cx += px * curveAmount;
-        cy += py * curveAmount;
-
-        // Calculate intersection point on the edge of the target circle (radius 30 + arrow size approx 10)
-        // We want the arrow to point to the edge, efficiently.
-        // Actually, Q curves are hard to chop exactly. 
-        // Easier approach: Use a marker-end that has refX properly set, OR calculate the point on the circle.
-
-        // Let's recalculate target/source points to be on the circumference.
-        const radius = 30 + 5; // Node radius + buffer
-        const angleSource = Math.atan2(cy - source.y, cx - source.x);
-        const angleTarget = Math.atan2(cy - target.y, cx - target.x);
-
-        const sx = source.x + radius * Math.cos(angleSource);
-        const sy = source.y + radius * Math.sin(angleSource);
-
-        const tx = target.x + radius * Math.cos(angleTarget);
-        const ty = target.y + radius * Math.sin(angleTarget);
-
-        return `M ${sx} ${sy} Q ${cx} ${cy} ${tx} ${ty}`;
-    };
-
-    return (
-        <div className="w-full flex flex-col items-center bg-slate-50 dark:bg-slate-900/50 rounded-xl border border-slate-200 dark:border-slate-700 p-6 overflow-hidden relative">
-            <div className="absolute top-2 right-2 flex gap-2">
-                <div className="flex items-center gap-1 text-[10px] text-slate-400 dark:text-slate-500 bg-white dark:bg-slate-800 px-2 py-1 rounded-full border border-slate-200 dark:border-slate-700 shadow-sm">
-                    <span className="w-2 h-2 rounded-full bg-blue-500 animate-pulse"></span>
-                    AI Inferred Connection
-                </div>
+      {/* Edge detail overlay */}
+      <div style={{
+        position: 'absolute', bottom: 0, left: 0, right: 0,
+        background: 'var(--panel)', borderTop: '1px solid var(--border)',
+        padding: '10px 14px',
+        transform: activeEdge ? 'translateY(0)' : 'translateY(100%)',
+        opacity: activeEdge ? 1 : 0,
+        transition: 'transform 0.2s, opacity 0.2s',
+        pointerEvents: activeEdge ? 'auto' : 'none',
+      }}>
+        {activeEdge && (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 5, textAlign: 'center' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, background: 'var(--soft)', color: 'var(--fg)', padding: '2px 6px', borderRadius: 4 }}>
+                {activeEdge.data.source_collection}.{activeEdge.data.source_field}
+              </span>
+              <span style={{ color: 'var(--muted)', fontSize: 12 }}>→</span>
+              <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, background: 'var(--soft)', color: 'var(--fg)', padding: '2px 6px', borderRadius: 4 }}>
+                {activeEdge.data.target_collection}.{activeEdge.data.target_field}
+              </span>
             </div>
+            <p style={{ fontSize: 11.5, color: 'var(--muted)', margin: 0, lineHeight: 1.4 }}>
+              {activeEdge.data.description}
+            </p>
+          </div>
+        )}
+      </div>
 
-            <svg width="400" height="300" viewBox="0 0 400 300" className="w-full max-w-[500px] h-auto pointer-events-auto">
-                <defs>
-                    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="22" refY="3.5" orient="auto">
-                        <polygon points="0 0, 10 3.5, 0 7" fill="#64748b" className="dark:fill-slate-400" />
-                    </marker>
-                    <marker id="arrowhead-hover" markerWidth="10" markerHeight="7" refX="22" refY="3.5" orient="auto">
-                        <polygon points="0 0, 10 3.5, 0 7" fill="#3b82f6" />
-                    </marker>
-                    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
-                        <feGaussianBlur stdDeviation="2.5" result="coloredBlur" />
-                        <feMerge>
-                            <feMergeNode in="coloredBlur" />
-                            <feMergeNode in="SourceGraphic" />
-                        </feMerge>
-                    </filter>
-                </defs>
-
-                {/* Edges */}
-                {edges.map((edge, i) => {
-                    const isHovered = hoveredEdge === i;
-                    const pathData = getPath(edge.source, edge.target, i);
-
-                    return (
-                        <g
-                            key={i}
-                            onMouseEnter={() => setHoveredEdge(i)}
-                            onMouseLeave={() => setHoveredEdge(null)}
-                            className="transition-opacity duration-300"
-                            style={{ opacity: (hoveredEdge !== null && !isHovered) ? 0.3 : 1 }}
-                        >
-                            {/* Invisible wideline for easier hovering */}
-                            <path d={pathData} stroke="transparent" strokeWidth="20" fill="none" className="cursor-pointer" />
-
-                            {/* Visible line - No arrowheads */}
-                            <path
-                                d={pathData}
-                                stroke={isHovered ? "#3b82f6" : "#cbd5e1"}
-                                strokeWidth={isHovered ? 3 : 2}
-                                fill="none"
-                                className={`transition-colors duration-300 ${isHovered ? '' : 'dark:stroke-slate-600'}`}
-                            />
-
-                            {/* Animated particle flow only on hover */}
-                            {isHovered && (
-                                <circle r="3" fill="#3b82f6">
-                                    <animateMotion dur="1.5s" repeatCount="indefinite" path={pathData} />
-                                </circle>
-                            )}
-                        </g>
-                    );
-                })}
-
-                {/* Nodes */}
-                {nodes.map(node => {
-                    const isHovered = hoveredNode === node.id;
-                    const isRelatedToHoveredEdge = hoveredEdge !== null && (edges[hoveredEdge!].source.id === node.id || edges[hoveredEdge!].target.id === node.id);
-
-                    return (
-                        <g
-                            key={node.id}
-                            transform={`translate(${node.x},${node.y})`}
-                            onMouseEnter={() => setHoveredNode(node.id)}
-                            onMouseLeave={() => setHoveredNode(null)}
-                            className="cursor-pointer transition-all duration-300"
-                            style={{
-                                opacity: (hoveredEdge !== null && !isRelatedToHoveredEdge) ? 0.4 : 1
-                            }}
-                        >
-                            <circle
-                                r="30"
-                                fill={isHovered || isRelatedToHoveredEdge ? "#eff6ff" : "white"}
-                                stroke={isHovered || isRelatedToHoveredEdge ? "#3b82f6" : "#cbd5e1"}
-                                strokeWidth={isHovered ? 3 : 2}
-                                className={`transition-colors duration-300 dark:bg-slate-800 dark:fill-slate-800 ${isHovered ? '' : 'dark:stroke-slate-600'}`}
-                                filter={isHovered ? "url(#glow)" : ""}
-                            />
-                            {/* Full Name */}
-                            <text
-                                y="5"
-                                textAnchor="middle"
-                                alignmentBaseline="middle"
-                                className={`text-[10px] font-bold pointer-events-none custom-text-shadow ${isHovered ? 'fill-blue-600' : 'fill-slate-600 dark:fill-slate-300'}`}
-                                style={{ textShadow: '0 1px 2px rgba(255,255,255,0.8)' }}
-                            >
-                                {node.id}
-                            </text>
-                        </g>
-                    );
-                })}
-            </svg>
-
-            {/* Detail Card Overlay - Appears when hovering an edge */}
-            <div className={`absolute bottom-4 left-0 right-0 mx-auto w-[90%] bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm border border-slate-200 dark:border-slate-600 shadow-lg rounded-lg p-3 transition-transform duration-300 ${hoveredEdge !== null ? 'translate-y-0 opacity-100' : 'translate-y-10 opacity-0 pointer-events-none'}`}>
-                {hoveredEdge !== null && (
-                    <div className="flex flex-col items-center text-center">
-                        <div className="flex items-center gap-2 mb-1">
-                            <span className="font-mono bg-slate-100 dark:bg-slate-700 px-1.5 py-0.5 rounded text-xs text-slate-700 dark:text-slate-200 font-bold">
-                                {edges[hoveredEdge].data.source_collection}.{edges[hoveredEdge].data.source_field}
-                            </span>
-                            <span className="text-slate-400">→</span>
-                            <span className="font-mono bg-slate-100 dark:bg-slate-700 px-1.5 py-0.5 rounded text-xs text-slate-700 dark:text-slate-200 font-bold">
-                                {edges[hoveredEdge].data.target_collection}.{edges[hoveredEdge].data.target_field}
-                            </span>
-                        </div>
-                        <p className="text-xs text-slate-600 dark:text-slate-400">
-                            {edges[hoveredEdge].data.description}
-                        </p>
-                    </div>
-                )}
-            </div>
-
-            {/* Empty State Overlay */}
-            {edges.length === 0 && (
-                <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                    <div className="bg-white/80 dark:bg-slate-900/80 backdrop-blur p-4 rounded-lg text-center">
-                        <p className="text-slate-500 text-sm">No connections found</p>
-                    </div>
-                </div>
-            )}
-
+      {/* Empty state */}
+      {edges.length === 0 && (
+        <div style={{
+          position: 'absolute', inset: 0,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          pointerEvents: 'none',
+        }}>
+          <span style={{ fontSize: 12, color: 'var(--muted)' }}>No connections found between these collections</span>
         </div>
-    );
+      )}
+    </div>
+  );
 };
 
 export default SchemaRelationshipGraph;

--- a/frontend/components/ShareQueryDialog.tsx
+++ b/frontend/components/ShareQueryDialog.tsx
@@ -1,7 +1,7 @@
+
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { SavedQuery } from '../types';
-import { SpinnerIcon, XIcon, PlusCircleIcon, TrashIcon } from './icons/material-icons-imports';
 
 interface ShareQueryDialogProps {
   isOpen: boolean;
@@ -9,6 +9,13 @@ interface ShareQueryDialogProps {
   onSave: (updatedQuery: SavedQuery) => void;
   query: SavedQuery;
 }
+
+const fieldStyle: React.CSSProperties = {
+  flex: 1, padding: '7px 10px', background: 'var(--soft)',
+  border: '1px solid var(--border)', borderRadius: 6,
+  color: 'var(--fg)', fontFamily: 'var(--font-body)', fontSize: 13,
+  outline: 'none', boxSizing: 'border-box',
+};
 
 const ShareQueryDialog: React.FC<ShareQueryDialogProps> = ({ isOpen, onClose, onSave, query }) => {
   const [sharedWith, setSharedWith] = useState<string[]>([]);
@@ -25,158 +32,194 @@ const ShareQueryDialog: React.FC<ShareQueryDialogProps> = ({ isOpen, onClose, on
   }, [isOpen, query]);
 
   const handleAddEmail = () => {
-    const trimmedEmail = newEmail.trim().toLowerCase();
-    if (!trimmedEmail) return;
-
-    if (!/^\S+@\S+\.\S+$/.test(trimmedEmail)) {
-        setError('Please enter a valid email address.');
-        return;
-    }
-    if (sharedWith.includes(trimmedEmail)) {
-        setError('This email has already been added.');
-        return;
-    }
-    if (trimmedEmail === query.ownerEmail) {
-        setError('You cannot share a query with its owner.');
-        return;
-    }
-
-    setSharedWith([...sharedWith, trimmedEmail]);
+    const trimmed = newEmail.trim().toLowerCase();
+    if (!trimmed) return;
+    if (!/^\S+@\S+\.\S+$/.test(trimmed)) { setError('Please enter a valid email address.'); return; }
+    if (sharedWith.includes(trimmed)) { setError('This email has already been added.'); return; }
+    if (trimmed === query.ownerEmail) { setError('You cannot share a query with its owner.'); return; }
+    setSharedWith([...sharedWith, trimmed]);
     setNewEmail('');
     setError('');
   };
 
-  const handleRemoveEmail = (emailToRemove: string) => {
-    setSharedWith(sharedWith.filter(email => email !== emailToRemove));
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') { e.preventDefault(); handleAddEmail(); }
+  };
+
+  const handleRemoveEmail = (email: string) => {
+    setSharedWith(sharedWith.filter(e => e !== email));
   };
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSaving(true);
-    const updatedQuery = { ...query, sharedWith };
-    await onSave(updatedQuery);
+    await onSave({ ...query, sharedWith });
     setIsSaving(false);
   };
-  
+
   if (!isOpen) return null;
 
   return createPortal(
-    <div className="fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4 animate-fade-in-fast">
-      <div 
-        className="bg-white dark:bg-slate-800 rounded-xl shadow-2xl w-full max-w-lg transform transition-all animate-scale-in"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="dialog-title"
-      >
-        <form onSubmit={handleSave}>
-          <header className="flex items-center justify-between p-4 sm:p-6 border-b border-slate-200 dark:border-slate-700">
-            <div>
-                <h2 id="dialog-title" className="text-xl font-bold text-slate-900 dark:text-slate-100">
-                Share Query
-                </h2>
-                <p className="text-sm text-slate-500 dark:text-slate-400 max-w-sm truncate" title={query.name}>
-                    {query.name}
-                </p>
-            </div>
-            <button
-              type="button"
-              onClick={onClose}
-              className="p-1.5 rounded-full text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
-              aria-label="Close dialog"
-              title="Close dialog"
-            >
-              <XIcon className="w-5 h-5" />
-            </button>
-          </header>
+    <>
+      <style>{`
+        @keyframes qp-dialog-in {
+          from { opacity: 0; transform: scale(0.96) translateY(4px); }
+          to   { opacity: 1; transform: scale(1)    translateY(0); }
+        }
+        .qp-dialog-box { animation: qp-dialog-in 0.18s cubic-bezier(0.16,1,0.3,1); }
+        .qp-share-field:focus { border-color: var(--accent) !important; outline: none; }
+      `}</style>
 
-          <main className="p-4 sm:p-6 space-y-4 max-h-[60vh] overflow-y-auto">
-            <div>
-              <label htmlFor="share-email" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-                Add people by email
-              </label>
-              <div className="flex items-center gap-2">
-                <input
-                    id="share-email"
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.35)', zIndex: 50, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16 }}
+      >
+        {/* Dialog */}
+        <div
+          className="qp-dialog-box"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="sqdlg-title"
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            background: 'var(--panel)', border: '1px solid var(--border)',
+            borderRadius: 12, width: '100%', maxWidth: 520,
+            boxShadow: '0 20px 60px rgba(0,0,0,0.14)',
+            fontFamily: 'var(--font-body)', display: 'flex', flexDirection: 'column',
+          }}
+        >
+          <form onSubmit={handleSave} style={{ display: 'flex', flexDirection: 'column' }}>
+            {/* Header */}
+            <div style={{ display: 'flex', alignItems: 'flex-start', padding: '14px 18px', borderBottom: '1px solid var(--border)', gap: 10 }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div id="sqdlg-title" style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)' }}>Share query</div>
+                <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{query.name}</div>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close"
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex', padding: 4, borderRadius: 5, flexShrink: 0 }}
+              >
+                <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <path d="M3 3l10 10M13 3L3 13"/>
+                </svg>
+              </button>
+            </div>
+
+            {/* Body */}
+            <div style={{ padding: '16px 18px', display: 'flex', flexDirection: 'column', gap: 16, maxHeight: '60vh', overflowY: 'auto' }}>
+              {/* Add email row */}
+              <div>
+                <label htmlFor="sqdlg-email" style={{ fontSize: 11.5, fontWeight: 500, color: 'var(--fg)', display: 'block', marginBottom: 6 }}>
+                  Add people by email
+                </label>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <input
+                    id="sqdlg-email"
                     type="email"
                     value={newEmail}
-                    onChange={(e) => {
-                        setNewEmail(e.target.value);
-                        setError(''); // Clear error on type
-                    }}
-                    className="flex-grow p-2 bg-slate-50 dark:bg-slate-700/50 border border-slate-300 dark:border-slate-600 rounded-lg text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    placeholder="e.g., colleague@example.com"
-                />
-                <button 
+                    onChange={(e) => { setNewEmail(e.target.value); setError(''); }}
+                    onKeyDown={handleKeyDown}
+                    className="qp-share-field"
+                    style={fieldStyle}
+                    placeholder="colleague@example.com"
+                  />
+                  <button
                     type="button"
                     onClick={handleAddEmail}
-                    className="p-2 rounded-full text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/40 transition-colors"
-                    title="Add email"
-                >
-                    <PlusCircleIcon className="w-6 h-6"/>
-                </button>
+                    className="qa-btn"
+                    style={{ fontSize: 12, padding: '7px 12px', flexShrink: 0 }}
+                  >
+                    Add
+                  </button>
+                </div>
+                {error && <p style={{ fontSize: 11.5, color: 'var(--status-err)', marginTop: 4, margin: '4px 0 0' }}>{error}</p>}
               </div>
-              {error && <p className="text-red-500 text-xs mt-1">{error}</p>}
-            </div>
 
-            <div className="space-y-2">
-                 <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300">People with access</h3>
-                 <div className="space-y-2">
-                    <div className="flex items-center justify-between bg-slate-100 dark:bg-slate-700/50 p-2 rounded-lg">
-                        <span className="text-sm font-semibold text-slate-800 dark:text-slate-200">{query.ownerEmail}</span>
-                        <span className="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase">Owner</span>
+              {/* People with access */}
+              <div>
+                <div style={{ fontSize: 11.5, fontWeight: 500, color: 'var(--fg)', marginBottom: 8 }}>People with access</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  {/* Owner row */}
+                  <div style={{
+                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                    padding: '7px 10px', background: 'var(--soft)', borderRadius: 7,
+                  }}>
+                    <span style={{ fontSize: 13, color: 'var(--fg)', fontWeight: 500 }}>{query.ownerEmail}</span>
+                    <span style={{
+                      fontSize: 10.5, color: 'var(--accent)', fontWeight: 600, textTransform: 'uppercase',
+                      letterSpacing: '0.05em', background: 'var(--accent-soft)', padding: '2px 7px', borderRadius: 4,
+                    }}>Owner</span>
+                  </div>
+
+                  {/* Shared-with rows */}
+                  {sharedWith.map(email => (
+                    <div
+                      key={email}
+                      style={{
+                        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                        padding: '7px 10px', background: 'var(--soft)', borderRadius: 7,
+                      }}
+                    >
+                      <span style={{ fontSize: 13, color: 'var(--fg)' }}>{email}</span>
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveEmail(email)}
+                        aria-label={`Remove ${email}`}
+                        style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex', padding: 4, borderRadius: 4 }}
+                        onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--status-err)'; }}
+                        onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
+                      >
+                        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                          <path d="M2 4h12M5 4V3a1 1 0 011-1h4a1 1 0 011 1v1M6 7v5M10 7v5M3 4l1 9a1 1 0 001 1h6a1 1 0 001-1l1-9"/>
+                        </svg>
+                      </button>
                     </div>
-                    {sharedWith.map(email => (
-                         <div key={email} className="flex items-center justify-between bg-slate-100 dark:bg-slate-700/50 p-2 rounded-lg animate-fade-in">
-                            <span className="text-sm text-slate-600 dark:text-slate-300">{email}</span>
-                            <button
-                                type="button"
-                                onClick={() => handleRemoveEmail(email)}
-                                className="p-1 rounded-full text-slate-500 hover:bg-red-200 dark:hover:bg-red-900/50 hover:text-red-600 dark:hover:text-red-400"
-                                title="Remove access"
-                            >
-                                <TrashIcon className="w-4 h-4"/>
-                            </button>
-                        </div>
-                    ))}
-                    {sharedWith.length === 0 && (
-                        <p className="text-xs text-slate-500 dark:text-slate-400 text-center py-2">Not shared with anyone yet.</p>
-                    )}
-                 </div>
+                  ))}
+
+                  {sharedWith.length === 0 && (
+                    <p style={{ fontSize: 12, color: 'var(--muted)', textAlign: 'center', padding: '8px 0', margin: 0 }}>
+                      Not shared with anyone yet.
+                    </p>
+                  )}
+                </div>
+              </div>
             </div>
 
-          </main>
-
-          <footer className="flex justify-end items-center gap-3 p-4 bg-slate-50 dark:bg-slate-800/50 border-t border-slate-200 dark:border-slate-700">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={isSaving}
-              className="px-4 py-2 border border-slate-300 dark:border-slate-600 text-sm font-medium rounded-md text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-700 hover:bg-slate-50 dark:hover:bg-slate-600 transition-colors disabled:opacity-50"
-              title="Discard changes and close"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={isSaving}
-              className="w-28 flex justify-center items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-slate-400 dark:disabled:bg-slate-600 disabled:cursor-not-allowed transition-colors"
-              title="Save sharing settings"
-            >
-              {isSaving ? <SpinnerIcon className="w-5 h-5"/> : 'Done'}
-            </button>
-          </footer>
-        </form>
+            {/* Footer */}
+            <div style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8,
+              padding: '12px 18px', borderTop: '1px solid var(--border)',
+              background: 'var(--soft)', borderRadius: '0 0 12px 12px',
+            }}>
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isSaving}
+                className="qa-btn"
+                style={{ fontSize: 13 }}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={isSaving}
+                className="qa-btn primary"
+                style={{ fontSize: 13, minWidth: 72, justifyContent: 'center', opacity: isSaving ? 0.6 : 1 }}
+              >
+                {isSaving ? (
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ animation: 'qp-spin 0.8s linear infinite' }}>
+                    <circle cx="8" cy="8" r="6" strokeOpacity="0.3"/><path d="M8 2a6 6 0 0 1 6 6"/>
+                  </svg>
+                ) : 'Done'}
+              </button>
+            </div>
+          </form>
+        </div>
       </div>
-       <style>{`
-          @keyframes scale-in {
-              from { opacity: 0; transform: scale(0.95); }
-              to { opacity: 1; transform: scale(1); }
-          }
-          .animate-scale-in {
-              animation: scale-in 0.2s ease-out forwards;
-          }
-      `}</style>
-    </div>,
+    </>,
     document.body
   );
 };

--- a/frontend/components/ShortcutCheatsheet.tsx
+++ b/frontend/components/ShortcutCheatsheet.tsx
@@ -1,7 +1,6 @@
 
 import React from 'react';
 import { createPortal } from 'react-dom';
-import { KeyboardIcon, XIcon } from './icons/material-icons-imports';
 
 interface ShortcutCheatsheetProps {
   isOpen: boolean;
@@ -9,72 +8,112 @@ interface ShortcutCheatsheetProps {
 }
 
 const Kbd: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-    <kbd className="px-2 py-1.5 text-xs font-semibold text-slate-700 bg-slate-200 border border-slate-300 rounded-md dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600">
-        {children}
-    </kbd>
+  <kbd style={{
+    padding: '3px 7px', fontSize: 11.5, fontFamily: 'var(--font-mono)',
+    color: 'var(--fg)', background: 'var(--soft)', border: '1px solid var(--border)',
+    borderRadius: 5, lineHeight: 1,
+  }}>
+    {children}
+  </kbd>
 );
 
 const ShortcutItem: React.FC<{ keys: string[]; description: string }> = ({ keys, description }) => (
-    <div className="flex items-center justify-between p-3 bg-slate-100 dark:bg-slate-700/50 rounded-lg">
-        <span className="text-sm text-slate-800 dark:text-slate-200">{description}</span>
-        <div className="flex items-center gap-1">
-            {keys.map((key, index) => (
-                <React.Fragment key={key}>
-                    <Kbd>{key}</Kbd>
-                    {index < keys.length - 1 && <span className="text-slate-400">+</span>}
-                </React.Fragment>
-            ))}
-        </div>
+  <div style={{
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+    padding: '8px 10px', background: 'var(--soft)', borderRadius: 7,
+  }}>
+    <span style={{ fontSize: 13, color: 'var(--fg)' }}>{description}</span>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+      {keys.map((key, i) => (
+        <React.Fragment key={key}>
+          <Kbd>{key}</Kbd>
+          {i < keys.length - 1 && <span style={{ fontSize: 11, color: 'var(--muted)' }}>+</span>}
+        </React.Fragment>
+      ))}
     </div>
+  </div>
 );
 
 const ShortcutCheatsheet: React.FC<ShortcutCheatsheetProps> = ({ isOpen, onClose }) => {
   if (!isOpen) return null;
 
-  const isMac = typeof window !== 'undefined' && navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-  const commandKey = isMac ? '⌘' : 'Ctrl';
+  const cmd = typeof window !== 'undefined' && /mac/i.test(navigator.platform) ? '⌘' : 'Ctrl';
 
   return createPortal(
-    <div className="fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4 animate-fade-in-fast">
-      <div 
-        className="bg-white dark:bg-slate-800 rounded-xl shadow-2xl w-full max-w-lg transform transition-all animate-scale-in"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="dialog-title"
-      >
-        <header className="flex items-center justify-between p-4 sm:p-6 border-b border-slate-200 dark:border-slate-700">
-          <h2 id="dialog-title" className="text-xl font-bold text-slate-900 dark:text-slate-100 flex items-center gap-3">
-            <KeyboardIcon className="w-6 h-6" />
-            Keyboard Shortcuts
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="p-1.5 rounded-full text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
-            aria-label="Close dialog"
-          >
-            <XIcon className="w-5 h-5" />
-          </button>
-        </header>
-
-        <main className="p-4 sm:p-6 space-y-3">
-            <ShortcutItem keys={[commandKey, 'Enter']} description="Run Query (in editor)" />
-            <ShortcutItem keys={[commandKey, 'G']} description="Generate Query (in prompt)" />
-            <ShortcutItem keys={[commandKey, 'S']} description="Save Current Query" />
-            <ShortcutItem keys={[commandKey, '/']} description="Show This Cheatsheet" />
-            <ShortcutItem keys={['Esc']} description="Close Dialog or Panel" />
-        </main>
-      </div>
+    <>
       <style>{`
-          @keyframes scale-in {
-              from { opacity: 0; transform: scale(0.95); }
-              to { opacity: 1; transform: scale(1); }
-          }
-          .animate-scale-in {
-              animation: scale-in 0.2s ease-out forwards;
-          }
+        @keyframes qp-dialog-in {
+          from { opacity: 0; transform: scale(0.96) translateY(4px); }
+          to   { opacity: 1; transform: scale(1)    translateY(0); }
+        }
+        .qp-dialog-box { animation: qp-dialog-in 0.18s cubic-bezier(0.16,1,0.3,1); }
       `}</style>
-    </div>,
+
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.35)', zIndex: 50, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16 }}
+      >
+        {/* Dialog */}
+        <div
+          className="qp-dialog-box"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="sc-title"
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            background: 'var(--panel)', border: '1px solid var(--border)',
+            borderRadius: 12, width: '100%', maxWidth: 480,
+            boxShadow: '0 20px 60px rgba(0,0,0,0.14)',
+            fontFamily: 'var(--font-body)',
+          }}
+        >
+          {/* Header */}
+          <div style={{ display: 'flex', alignItems: 'center', padding: '14px 18px', borderBottom: '1px solid var(--border)' }}>
+            <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.4" style={{ marginRight: 8, flexShrink: 0 }}>
+              <rect x="1" y="4" width="14" height="9" rx="2"/>
+              <path d="M4 7h1M7 7h1M10 7h1M4 10h2M9 10h3"/>
+            </svg>
+            <span id="sc-title" style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)' }}>Keyboard shortcuts</span>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              style={{ marginLeft: 'auto', background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex', padding: 4, borderRadius: 5 }}
+            >
+              <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M3 3l10 10M13 3L3 13"/>
+              </svg>
+            </button>
+          </div>
+
+          {/* Body */}
+          <div style={{ padding: '14px 18px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <ShortcutItem keys={[cmd, 'Enter']} description="Run query (in editor)" />
+            <ShortcutItem keys={[cmd, 'G']} description="Generate query (in prompt)" />
+            <ShortcutItem keys={[cmd, 'S']} description="Save current query" />
+            <ShortcutItem keys={[cmd, '/']} description="Show this cheatsheet" />
+            <ShortcutItem keys={['Esc']} description="Close dialog or panel" />
+          </div>
+
+          {/* Footer */}
+          <div style={{
+            display: 'flex', justifyContent: 'flex-end',
+            padding: '10px 18px', borderTop: '1px solid var(--border)',
+            background: 'var(--soft)', borderRadius: '0 0 12px 12px',
+          }}>
+            <button
+              type="button"
+              onClick={onClose}
+              className="qa-btn"
+              style={{ fontSize: 13 }}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </>,
     document.body
   );
 };

--- a/frontend/contexts/ThemeContext.tsx
+++ b/frontend/contexts/ThemeContext.tsx
@@ -10,13 +10,17 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const [theme, setTheme] = useState<Theme>('light');
+  const [theme, setTheme] = useState<Theme>(() => {
+    const saved = localStorage.getItem('theme') as Theme | null;
+    if (saved === 'dark' || saved === 'light') return saved;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
 
   useEffect(() => {
     const root = window.document.documentElement;
-    const initialTheme = root.classList.contains('dark') ? 'dark' : 'light';
-    setTheme(initialTheme);
-  }, []);
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+  }, [theme]);
 
   const toggleTheme = () => {
     const newTheme = theme === 'light' ? 'dark' : 'light';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>QueryPal</title>
+    <link rel="stylesheet" href="/src/design-tokens.css" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/frontend/pages/AnalyticsPage.tsx
+++ b/frontend/pages/AnalyticsPage.tsx
@@ -1,248 +1,200 @@
 import React from 'react';
-import AppLayout from '../components/AppLayout';
 
-/* Static demo data matching the design's QP_DATA shape */
-const runs14d = [42, 38, 51, 47, 55, 49, 62, 58, 71, 67, 74, 69, 82, 78];
-const fails14d = [3, 2, 4, 3, 5, 4, 6, 3, 5, 4, 7, 5, 4, 6];
-const studiesByMonth = [78, 84, 72, 91, 103, 118, 127, 134, 142, 128, 151, 164];
-const MONTHS = ['Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec', 'Jan', 'Feb', 'Mar', 'Apr', 'May'];
-const BY_DEPT = [
-  { name: 'Cardiac', count: 524, pct: 43 },
-  { name: 'Ortho', count: 318, pct: 26 },
-  { name: 'Vascular', count: 187, pct: 15 },
-  { name: 'Neuro', count: 142, pct: 12 },
-  { name: 'Other', count: 76, pct: 4 },
-];
-const DEPT_COLORS = ['var(--accent)', '#7c8a4a', '#4a7c8a', '#8a4a7c', '#a89070'];
+interface AnalyticsPageProps {
+  accountId?: string;
+  databaseName?: string;
+}
 
-const SCATTER = [
-  { x: 0.8, y: 1.94, ok: true }, { x: 1.2, y: 2.14, ok: true }, { x: 1.6, y: 1.71, ok: true },
-  { x: 2.0, y: 1.42, ok: false }, { x: 0.4, y: 2.62, ok: true }, { x: 1.0, y: 2.04, ok: true },
-  { x: 1.8, y: 1.62, ok: false }, { x: 2.4, y: 1.18, ok: false }, { x: 0.6, y: 2.81, ok: true },
-  { x: 1.4, y: 1.88, ok: true }, { x: 2.2, y: 1.51, ok: false }, { x: 0.9, y: 2.32, ok: true },
-  { x: 1.1, y: 2.21, ok: true }, { x: 1.7, y: 1.55, ok: false }, { x: 0.5, y: 2.94, ok: true },
-];
+const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName }) => {
+  const hasConnection = !!(accountId && databaseName);
 
-/* ── Sparkline (140×36 SVG) ── */
-const Sparkline: React.FC<{ data: number[]; color?: string; fill?: boolean }> = ({
-  data, color = 'var(--accent)', fill = true,
-}) => {
-  const W = 140, H = 36, pad = 2;
-  const min = Math.min(...data), max = Math.max(...data);
-  const range = max - min || 1;
-  const pts = data.map((v, i) => ({
-    x: pad + (i / (data.length - 1)) * (W - pad * 2),
-    y: H - pad - ((v - min) / range) * (H - pad * 2),
-  }));
-  const path = pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
-  const fillPath = `${path} L${pts[pts.length - 1].x},${H} L${pts[0].x},${H} Z`;
   return (
-    <svg width={W} height={H} style={{ overflow: 'visible' }}>
-      {fill && (
-        <defs>
-          <linearGradient id={`sg-${color.replace(/[^a-z]/gi, '')}`} x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor={color} stopOpacity="0.2"/>
-            <stop offset="100%" stopColor={color} stopOpacity="0"/>
-          </linearGradient>
-        </defs>
-      )}
-      {fill && <path d={fillPath} fill={`url(#sg-${color.replace(/[^a-z]/gi, '')})`}/>}
-      <path d={path} fill="none" stroke={color} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round"/>
-    </svg>
-  );
-};
-
-/* ── Area chart (full width) ── */
-const AreaChart: React.FC<{ data: number[]; labels: string[] }> = ({ data, labels }) => {
-  const W = 600, H = 160, padL = 36, padB = 24, padR = 16, padT = 12;
-  const iW = W - padL - padR, iH = H - padB - padT;
-  const min = 0, max = Math.max(...data) * 1.1;
-  const xs = data.map((_, i) => padL + (i / (data.length - 1)) * iW);
-  const ys = data.map((v) => padT + iH - ((v - min) / (max - min)) * iH);
-  const path = xs.map((x, i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${ys[i].toFixed(1)}`).join(' ');
-  const fillPath = `${path} L${xs[xs.length - 1]},${padT + iH} L${xs[0]},${padT + iH} Z`;
-  const yTicks = [0, Math.round(max * 0.25), Math.round(max * 0.5), Math.round(max * 0.75), Math.round(max)];
-  return (
-    <svg viewBox={`0 0 ${W} ${H}`} style={{ width: '100%', height: 'auto', overflow: 'visible' }}>
-      <defs>
-        <linearGradient id="area-fill" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.25"/>
-          <stop offset="100%" stopColor="var(--accent)" stopOpacity="0"/>
-        </linearGradient>
-      </defs>
-      {/* Grid lines */}
-      {yTicks.map((t) => {
-        const y = padT + iH - ((t - min) / (max - min)) * iH;
-        return (
-          <g key={t}>
-            <line x1={padL} y1={y} x2={W - padR} y2={y} stroke="var(--border)" strokeWidth="1"/>
-            <text x={padL - 4} y={y + 3.5} textAnchor="end" fontSize="9" fill="var(--muted)">{t}</text>
-          </g>
-        );
-      })}
-      {/* X labels */}
-      {xs.map((x, i) => (
-        <text key={i} x={x} y={H - 6} textAnchor="middle" fontSize="9" fill="var(--muted)">{labels[i]}</text>
-      ))}
-      <path d={fillPath} fill="url(#area-fill)"/>
-      <path d={path} fill="none" stroke="var(--accent)" strokeWidth="2" strokeLinejoin="round" strokeLinecap="round"/>
-      {/* Dots on last point */}
-      <circle cx={xs[xs.length - 1]} cy={ys[ys.length - 1]} r="4" fill="var(--accent)" stroke="var(--panel)" strokeWidth="2"/>
-    </svg>
-  );
-};
-
-/* ── Donut chart ── */
-const DonutChart: React.FC<{ data: typeof BY_DEPT }> = ({ data }) => {
-  const R = 52, cx = 70, cy = 70, strokeW = 20;
-  const total = data.reduce((s, d) => s + d.count, 0);
-  let angle = -Math.PI / 2;
-  const arcs = data.map((d, i) => {
-    const sweep = (d.count / total) * 2 * Math.PI;
-    const x1 = cx + R * Math.cos(angle);
-    const y1 = cy + R * Math.sin(angle);
-    angle += sweep;
-    const x2 = cx + R * Math.cos(angle);
-    const y2 = cy + R * Math.sin(angle);
-    return { x1, y1, x2, y2, sweep, large: sweep > Math.PI ? 1 : 0, color: DEPT_COLORS[i], ...d };
-  });
-  return (
-    <div style={{ display: 'flex', gap: 20, alignItems: 'center' }}>
-      <svg width="140" height="140" viewBox="0 0 140 140">
-        {arcs.map((a, i) => {
-          const d = `M${a.x1.toFixed(2)},${a.y1.toFixed(2)} A${R},${R} 0 ${a.large},1 ${a.x2.toFixed(2)},${a.y2.toFixed(2)}`;
-          return <path key={i} d={d} fill="none" stroke={a.color} strokeWidth={strokeW} strokeLinecap="butt"/>;
-        })}
-        <text x={cx} y={cy + 4} textAnchor="middle" fontSize="18" fontWeight="500" fill="var(--fg)" fontFamily="var(--font-display)">{total.toLocaleString()}</text>
-        <text x={cx} y={cy + 18} textAnchor="middle" fontSize="9" fill="var(--muted)">studies</text>
-      </svg>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-        {arcs.map((a, i) => (
-          <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 7, fontSize: 12 }}>
-            <span style={{ width: 8, height: 8, borderRadius: '50%', background: a.color, flexShrink: 0 }}/>
-            <span style={{ color: 'var(--muted)' }}>{a.name}</span>
-            <span style={{ marginLeft: 'auto', fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg)' }}>{a.pct}%</span>
+    <div style={{
+      flex: 1, display: 'flex', flexDirection: 'column',
+      background: 'var(--bg)', minHeight: 0,
+    }}>
+      {/* Page header */}
+      <div style={{
+        padding: '20px 28px 16px',
+        borderBottom: '1px solid var(--border)',
+        background: 'var(--panel)',
+        flexShrink: 0,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <div style={{
+            width: 32, height: 32, borderRadius: 8, flexShrink: 0,
+            background: 'var(--accent-soft)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.4">
+              <path d="M2 13h12M4 11V6M7 11V3M10 11V8M13 11V5"/>
+            </svg>
           </div>
-        ))}
-      </div>
-    </div>
-  );
-};
-
-/* ── Scatter plot ── */
-const ScatterPlot: React.FC<{ data: typeof SCATTER }> = ({ data }) => {
-  const W = 260, H = 160, padL = 36, padB = 28, padR = 16, padT = 12;
-  const iW = W - padL - padR, iH = H - padB - padT;
-  const xMin = 0, xMax = 2.8, yMin = 1, yMax = 3.2;
-  const toX = (v: number) => padL + ((v - xMin) / (xMax - xMin)) * iW;
-  const toY = (v: number) => padT + iH - ((v - yMin) / (yMax - yMin)) * iH;
-  const thresholdY = toY(2.0);
-  return (
-    <svg viewBox={`0 0 ${W} ${H}`} style={{ width: '100%', height: 'auto', overflow: 'visible' }}>
-      {/* Threshold line */}
-      <line x1={padL} y1={thresholdY} x2={W - padR} y2={thresholdY} stroke="var(--status-err)" strokeWidth="1" strokeDasharray="4 3"/>
-      <text x={W - padR + 2} y={thresholdY + 3} fontSize="8" fill="var(--status-err)">SF 2.0</text>
-      {/* Axes */}
-      <line x1={padL} y1={padT} x2={padL} y2={padT + iH} stroke="var(--border)" strokeWidth="1"/>
-      <line x1={padL} y1={padT + iH} x2={W - padR} y2={padT + iH} stroke="var(--border)" strokeWidth="1"/>
-      <text x={padL - 4} y={padT + 4} textAnchor="end" fontSize="8" fill="var(--muted)">SF</text>
-      <text x={(padL + W - padR) / 2} y={H - 2} textAnchor="middle" fontSize="8" fill="var(--muted)">Mesh size (M elements)</text>
-      {/* Points */}
-      {data.map((pt, i) => (
-        <circle
-          key={i}
-          cx={toX(pt.x)} cy={toY(pt.y)} r="4"
-          fill={pt.ok ? 'var(--accent)' : 'var(--status-err)'}
-          fillOpacity="0.7"
-          stroke={pt.ok ? 'var(--accent)' : 'var(--status-err)'}
-          strokeWidth="1"
-        />
-      ))}
-    </svg>
-  );
-};
-
-/* ── KPI card ── */
-const KpiCard: React.FC<{
-  label: string;
-  value: string;
-  delta?: string;
-  positive?: boolean;
-  sparkData?: number[];
-  sparkColor?: string;
-}> = ({ label, value, delta, positive, sparkData, sparkColor }) => (
-  <div style={{ background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 12, padding: 18, display: 'flex', flexDirection: 'column', gap: 10 }}>
-    <div style={{ fontSize: 11, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>{label}</div>
-    <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', gap: 8 }}>
-      <div>
-        <div style={{ fontSize: 26, fontWeight: 500, fontFamily: 'var(--font-display)', letterSpacing: '-0.02em', lineHeight: 1.1 }}>{value}</div>
-        {delta && (
-          <div style={{ fontSize: 11.5, color: positive ? 'var(--accent)' : 'var(--status-err)', marginTop: 4 }}>
-            {positive ? '↑' : '↓'} {delta} vs prev 14d
-          </div>
-        )}
-      </div>
-      {sparkData && <Sparkline data={sparkData} color={sparkColor || 'var(--accent)'} fill />}
-    </div>
-  </div>
-);
-
-/* ──────────────────────────────────────────────────────────── */
-
-const AnalyticsPage: React.FC = () => {
-  const totalRuns = runs14d.reduce((a, b) => a + b, 0);
-  const totalFails = fails14d.reduce((a, b) => a + b, 0);
-
-  return (
-    <AppLayout>
-      <div style={{ padding: '28px 32px', maxWidth: 1100, minWidth: 0 }}>
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 24 }}>
           <div>
-            <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 22, letterSpacing: '-0.02em', margin: 0 }}>
+            <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
               Analytics
-            </h1>
-            <p style={{ fontSize: 12.5, color: 'var(--muted)', margin: '4px 0 0' }}>
-              Last updated · {new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+            </div>
+            {hasConnection && (
+              <div style={{ fontSize: 11.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)', marginTop: 1 }}>
+                {databaseName}
+              </div>
+            )}
+          </div>
+          <span className="qa-chip accent" style={{ marginLeft: 6 }}>Coming soon</span>
+        </div>
+      </div>
+
+      {/* Coming soon body */}
+      <div style={{
+        flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: '48px 32px',
+      }}>
+        <div style={{
+          maxWidth: 560, width: '100%',
+          display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 32,
+          textAlign: 'center',
+        }}>
+          {/* Icon cluster */}
+          <div style={{ position: 'relative', width: 80, height: 80 }}>
+            <div style={{
+              width: 80, height: 80, borderRadius: 20,
+              background: 'var(--accent-soft)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}>
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M3 18h18M6 14V9M9 14V5M12 14v-3M15 14V7M18 14v-6"/>
+              </svg>
+            </div>
+            {/* Small badge */}
+            <div style={{
+              position: 'absolute', bottom: -6, right: -6,
+              width: 24, height: 24, borderRadius: 8,
+              background: 'var(--panel)', border: '1px solid var(--border)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
+            }}>
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="var(--muted)" strokeWidth="1.5">
+                <circle cx="8" cy="8" r="6"/><path d="M8 5v4M8 10.5v.5"/>
+              </svg>
+            </div>
+          </div>
+
+          {/* Heading */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <h2 style={{
+              fontSize: 22, fontWeight: 600, margin: 0,
+              fontFamily: 'var(--font-display)', color: 'var(--fg)',
+              letterSpacing: '-0.02em',
+            }}>
+              Database Audit & Insights
+            </h2>
+            <p style={{
+              fontSize: 13.5, color: 'var(--muted)', margin: 0, lineHeight: 1.6,
+              fontFamily: 'var(--font-body)',
+            }}>
+              {"This tab will surface automated collection audits powered by "}
+              <span style={{ color: 'var(--fg)', fontWeight: 500 }}>QueryArgus</span>
+              {" — an AI agent that analyses your collections for schema inconsistencies, missing indexes, high-cardinality fields, and query performance opportunities."}
             </p>
           </div>
-          <button className="qa-btn">
-            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-              <path d="M14 8A6 6 0 112 8M14 8l-2-2M14 8l-2 2"/>
-            </svg>
-            Refresh
-          </button>
-        </div>
 
-        {/* KPI row */}
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 14, marginBottom: 24 }}>
-          <KpiCard label="Studies run (14d)" value={totalRuns.toLocaleString()} delta="12%" positive sparkData={runs14d} />
-          <KpiCard label="Diverged (14d)" value={totalFails.toLocaleString()} delta="8%" positive={false} sparkData={fails14d} sparkColor="var(--status-err)" />
-          <KpiCard label="Avg safety factor" value="1.92" delta="0.07" positive={false} sparkData={runs14d.map(v => v / 40 + 1.6)} />
-          <KpiCard label="Avg runtime" value="3h 24m" delta="11m" positive sparkData={runs14d.map(v => v / 82 * 3.6 + 1.2)} />
-        </div>
-
-        {/* Charts row 1 */}
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 20, marginBottom: 20 }}>
-          {/* Area chart */}
-          <div style={{ background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 12, padding: 22 }}>
-            <div style={{ fontSize: 12, fontWeight: 500, marginBottom: 14, color: 'var(--fg)' }}>Studies completed by month</div>
-            <AreaChart data={studiesByMonth} labels={MONTHS} />
+          {/* Feature preview cards */}
+          <div style={{
+            width: '100%', display: 'grid',
+            gridTemplateColumns: '1fr 1fr', gap: 12,
+          }}>
+            {[
+              {
+                icon: (
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+                    <path d="M3 2h7l3 3v9H3z"/><path d="M6 7h5M6 9h5M6 11h3"/>
+                  </svg>
+                ),
+                title: 'Schema findings',
+                desc: 'Inconsistent field types, sparse fields, and structural anomalies across documents.',
+              },
+              {
+                icon: (
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+                    <path d="M2 13h12M4 11V6M7 11V3M10 11V8M13 11V5"/>
+                  </svg>
+                ),
+                title: 'Performance insights',
+                desc: 'Missing index recommendations, high-cardinality fields, and costly query patterns.',
+              },
+              {
+                icon: (
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+                    <circle cx="8" cy="8" r="6"/><path d="M8 5v3.5L10 10"/>
+                  </svg>
+                ),
+                title: 'Audit history',
+                desc: 'Track findings over time to measure how your database health evolves.',
+              },
+              {
+                icon: (
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+                    <path d="M8 1L15 14H1L8 1z"/><path d="M8 6v4M8 11.5v.5"/>
+                  </svg>
+                ),
+                title: 'Severity scoring',
+                desc: 'Each finding is evaluated and scored so you can triage the most impactful issues first.',
+              },
+            ].map(({ icon, title, desc }) => (
+              <div key={title} style={{
+                background: 'var(--panel)', border: '1px solid var(--border)',
+                borderRadius: 10, padding: '14px 16px',
+                display: 'flex', flexDirection: 'column', gap: 6,
+                textAlign: 'left',
+              }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+                  <span style={{ color: 'var(--accent)', display: 'flex', flexShrink: 0 }}>{icon}</span>
+                  <span style={{ fontSize: 12.5, fontWeight: 500, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
+                    {title}
+                  </span>
+                </div>
+                <p style={{ fontSize: 12, color: 'var(--muted)', margin: 0, lineHeight: 1.5, fontFamily: 'var(--font-body)' }}>
+                  {desc}
+                </p>
+              </div>
+            ))}
           </div>
-          {/* Donut */}
-          <div style={{ background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 12, padding: 22, minWidth: 260 }}>
-            <div style={{ fontSize: 12, fontWeight: 500, marginBottom: 14, color: 'var(--fg)' }}>By department</div>
-            <DonutChart data={BY_DEPT} />
-          </div>
-        </div>
 
-        {/* Charts row 2 */}
-        <div style={{ background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 12, padding: 22, maxWidth: 380 }}>
-          <div style={{ fontSize: 12, fontWeight: 500, marginBottom: 14, color: 'var(--fg)' }}>Mesh size vs. safety factor</div>
-          <ScatterPlot data={SCATTER} />
+          {/* Context note */}
+          {hasConnection ? (
+            <div style={{
+              display: 'flex', alignItems: 'center', gap: 8,
+              padding: '10px 16px', borderRadius: 8,
+              background: 'var(--accent-soft)',
+              border: '1px solid color-mix(in oklch, var(--accent) 20%, var(--border))',
+            }}>
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.5" style={{ flexShrink: 0 }}>
+                <circle cx="8" cy="8" r="6"/><path d="M8 7v4M8 5.5v.5"/>
+              </svg>
+              <span style={{ fontSize: 12, color: 'var(--accent)', fontFamily: 'var(--font-body)' }}>
+                {"When available, audits will run against "}
+                <span style={{ fontFamily: 'var(--font-mono)', fontWeight: 500 }}>{databaseName}</span>
+                {" — no reconnection needed."}
+              </span>
+            </div>
+          ) : (
+            <div style={{
+              display: 'flex', alignItems: 'center', gap: 8,
+              padding: '10px 16px', borderRadius: 8,
+              background: 'var(--soft)',
+              border: '1px solid var(--border)',
+            }}>
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="var(--muted)" strokeWidth="1.5" style={{ flexShrink: 0 }}>
+                <circle cx="8" cy="8" r="6"/><path d="M8 7v4M8 5.5v.5"/>
+              </svg>
+              <span style={{ fontSize: 12, color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>
+                Connect to a database from Workspace or Explorer first, then return here to run an audit.
+              </span>
+            </div>
+          )}
         </div>
       </div>
-    </AppLayout>
+    </div>
   );
 };
 

--- a/frontend/pages/AnalyticsPage.tsx
+++ b/frontend/pages/AnalyticsPage.tsx
@@ -1,0 +1,249 @@
+import React from 'react';
+import AppLayout from '../components/AppLayout';
+
+/* Static demo data matching the design's QP_DATA shape */
+const runs14d = [42, 38, 51, 47, 55, 49, 62, 58, 71, 67, 74, 69, 82, 78];
+const fails14d = [3, 2, 4, 3, 5, 4, 6, 3, 5, 4, 7, 5, 4, 6];
+const studiesByMonth = [78, 84, 72, 91, 103, 118, 127, 134, 142, 128, 151, 164];
+const MONTHS = ['Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec', 'Jan', 'Feb', 'Mar', 'Apr', 'May'];
+const BY_DEPT = [
+  { name: 'Cardiac', count: 524, pct: 43 },
+  { name: 'Ortho', count: 318, pct: 26 },
+  { name: 'Vascular', count: 187, pct: 15 },
+  { name: 'Neuro', count: 142, pct: 12 },
+  { name: 'Other', count: 76, pct: 4 },
+];
+const DEPT_COLORS = ['var(--accent)', '#7c8a4a', '#4a7c8a', '#8a4a7c', '#a89070'];
+
+const SCATTER = [
+  { x: 0.8, y: 1.94, ok: true }, { x: 1.2, y: 2.14, ok: true }, { x: 1.6, y: 1.71, ok: true },
+  { x: 2.0, y: 1.42, ok: false }, { x: 0.4, y: 2.62, ok: true }, { x: 1.0, y: 2.04, ok: true },
+  { x: 1.8, y: 1.62, ok: false }, { x: 2.4, y: 1.18, ok: false }, { x: 0.6, y: 2.81, ok: true },
+  { x: 1.4, y: 1.88, ok: true }, { x: 2.2, y: 1.51, ok: false }, { x: 0.9, y: 2.32, ok: true },
+  { x: 1.1, y: 2.21, ok: true }, { x: 1.7, y: 1.55, ok: false }, { x: 0.5, y: 2.94, ok: true },
+];
+
+/* ── Sparkline (140×36 SVG) ── */
+const Sparkline: React.FC<{ data: number[]; color?: string; fill?: boolean }> = ({
+  data, color = 'var(--accent)', fill = true,
+}) => {
+  const W = 140, H = 36, pad = 2;
+  const min = Math.min(...data), max = Math.max(...data);
+  const range = max - min || 1;
+  const pts = data.map((v, i) => ({
+    x: pad + (i / (data.length - 1)) * (W - pad * 2),
+    y: H - pad - ((v - min) / range) * (H - pad * 2),
+  }));
+  const path = pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+  const fillPath = `${path} L${pts[pts.length - 1].x},${H} L${pts[0].x},${H} Z`;
+  return (
+    <svg width={W} height={H} style={{ overflow: 'visible' }}>
+      {fill && (
+        <defs>
+          <linearGradient id={`sg-${color.replace(/[^a-z]/gi, '')}`} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity="0.2"/>
+            <stop offset="100%" stopColor={color} stopOpacity="0"/>
+          </linearGradient>
+        </defs>
+      )}
+      {fill && <path d={fillPath} fill={`url(#sg-${color.replace(/[^a-z]/gi, '')})`}/>}
+      <path d={path} fill="none" stroke={color} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round"/>
+    </svg>
+  );
+};
+
+/* ── Area chart (full width) ── */
+const AreaChart: React.FC<{ data: number[]; labels: string[] }> = ({ data, labels }) => {
+  const W = 600, H = 160, padL = 36, padB = 24, padR = 16, padT = 12;
+  const iW = W - padL - padR, iH = H - padB - padT;
+  const min = 0, max = Math.max(...data) * 1.1;
+  const xs = data.map((_, i) => padL + (i / (data.length - 1)) * iW);
+  const ys = data.map((v) => padT + iH - ((v - min) / (max - min)) * iH);
+  const path = xs.map((x, i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${ys[i].toFixed(1)}`).join(' ');
+  const fillPath = `${path} L${xs[xs.length - 1]},${padT + iH} L${xs[0]},${padT + iH} Z`;
+  const yTicks = [0, Math.round(max * 0.25), Math.round(max * 0.5), Math.round(max * 0.75), Math.round(max)];
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} style={{ width: '100%', height: 'auto', overflow: 'visible' }}>
+      <defs>
+        <linearGradient id="area-fill" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.25"/>
+          <stop offset="100%" stopColor="var(--accent)" stopOpacity="0"/>
+        </linearGradient>
+      </defs>
+      {/* Grid lines */}
+      {yTicks.map((t) => {
+        const y = padT + iH - ((t - min) / (max - min)) * iH;
+        return (
+          <g key={t}>
+            <line x1={padL} y1={y} x2={W - padR} y2={y} stroke="var(--border)" strokeWidth="1"/>
+            <text x={padL - 4} y={y + 3.5} textAnchor="end" fontSize="9" fill="var(--muted)">{t}</text>
+          </g>
+        );
+      })}
+      {/* X labels */}
+      {xs.map((x, i) => (
+        <text key={i} x={x} y={H - 6} textAnchor="middle" fontSize="9" fill="var(--muted)">{labels[i]}</text>
+      ))}
+      <path d={fillPath} fill="url(#area-fill)"/>
+      <path d={path} fill="none" stroke="var(--accent)" strokeWidth="2" strokeLinejoin="round" strokeLinecap="round"/>
+      {/* Dots on last point */}
+      <circle cx={xs[xs.length - 1]} cy={ys[ys.length - 1]} r="4" fill="var(--accent)" stroke="var(--panel)" strokeWidth="2"/>
+    </svg>
+  );
+};
+
+/* ── Donut chart ── */
+const DonutChart: React.FC<{ data: typeof BY_DEPT }> = ({ data }) => {
+  const R = 52, cx = 70, cy = 70, strokeW = 20;
+  const total = data.reduce((s, d) => s + d.count, 0);
+  let angle = -Math.PI / 2;
+  const arcs = data.map((d, i) => {
+    const sweep = (d.count / total) * 2 * Math.PI;
+    const x1 = cx + R * Math.cos(angle);
+    const y1 = cy + R * Math.sin(angle);
+    angle += sweep;
+    const x2 = cx + R * Math.cos(angle);
+    const y2 = cy + R * Math.sin(angle);
+    return { x1, y1, x2, y2, sweep, large: sweep > Math.PI ? 1 : 0, color: DEPT_COLORS[i], ...d };
+  });
+  return (
+    <div style={{ display: 'flex', gap: 20, alignItems: 'center' }}>
+      <svg width="140" height="140" viewBox="0 0 140 140">
+        {arcs.map((a, i) => {
+          const d = `M${a.x1.toFixed(2)},${a.y1.toFixed(2)} A${R},${R} 0 ${a.large},1 ${a.x2.toFixed(2)},${a.y2.toFixed(2)}`;
+          return <path key={i} d={d} fill="none" stroke={a.color} strokeWidth={strokeW} strokeLinecap="butt"/>;
+        })}
+        <text x={cx} y={cy + 4} textAnchor="middle" fontSize="18" fontWeight="500" fill="var(--fg)" fontFamily="var(--font-display)">{total.toLocaleString()}</text>
+        <text x={cx} y={cy + 18} textAnchor="middle" fontSize="9" fill="var(--muted)">studies</text>
+      </svg>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {arcs.map((a, i) => (
+          <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 7, fontSize: 12 }}>
+            <span style={{ width: 8, height: 8, borderRadius: '50%', background: a.color, flexShrink: 0 }}/>
+            <span style={{ color: 'var(--muted)' }}>{a.name}</span>
+            <span style={{ marginLeft: 'auto', fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg)' }}>{a.pct}%</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+/* ── Scatter plot ── */
+const ScatterPlot: React.FC<{ data: typeof SCATTER }> = ({ data }) => {
+  const W = 260, H = 160, padL = 36, padB = 28, padR = 16, padT = 12;
+  const iW = W - padL - padR, iH = H - padB - padT;
+  const xMin = 0, xMax = 2.8, yMin = 1, yMax = 3.2;
+  const toX = (v: number) => padL + ((v - xMin) / (xMax - xMin)) * iW;
+  const toY = (v: number) => padT + iH - ((v - yMin) / (yMax - yMin)) * iH;
+  const thresholdY = toY(2.0);
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} style={{ width: '100%', height: 'auto', overflow: 'visible' }}>
+      {/* Threshold line */}
+      <line x1={padL} y1={thresholdY} x2={W - padR} y2={thresholdY} stroke="var(--status-err)" strokeWidth="1" strokeDasharray="4 3"/>
+      <text x={W - padR + 2} y={thresholdY + 3} fontSize="8" fill="var(--status-err)">SF 2.0</text>
+      {/* Axes */}
+      <line x1={padL} y1={padT} x2={padL} y2={padT + iH} stroke="var(--border)" strokeWidth="1"/>
+      <line x1={padL} y1={padT + iH} x2={W - padR} y2={padT + iH} stroke="var(--border)" strokeWidth="1"/>
+      <text x={padL - 4} y={padT + 4} textAnchor="end" fontSize="8" fill="var(--muted)">SF</text>
+      <text x={(padL + W - padR) / 2} y={H - 2} textAnchor="middle" fontSize="8" fill="var(--muted)">Mesh size (M elements)</text>
+      {/* Points */}
+      {data.map((pt, i) => (
+        <circle
+          key={i}
+          cx={toX(pt.x)} cy={toY(pt.y)} r="4"
+          fill={pt.ok ? 'var(--accent)' : 'var(--status-err)'}
+          fillOpacity="0.7"
+          stroke={pt.ok ? 'var(--accent)' : 'var(--status-err)'}
+          strokeWidth="1"
+        />
+      ))}
+    </svg>
+  );
+};
+
+/* ── KPI card ── */
+const KpiCard: React.FC<{
+  label: string;
+  value: string;
+  delta?: string;
+  positive?: boolean;
+  sparkData?: number[];
+  sparkColor?: string;
+}> = ({ label, value, delta, positive, sparkData, sparkColor }) => (
+  <div style={{ background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 12, padding: 18, display: 'flex', flexDirection: 'column', gap: 10 }}>
+    <div style={{ fontSize: 11, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>{label}</div>
+    <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', gap: 8 }}>
+      <div>
+        <div style={{ fontSize: 26, fontWeight: 500, fontFamily: 'var(--font-display)', letterSpacing: '-0.02em', lineHeight: 1.1 }}>{value}</div>
+        {delta && (
+          <div style={{ fontSize: 11.5, color: positive ? 'var(--accent)' : 'var(--status-err)', marginTop: 4 }}>
+            {positive ? '↑' : '↓'} {delta} vs prev 14d
+          </div>
+        )}
+      </div>
+      {sparkData && <Sparkline data={sparkData} color={sparkColor || 'var(--accent)'} fill />}
+    </div>
+  </div>
+);
+
+/* ──────────────────────────────────────────────────────────── */
+
+const AnalyticsPage: React.FC = () => {
+  const totalRuns = runs14d.reduce((a, b) => a + b, 0);
+  const totalFails = fails14d.reduce((a, b) => a + b, 0);
+
+  return (
+    <AppLayout>
+      <div style={{ padding: '28px 32px', maxWidth: 1100, minWidth: 0 }}>
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 24 }}>
+          <div>
+            <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 22, letterSpacing: '-0.02em', margin: 0 }}>
+              Analytics
+            </h1>
+            <p style={{ fontSize: 12.5, color: 'var(--muted)', margin: '4px 0 0' }}>
+              Last updated · {new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+            </p>
+          </div>
+          <button className="qa-btn">
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M14 8A6 6 0 112 8M14 8l-2-2M14 8l-2 2"/>
+            </svg>
+            Refresh
+          </button>
+        </div>
+
+        {/* KPI row */}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 14, marginBottom: 24 }}>
+          <KpiCard label="Studies run (14d)" value={totalRuns.toLocaleString()} delta="12%" positive sparkData={runs14d} />
+          <KpiCard label="Diverged (14d)" value={totalFails.toLocaleString()} delta="8%" positive={false} sparkData={fails14d} sparkColor="var(--status-err)" />
+          <KpiCard label="Avg safety factor" value="1.92" delta="0.07" positive={false} sparkData={runs14d.map(v => v / 40 + 1.6)} />
+          <KpiCard label="Avg runtime" value="3h 24m" delta="11m" positive sparkData={runs14d.map(v => v / 82 * 3.6 + 1.2)} />
+        </div>
+
+        {/* Charts row 1 */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 20, marginBottom: 20 }}>
+          {/* Area chart */}
+          <div style={{ background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 12, padding: 22 }}>
+            <div style={{ fontSize: 12, fontWeight: 500, marginBottom: 14, color: 'var(--fg)' }}>Studies completed by month</div>
+            <AreaChart data={studiesByMonth} labels={MONTHS} />
+          </div>
+          {/* Donut */}
+          <div style={{ background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 12, padding: 22, minWidth: 260 }}>
+            <div style={{ fontSize: 12, fontWeight: 500, marginBottom: 14, color: 'var(--fg)' }}>By department</div>
+            <DonutChart data={BY_DEPT} />
+          </div>
+        </div>
+
+        {/* Charts row 2 */}
+        <div style={{ background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 12, padding: 22, maxWidth: 380 }}>
+          <div style={{ fontSize: 12, fontWeight: 500, marginBottom: 14, color: 'var(--fg)' }}>Mesh size vs. safety factor</div>
+          <ScatterPlot data={SCATTER} />
+        </div>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default AnalyticsPage;

--- a/frontend/pages/AnalyticsPageWrapper.tsx
+++ b/frontend/pages/AnalyticsPageWrapper.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import AppLayout from '../components/AppLayout';
+import AnalyticsPage from './AnalyticsPage';
+import { CollectionSummary, DbInfo, CosmosDBAccount } from '../types';
+
+interface SessionConnection {
+  accountId?: string;
+  databaseName?: string;
+  accountName?: string;
+  collections?: CollectionSummary[];
+  availableAccounts?: CosmosDBAccount[];
+  availableDbs?: DbInfo[];
+}
+
+const readSessionConnection = (): SessionConnection | null => {
+  try {
+    const saved = sessionStorage.getItem('qp_connection');
+    return saved ? JSON.parse(saved) : null;
+  } catch { return null; }
+};
+
+const AnalyticsPageWrapper: React.FC = () => {
+  const conn = readSessionConnection();
+
+  return (
+    <AppLayout
+      accountId={conn?.accountId}
+      accountName={conn?.accountName}
+      databaseName={conn?.databaseName}
+      collections={conn?.collections}
+      availableAccounts={conn?.availableAccounts}
+      availableDbs={conn?.availableDbs}
+    >
+      <AnalyticsPage
+        accountId={conn?.accountId}
+        databaseName={conn?.databaseName}
+      />
+    </AppLayout>
+  );
+};
+
+export default AnalyticsPageWrapper;

--- a/frontend/pages/AuditPage.tsx
+++ b/frontend/pages/AuditPage.tsx
@@ -2,9 +2,8 @@ import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
 import { API_BASE_URL } from '../app.config';
-import NavBar from '../components/NavBar';
+import AppLayout from '../components/AppLayout';
 import ChartDisplay, { VisualizationConfig } from '../components/ChartDisplay';
-import styles from './AuditPage.module.css';
 
 interface AuditResult {
     sql_query: string;
@@ -53,32 +52,67 @@ const AuditPage: React.FC = () => {
     };
 
     return (
-        <div className={styles.container}>
-            <NavBar />
-            <div className={styles.content}>
-                <h1 className={styles.title}>Audit Log Analysis</h1>
-                <p className={styles.subtitle}>Ask questions about your write operations history</p>
+        <AppLayout>
+            <div style={{ padding: '32px 40px', maxWidth: 860, fontFamily: 'var(--font-body)' }}>
+                <div style={{ marginBottom: 28 }}>
+                    <h1 style={{
+                        fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 22,
+                        letterSpacing: '-0.02em', margin: 0, color: 'var(--fg)',
+                    }}>Audit Log Analysis</h1>
+                    <p style={{ fontSize: 13, color: 'var(--muted)', margin: '6px 0 0' }}>
+                        Ask questions about your write operations history
+                    </p>
+                </div>
 
-                <form onSubmit={handleSubmit} className={styles.form}>
+                <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 28 }}>
                     <textarea
-                        className={styles.input}
                         value={question}
                         onChange={(e) => setQuestion(e.target.value)}
                         placeholder="e.g., How many documents were deleted yesterday?"
                         rows={3}
+                        style={{
+                            padding: '10px 14px',
+                            border: '1px solid var(--border)',
+                            borderRadius: 10,
+                            background: 'var(--panel)',
+                            color: 'var(--fg)',
+                            fontFamily: 'var(--font-body)',
+                            fontSize: 13.5,
+                            resize: 'vertical',
+                            outline: 'none',
+                            lineHeight: 1.5,
+                        }}
+                        onFocus={(e) => (e.target.style.borderColor = 'var(--accent)')}
+                        onBlur={(e) => (e.target.style.borderColor = 'var(--border)')}
                     />
-                    <button type="submit" className={styles.button} disabled={loading}>
-                        {loading ? 'Analyzing...' : 'Analyze'}
+                    <button
+                        type="submit"
+                        className="qa-btn primary"
+                        disabled={loading}
+                        style={{ alignSelf: 'flex-start', opacity: loading ? 0.65 : 1 }}
+                    >
+                        {loading ? 'Analyzing…' : 'Analyze'}
                     </button>
                 </form>
 
-                {error && <div className={styles.error}>{error}</div>}
+                {error && (
+                    <div style={{
+                        padding: '12px 16px', borderRadius: 10,
+                        background: 'color-mix(in oklch, var(--status-err) 12%, var(--bg))',
+                        border: '1px solid color-mix(in oklch, var(--status-err) 25%, var(--border))',
+                        color: 'var(--status-err)', fontSize: 13, marginBottom: 20,
+                    }}>
+                        {error}
+                    </div>
+                )}
 
                 {data && (
-                    <div className={styles.resultsContainer}>
-                        <div className={styles.summarySection}>
-                            <h2>AI Insight</h2>
-                            <div className={styles.markdown}>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+                        <div style={{ background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 12, padding: 22 }}>
+                            <div style={{ fontSize: 11, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)', marginBottom: 12 }}>
+                                AI Insight
+                            </div>
+                            <div style={{ fontSize: 13.5, lineHeight: 1.6, color: 'var(--fg)' }}>
                                 <ReactMarkdown>{data.summary}</ReactMarkdown>
                             </div>
                         </div>
@@ -87,44 +121,58 @@ const AuditPage: React.FC = () => {
                             <ChartDisplay config={data.visualization} data={data.results} />
                         )}
 
-                        <div className={styles.detailsSection}>
+                        <div style={{ background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 12, padding: 22 }}>
                             <details>
-                                <summary>View SQL Query</summary>
-                                <code className={styles.sqlBlock}>{data.sql_query}</code>
+                                <summary style={{ cursor: 'pointer', fontSize: 12.5, color: 'var(--muted)', marginBottom: 10 }}>
+                                    View SQL Query
+                                </summary>
+                                <pre style={{
+                                    fontFamily: 'var(--font-mono)', fontSize: 12,
+                                    background: 'var(--soft)', borderRadius: 8, padding: '12px 14px',
+                                    overflowX: 'auto', color: 'var(--fg)', margin: '8px 0 0',
+                                }}>{data.sql_query}</pre>
                             </details>
 
-                            <h3>Raw Data ({data.results.length} rows)</h3>
-                            {data.results.length > 0 ? (
-                                <div className={styles.tableWrapper}>
-                                    <table className={styles.table}>
-                                        <thead>
-                                            <tr>
-                                                {Object.keys(data.results[0]).map((key) => (
-                                                    <th key={key}>{key}</th>
-                                                ))}
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {data.results.map((row, i) => (
-                                                <tr key={i}>
-                                                    {Object.values(row).map((val: any, j) => (
-                                                        <td key={j}>
-                                                            {typeof val === 'object' ? JSON.stringify(val) : String(val)}
-                                                        </td>
+                            <div style={{ marginTop: 20 }}>
+                                <div style={{ fontSize: 12.5, fontWeight: 500, color: 'var(--muted)', marginBottom: 10 }}>
+                                    Raw data <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>({data.results.length} rows)</span>
+                                </div>
+                                {data.results.length > 0 ? (
+                                    <div style={{ overflowX: 'auto' }}>
+                                        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12.5 }}>
+                                            <thead>
+                                                <tr style={{ borderBottom: '1px solid var(--border)' }}>
+                                                    {Object.keys(data.results[0]).map((key) => (
+                                                        <th key={key} style={{
+                                                            padding: '7px 10px', textAlign: 'left',
+                                                            fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em',
+                                                            color: 'var(--muted)', fontWeight: 500,
+                                                        }}>{key}</th>
                                                     ))}
                                                 </tr>
-                                            ))}
-                                        </tbody>
-                                    </table>
-                                </div>
-                            ) : (
-                                <p>No results found.</p>
-                            )}
+                                            </thead>
+                                            <tbody>
+                                                {data.results.map((row, i) => (
+                                                    <tr key={i} style={{ borderBottom: '1px solid var(--border)' }}>
+                                                        {Object.values(row).map((val: any, j) => (
+                                                            <td key={j} style={{ padding: '8px 10px', color: 'var(--fg)' }}>
+                                                                {typeof val === 'object' ? JSON.stringify(val) : String(val)}
+                                                            </td>
+                                                        ))}
+                                                    </tr>
+                                                ))}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                ) : (
+                                    <p style={{ color: 'var(--muted)', fontSize: 13 }}>No results found.</p>
+                                )}
+                            </div>
                         </div>
                     </div>
                 )}
             </div>
-        </div>
+        </AppLayout>
     );
 };
 

--- a/frontend/pages/DataExplorerPage.tsx
+++ b/frontend/pages/DataExplorerPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { FilterState } from '../utils/queryHandover';
 import { useNavigate } from 'react-router-dom';
 import { SelectedResource, DbInfo, BreadcrumbItem, CosmosDBAccount, CollectionInfo } from '../types';
 import { getDocuments, getCollectionInfo, findDocumentById, getDatabasesForAccount, clearDocumentsCache, getSingleDocument, getDocumentsQueryCode } from '../services/dbService';
@@ -75,6 +76,7 @@ interface DataExplorerPageProps {
   availableDbs: DbInfo[];
   availableAccounts: CosmosDBAccount[];
   initialDocumentId?: string;
+  initialFilters?: FilterState[];
   onNavigateBack: () => void;
   embedded?: boolean;
   sidebarSelectedCollection?: string;
@@ -158,6 +160,7 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
   availableDbs,
   availableAccounts,
   initialDocumentId,
+  initialFilters,
   onNavigateBack,
   embedded = false,
   sidebarSelectedCollection,
@@ -399,6 +402,15 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
     setOpenDocuments([]);
     // Do not reset pinned documents here, as they should persist across DB/collection changes.
   }, []);
+
+  // Apply handover filters once after the first collection selection
+  const appliedInitialFilters = useRef(false);
+  useEffect(() => {
+    if (!initialFilters?.length || appliedInitialFilters.current || !selectedCollection) return;
+    appliedInitialFilters.current = true;
+    setFilters(initialFilters);
+    setDebouncedFilters(initialFilters);
+  }, [selectedCollection, initialFilters]);
 
   // Debounce filters
   useEffect(() => {

--- a/frontend/pages/DataExplorerPage.tsx
+++ b/frontend/pages/DataExplorerPage.tsx
@@ -76,6 +76,7 @@ interface DataExplorerPageProps {
   availableAccounts: CosmosDBAccount[];
   initialDocumentId?: string;
   onNavigateBack: () => void;
+  embedded?: boolean;
 }
 
 interface PinnedDocument {
@@ -160,7 +161,8 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
   availableDbs,
   availableAccounts,
   initialDocumentId,
-  onNavigateBack
+  onNavigateBack,
+  embedded = false,
 }) => {
   const navigate = useNavigate();
 
@@ -1091,9 +1093,9 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
     }
   }
 
-  return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-800 dark:text-slate-200 font-sans">
-      <div className="flex flex-col h-screen relative">
+  const pageContent = (
+    <>
+    <div className={embedded ? 'flex flex-col h-full relative' : 'flex flex-col h-screen relative'}>
 
         {/* Loading Overlay */}
         {isLoadingDbsForAccount && (
@@ -1105,8 +1107,8 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
           </div>
         )}
 
-        {/* Header */}
-        <header className="flex-shrink-0 bg-white dark:bg-slate-800/50 border-b border-slate-200 dark:border-slate-700">
+        {/* Header — hidden in embedded mode (AppTopBar handles breadcrumb) */}
+        {!embedded && <header className="flex-shrink-0 bg-white dark:bg-slate-800/50 border-b border-slate-200 dark:border-slate-700">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between h-16">
               <div className="flex items-center gap-4">
@@ -1202,7 +1204,7 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
               </div>
             </div>
           </div>
-        </header>
+        </header>}
 
         {/* Main Content Area */}
         <main className="flex-grow overflow-hidden block w-full h-full relative">
@@ -1732,6 +1734,12 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
             animation: pulse 1s infinite; 
           }
       `}</style>
+    </>
+  );
+
+  return embedded ? pageContent : (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-800 dark:text-slate-200 font-sans">
+      {pageContent}
     </div>
   );
 };

--- a/frontend/pages/DataExplorerPage.tsx
+++ b/frontend/pages/DataExplorerPage.tsx
@@ -77,6 +77,8 @@ interface DataExplorerPageProps {
   initialDocumentId?: string;
   onNavigateBack: () => void;
   embedded?: boolean;
+  sidebarSelectedCollection?: string;
+  onCollectionChange?: (name: string | undefined) => void;
 }
 
 interface PinnedDocument {
@@ -117,27 +119,22 @@ const DeleteDocumentDialog: React.FC<{
 }> = ({ open, document, onClose, onDelete, loading }) => {
   if (!open || !document) return null;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 dark:bg-black/60 animate-fade-in-fast">
-      <div className="bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-lg w-full p-6 border border-slate-200 dark:border-slate-700">
-        <h2 className="text-lg font-bold text-red-600 dark:text-red-400 mb-2 flex items-center gap-2">
-          <TrashIcon className="w-5 h-5" /> Confirm Delete Document
+    <div style={{ position: 'fixed', inset: 0, zIndex: 50, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(0,0,0,0.35)', fontFamily: 'var(--font-body)' }}>
+      <div style={{ background: 'var(--panel)', borderRadius: 12, boxShadow: '0 20px 60px rgba(0,0,0,0.14)', maxWidth: 480, width: '100%', padding: 24, border: '1px solid var(--border)' }}>
+        <h2 style={{ fontSize: 15, fontWeight: 600, color: 'var(--status-err)', marginBottom: 8, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M2 4h12M5 4V3a1 1 0 011-1h4a1 1 0 011 1v1M6 7v5M10 7v5M3 4l1 9a1 1 0 001 1h6a1 1 0 001-1l1-9"/></svg>
+          Confirm Delete Document
         </h2>
-        <p className="mb-3 text-slate-700 dark:text-slate-200 text-sm">Are you sure you want to delete this document? This action cannot be undone.</p>
-        <div className="bg-slate-100 dark:bg-slate-900 rounded p-3 text-xs overflow-x-auto text-slate-800 dark:text-slate-100 max-h-60 mb-4 border border-slate-200 dark:border-slate-700">
+        <p style={{ marginBottom: 12, color: 'var(--fg)', fontSize: 13 }}>Are you sure you want to delete this document? This action cannot be undone.</p>
+        <div style={{ background: '#0f0e0d', color: '#c8c4bc', borderRadius: 8, padding: 12, fontSize: 11.5, overflowX: 'auto', maxHeight: 240, marginBottom: 16, fontFamily: 'var(--font-mono)' }}>
           <JsonDisplay data={document} />
         </div>
-        <div className="flex justify-end gap-2">
-          <button
-            onClick={onClose}
-            disabled={loading}
-            className="px-4 py-2 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
-          >
-            Cancel
-          </button>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+          <button onClick={onClose} disabled={loading} className="qa-btn" style={{ fontSize: 13 }}>Cancel</button>
           <button
             onClick={onDelete}
             disabled={loading}
-            className="px-4 py-2 rounded-md border border-red-400 bg-red-600 text-white font-semibold hover:bg-red-700 transition-colors disabled:opacity-60"
+            style={{ padding: '7px 16px', borderRadius: 6, border: 'none', background: 'var(--status-err)', color: 'white', fontSize: 13, fontWeight: 600, cursor: loading ? 'not-allowed' : 'pointer', opacity: loading ? 0.6 : 1, fontFamily: 'var(--font-body)' }}
           >
             {loading ? 'Deleting...' : 'Delete'}
           </button>
@@ -163,6 +160,8 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
   initialDocumentId,
   onNavigateBack,
   embedded = false,
+  sidebarSelectedCollection,
+  onCollectionChange,
 }) => {
   const navigate = useNavigate();
 
@@ -200,14 +199,14 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
     operator?: string;
     type?: 'string' | 'number' | 'boolean' | 'date';
   }
-  const [filters, setFilters] = useState<FilterState[]>([{ id: 'default', key: 'all', value: '', isCustom: false, operator: 'equals', type: 'string' }]);
+  const [filters, setFilters] = useState<FilterState[]>([{ id: 'default', key: 'all', value: '', isCustom: false, operator: 'contains', type: 'string' }]);
   const [debouncedFilters, setDebouncedFilters] = useState<FilterState[]>(filters);
   const [schemaTree, setSchemaTree] = useState<SchemaKeyNode[]>([]);
   const [isFetchingSchema, setIsFetchingSchema] = useState(false);
   const [currentCollectionInfo, setCurrentCollectionInfo] = useState<CollectionInfo | null>(null);
 
   const addFilter = () => {
-    setFilters(prev => [...prev, { id: Math.random().toString(36).substring(7), key: 'all', value: '', isCustom: false, operator: 'equals', type: 'string' }]);
+    setFilters(prev => [...prev, { id: Math.random().toString(36).substring(7), key: 'all', value: '', isCustom: false, operator: 'contains', type: 'string' }]);
   };
 
   const removeFilter = (id: string) => {
@@ -391,8 +390,8 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
     setTotalPages(1);
     setTotalDocuments(0);
     setPageInput('1');
-    setFilters([{ id: 'default', key: 'all', value: '', isCustom: false, operator: 'equals', type: 'string' }]);
-    setDebouncedFilters([{ id: 'default', key: 'all', value: '', isCustom: false, operator: 'equals', type: 'string' }]);
+    setFilters([{ id: 'default', key: 'all', value: '', isCustom: false, operator: 'contains', type: 'string' }]);
+    setDebouncedFilters([{ id: 'default', key: 'all', value: '', isCustom: false, operator: 'contains', type: 'string' }]);
     setSchemaTree([]);
     setIsFetchingSchema(false);
     setOpenDocuments([]);
@@ -504,6 +503,7 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
       }
     } catch (e) {
       console.error("Failed to fetch schema for filters:", e);
+      if (e instanceof Error) setError(e.message);
     } finally {
       setIsFetchingSchema(false);
     }
@@ -613,10 +613,29 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
     if (selectedCollection === collectionName) return;
     setSelectedCollection(collectionName);
     setCurrentPage(1);
-    setFilters([{ id: 'default', key: 'all', value: '', isCustom: false, operator: 'equals', type: 'string' }]);
-    setDebouncedFilters([{ id: 'default', key: 'all', value: '', isCustom: false, operator: 'equals', type: 'string' }]);
+    setFilters([{ id: 'default', key: 'all', value: '', isCustom: false, operator: 'contains', type: 'string' }]);
+    setDebouncedFilters([{ id: 'default', key: 'all', value: '', isCustom: false, operator: 'contains', type: 'string' }]);
     await fetchSchemaForCollection(collectionName);
   }, [fetchSchemaForCollection, selectedCollection]);
+
+  // Sync active collection back to the sidebar
+  useEffect(() => {
+    onCollectionChange?.(selectedCollection ?? undefined);
+  }, [selectedCollection, onCollectionChange]);
+
+  // Respond to sidebar collection selection
+  useEffect(() => {
+    if (sidebarSelectedCollection && sidebarSelectedCollection !== selectedCollection) {
+      handleCollectionClick(sidebarSelectedCollection);
+    }
+  }, [sidebarSelectedCollection, selectedCollection, handleCollectionClick]);
+
+  // Auto-select first collection in embedded mode when none is selected
+  useEffect(() => {
+    if (embedded && !selectedCollection && !initialDocumentId && !sidebarSelectedCollection && currentDb && currentDb.collections.length > 0) {
+      handleCollectionClick(currentDb.collections[0].name);
+    }
+  }, [embedded, selectedCollection, initialDocumentId, sidebarSelectedCollection, currentDb, handleCollectionClick]);
 
   const handleRefresh = useCallback(() => {
     if (!selectedCollection) return;
@@ -701,6 +720,9 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
           }];
         });
       }
+      if (result.collectionName !== selectedCollection) {
+        onCollectionChange?.(result.collectionName);
+      }
       await fetchSchemaForCollection(result.collectionName);
     } catch (e) {
       if (e instanceof Error) setError(e.message);
@@ -708,7 +730,7 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
     } finally {
       setIsLoading(false);
     }
-  }, [openDocuments, currentResource, currentDb, currentAccount.id, fetchSchemaForCollection]);
+  }, [openDocuments, currentResource, currentDb, currentAccount.id, fetchSchemaForCollection, selectedCollection, onCollectionChange]);
 
   const handleBreadcrumbClick = useCallback(async (openDocId: string, index: number) => {
     const openDoc = openDocuments.find(d => d.id === openDocId);
@@ -742,22 +764,26 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
 
   const renderSortArrow = (key: 'name' | 'count') => {
     if (collectionSortKey !== key) return null;
-    return collectionSortOrder === 'asc' ? <ArrowUpwardIcon className="w-3 h-3" /> : <ArrowDownwardIcon className="w-3 h-3" />;
+    return collectionSortOrder === 'asc'
+      ? <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M8 13V3M3 8l5-5 5 5"/></svg>
+      : <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M8 3v10M3 8l5 5 5-5"/></svg>;
   };
 
   const renderDocumentList = () => {
     if (isLoading && documents.length === 0) {
       return (
-        <div className="flex flex-col items-center justify-center h-full text-slate-500 dark:text-slate-400">
-          <SpinnerIcon className="w-8 h-8" />
-          <p className="mt-2">Loading documents...</p>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', color: 'var(--muted)' }}>
+          <svg width="22" height="22" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ animation: 'qp-spin 0.8s linear infinite' }}>
+            <circle cx="8" cy="8" r="6" strokeOpacity="0.3"/><path d="M8 2a6 6 0 0 1 6 6"/>
+          </svg>
+          <p style={{ marginTop: 8, fontSize: 13 }}>Loading documents...</p>
         </div>
       );
     }
 
     if (error && !isLoading) {
       return (
-        <div className="p-4 text-red-600 bg-red-50 border border-red-200 text-sm rounded-md dark:bg-red-900/30 dark:border-red-500/50 dark:text-red-300">
+        <div style={{ margin: 12, padding: '10px 14px', color: 'var(--status-err)', background: 'color-mix(in oklch, #c94250 8%, var(--bg))', border: '1px solid color-mix(in oklch, #c94250 22%, var(--border))', fontSize: 13, borderRadius: 8 }}>
           {error}
         </div>
       );
@@ -765,25 +791,25 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
 
     if (!selectedCollection) {
       return (
-        <div className="text-center text-slate-500 dark:text-slate-400 py-10">
-          <p>Select a collection to view its documents.</p>
+        <div style={{ textAlign: 'center', color: 'var(--muted)', padding: '40px 16px' }}>
+          <p style={{ fontSize: 13 }}>Select a collection to view its documents.</p>
         </div>
       );
     }
 
     if (documents.length === 0 && !isLoading) {
       return (
-        <div className="text-center text-slate-500 dark:text-slate-400 py-10">
-          <p>No documents found.</p>
-          {debouncedFilters.some(f => f.value || f.operator === 'exists' || f.operator === 'not_exists') && <p className="text-xs">Try a different filter or value.</p>}
+        <div style={{ textAlign: 'center', color: 'var(--muted)', padding: '40px 16px' }}>
+          <p style={{ fontSize: 13 }}>No documents found.</p>
+          {debouncedFilters.some(f => f.value || f.operator === 'exists' || f.operator === 'not_exists') && <p style={{ fontSize: 11.5, marginTop: 4 }}>Try a different filter or value.</p>}
         </div>
       );
     }
 
     return (
-      <div className="flex flex-col h-full">
-        <div className={`flex-grow overflow-y-auto ${isLoading ? 'opacity-50' : ''}`}>
-          <ul className="divide-y divide-slate-200 dark:divide-slate-700">
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <div style={{ flexGrow: 1, overflowY: 'auto', opacity: isLoading ? 0.5 : 1 }}>
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
             {documents.map((doc) => {
               const docId = getDocId(doc);
               const isSelected = openDocuments.some(od => getDocId(od.doc) === docId);
@@ -792,7 +818,9 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
               return (
                 <li
                   key={docId}
-                  className={`flex items-center justify-between transition-colors group ${isSelected ? 'bg-blue-100 dark:bg-blue-900/50' : 'hover:bg-slate-100 dark:hover:bg-slate-700/50'}`}
+                  style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid var(--border)', background: isSelected ? 'var(--accent-soft)' : 'transparent' }}
+                  onMouseEnter={(e) => { if (!isSelected) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                  onMouseLeave={(e) => { if (!isSelected) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
                 >
                   <button
                     onClick={(e) => {
@@ -806,15 +834,12 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
                       const isAlreadyOpen = openDocuments.some(od => getDocId(od.doc) === docId && od.collectionName === selectedCollection);
 
                       if (e.metaKey || e.ctrlKey) {
-                        // Append to open documents
                         if (!isAlreadyOpen) {
                           setOpenDocuments(prev => [...prev, newDocObj]);
                         } else {
-                          // Deselect
                           setOpenDocuments(prev => prev.filter(od => !(getDocId(od.doc) === docId && od.collectionName === selectedCollection)));
                         }
                       } else {
-                        // Close all others
                         if (isAlreadyOpen) {
                           setOpenDocuments(prev => prev.filter(od => getDocId(od.doc) === docId && od.collectionName === selectedCollection));
                         } else {
@@ -822,44 +847,39 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
                         }
                       }
                     }}
-                    className="flex-grow text-left p-3 text-sm"
+                    style={{ flexGrow: 1, textAlign: 'left', padding: '9px 12px', background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'var(--font-mono)', fontSize: 11.5, color: 'var(--fg)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                    title={String(doc._id?.$oid || doc._id)}
                   >
-                    <p className="font-mono text-slate-800 dark:text-slate-200 truncate" title={String(doc._id?.$oid || doc._id)}>{String(doc._id?.$oid || doc._id)}</p>
+                    {String(doc._id?.$oid || doc._id)}
                   </button>
-                  <div className="flex items-center gap-1 mr-2">
-                    {/* Delete button */}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 2, marginRight: 6 }}>
                     <button
-                      onClick={() => {
-                        setDeleteTargetDoc(doc);
-                        setIsDeleteDialogOpen(true);
-                      }}
-                      className="p-2 rounded-full transition-colors text-slate-400 hover:text-red-600 hover:bg-red-100 dark:hover:bg-red-900/40 focus:outline-none focus:ring-2 focus:ring-red-400 opacity-0 group-hover:opacity-100"
+                      onClick={() => { setDeleteTargetDoc(doc); setIsDeleteDialogOpen(true); }}
+                      style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex' }}
                       title="Delete document"
                       aria-label="Delete document"
+                      onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--status-err)'; }}
+                      onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
                     >
-                      <TrashIcon className="w-5 h-5" />
+                      <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M2 4h12M5 4V3a1 1 0 011-1h4a1 1 0 011 1v1M6 7v5M10 7v5M3 4l1 9a1 1 0 001 1h6a1 1 0 001-1l1-9"/></svg>
                     </button>
-                    {/* Copy as new document button */}
                     <button
-                      onClick={() => {
-                        const { _id, ...rest } = doc;
-                        setCreateDocInitial(rest);
-                        setIsCreateDialogOpen(true);
-                      }}
-                      className="p-2 rounded-full transition-colors text-slate-400 hover:text-blue-600 hover:bg-blue-100 dark:hover:bg-blue-900/40 focus:outline-none focus:ring-2 focus:ring-blue-400 opacity-0 group-hover:opacity-100"
+                      onClick={() => { const { _id, ...rest } = doc; setCreateDocInitial(rest); setIsCreateDialogOpen(true); }}
+                      style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex' }}
                       title="Copy as new document"
                       aria-label="Copy as new document"
+                      onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; }}
+                      onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
                     >
-                      <FileCopyIcon className="w-5 h-5" />
+                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
                     </button>
-                    {/* Pin button */}
                     <button
                       onClick={() => handleTogglePin(doc, selectedCollection!)}
-                      className={`p-2 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 ${isPinned ? 'text-blue-500 hover:bg-blue-200/50 dark:hover:bg-blue-900/40' : 'text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700'} ${!isPinned ? 'opacity-0 group-hover:opacity-100' : ''}`}
+                      style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: 'pointer', color: isPinned ? 'var(--accent)' : 'var(--muted)', display: 'flex' }}
                       title={isPinned ? 'Unpin document' : 'Pin document'}
                       aria-label={isPinned ? 'Unpin document' : 'Pin document'}
                     >
-                      <PinIcon className={`w-5 h-5 ${isPinned ? 'fill-current' : 'stroke-current'} transition-colors`} />
+                      <svg width="13" height="13" viewBox="0 0 16 16" fill={isPinned ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="1.5"><path d="M9.5 1.5l5 5-1.5 1.5-1-1-3 3v4l-1.5-1.5-3-3-1.5 1.5v-4l3-3-1-1zM1.5 14.5l4-4"/></svg>
                     </button>
                   </div>
                 </li>
@@ -867,12 +887,12 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
             })}
           </ul>
         </div>
-        {/* Pagination Controls */}
-        <div className="flex-shrink-0 p-2 border-t border-slate-200 dark:border-slate-700 flex items-center justify-between">
-          <button onClick={() => handlePageChange(currentPage - 1)} disabled={currentPage <= 1 || isLoading} className="px-3 py-1 border border-slate-300 dark:border-slate-600 text-sm font-medium rounded-md text-slate-600 dark:text-slate-300 bg-white dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed">
+        {/* Pagination */}
+        <div style={{ flexShrink: 0, padding: '8px 12px', borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <button onClick={() => handlePageChange(currentPage - 1)} disabled={currentPage <= 1 || isLoading} className="qa-btn" style={{ fontSize: 12, padding: '4px 10px' }}>
             Previous
           </button>
-          <div className="text-xs text-slate-500 dark:text-slate-400 flex items-center gap-2">
+          <div style={{ fontSize: 12, color: 'var(--muted)', display: 'flex', alignItems: 'center', gap: 6 }}>
             <span>Page</span>
             <input
               type="text"
@@ -881,12 +901,12 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
               onKeyDown={handlePageInputSubmit}
               onBlur={handlePageInputSubmit}
               disabled={isLoading || totalPages <= 1}
-              className="w-12 text-center bg-slate-100 dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-md text-sm text-slate-900 dark:text-slate-100 disabled:opacity-50"
+              style={{ width: 40, textAlign: 'center', background: 'var(--soft)', border: '1px solid var(--border)', borderRadius: 4, fontSize: 12, color: 'var(--fg)', padding: '2px 4px', fontFamily: 'var(--font-body)' }}
               aria-label="Current page"
             />
             <span>of {totalPages}</span>
           </div>
-          <button onClick={() => handlePageChange(currentPage + 1)} disabled={currentPage >= totalPages || isLoading} className="px-3 py-1 border border-slate-300 dark:border-slate-600 text-sm font-medium rounded-md text-slate-600 dark:text-slate-300 bg-white dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed">
+          <button onClick={() => handlePageChange(currentPage + 1)} disabled={currentPage >= totalPages || isLoading} className="qa-btn" style={{ fontSize: 12, padding: '4px 10px' }}>
             Next
           </button>
         </div>
@@ -926,47 +946,41 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
     setOpenDocuments(prev => prev.map(od => od.id === openDocId ? { ...od, editMode: false } : od));
   };
 
-  // Only cover the editor area (right 60% for 2/4 xl:3/5), open/collapse vertically
   const PinnedDrawer = () => {
     const drawerHeight = isPinnedDrawerOpen ? '100%' : '48px';
-    // Clamp min/max height for card
     const minCardHeight = 120;
     const maxCardHeight = 600;
     return (
       <div
-        className="fixed bottom-0 right-0 z-30 transition-all duration-300 ease-in-out"
-        style={{ width: '60vw', maxWidth: '100vw', minWidth: '320px', height: drawerHeight, pointerEvents: 'auto' }}
+        style={{ position: 'fixed', bottom: 0, right: 0, zIndex: 30, width: '60vw', maxWidth: '100vw', minWidth: 320, height: drawerHeight, pointerEvents: 'auto', transition: 'height 0.3s ease-in-out' }}
         aria-hidden={!isPinnedDrawerOpen && pinnedDocuments.length === 0}
       >
-        <div className="h-full flex flex-col bg-white dark:bg-slate-800 border-l-2 border-blue-500 shadow-[0_0_20px_rgba(0,0,0,0.08)] dark:shadow-[0_0_30px_rgba(0,0,0,0.25)]">
+        <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--panel)', borderLeft: '2px solid var(--accent)', boxShadow: '0 0 20px rgba(0,0,0,0.1)' }}>
           <button
             onClick={() => setIsPinnedDrawerOpen(!isPinnedDrawerOpen)}
-            className="flex items-center justify-between p-3 text-left border-b border-slate-200 dark:border-slate-700 w-full"
+            style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 14px', minHeight: 48, background: 'none', border: 'none', cursor: 'pointer', width: '100%', borderBottom: '1px solid var(--border)', fontFamily: 'var(--font-body)' }}
             aria-expanded={isPinnedDrawerOpen}
-            style={{ minHeight: '48px' }}
           >
-            <div className="flex items-center gap-3">
-              <PinIcon className="w-5 h-5 text-blue-500" />
-              <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
-                Pinned Documents ({pinnedDocuments.length})
-              </h3>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.5"><path d="M9.5 1.5l5 5-1.5 1.5-1-1-3 3v4l-1.5-1.5-3-3-1.5 1.5v-4l3-3-1-1zM1.5 14.5l4-4"/></svg>
+              <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--fg)' }}>Pinned Documents ({pinnedDocuments.length})</span>
             </div>
-            <div className="flex items-center gap-4">
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
               {pinnedDocuments.length > 0 && (
                 <button
                   onClick={e => { e.stopPropagation(); handleClearAllPins(); }}
-                  className="flex items-center gap-2 px-3 py-1.5 border border-red-300 dark:border-red-500/50 text-xs font-medium rounded-md text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/40"
+                  style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '4px 10px', border: '1px solid color-mix(in oklch, #c94250 40%, var(--border))', borderRadius: 6, fontSize: 12, color: 'var(--status-err)', background: 'none', cursor: 'pointer', fontFamily: 'var(--font-body)' }}
                   title="Clear all pinned documents"
                 >
-                  <TrashIcon className="w-4 h-4" /> Clear All
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M2 4h12M5 4V3a1 1 0 011-1h4a1 1 0 011 1v1M6 7v5M10 7v5M3 4l1 9a1 1 0 001 1h6a1 1 0 001-1l1-9"/></svg>
+                  Clear All
                 </button>
               )}
-              <ChevronDownIcon className={`w-6 h-6 text-slate-500 dark:text-slate-400 transition-transform duration-300 ${isPinnedDrawerOpen ? 'rotate-180' : ''}`} />
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="var(--muted)" strokeWidth="1.5" style={{ transform: isPinnedDrawerOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.3s' }}><path d="M3 6l5 5 5-5"/></svg>
             </div>
           </button>
-          {/* Card size drag handles (universal for all cards) */}
           {isPinnedDrawerOpen && pinnedDocuments.length > 0 && (
-            <div className="flex items-center gap-2 px-3 py-1 bg-slate-50 dark:bg-slate-900 border-b border-slate-200 dark:border-slate-700 select-none" style={{ minHeight: '32px', height: '32px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 14px', background: 'var(--soft)', borderBottom: '1px solid var(--border)', minHeight: 32, userSelect: 'none' }}>
               <div
                 tabIndex={0}
                 aria-label="Drag to resize pinned document cards"
@@ -991,62 +1005,47 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
                     window.addEventListener('mouseup', onUp);
                   }
                 }}
-                style={{
-                  width: 44,
-                  height: 24,
-                  minWidth: 44,
-                  minHeight: 24,
-                  maxWidth: 44,
-                  maxHeight: 24,
-                  position: 'relative',
-                  background: 'transparent',
-                  border: '1px dashed #60a5fa',
-                  borderRadius: 6,
-                  display: 'inline-block',
-                  marginLeft: 0,
-                  marginRight: 0,
-                  cursor: 'nwse-resize',
-                  userSelect: 'none',
-                  boxSizing: 'border-box',
-                }}
+                style={{ width: 44, height: 24, position: 'relative', background: 'transparent', border: '1px dashed var(--accent)', borderRadius: 6, display: 'inline-block', cursor: 'nwse-resize', userSelect: 'none', boxSizing: 'border-box' }}
               >
                 <div style={{ position: 'absolute', right: 0, bottom: 0, width: 20, height: 20, display: 'flex', alignItems: 'flex-end', justifyContent: 'flex-end', pointerEvents: 'none' }}>
-                  <svg width="16" height="16" viewBox="0 0 20 20" fill="none"><rect x="6" y="16" width="8" height="2" rx="1" fill="#60a5fa" /><rect x="12" y="10" width="2" height="8" rx="1" fill="#60a5fa" /></svg>
+                  <svg width="12" height="12" viewBox="0 0 20 20" fill="none"><rect x="6" y="16" width="8" height="2" rx="1" fill="var(--accent)" /><rect x="12" y="10" width="2" height="8" rx="1" fill="var(--accent)" /></svg>
                 </div>
               </div>
-              <span className="text-xs text-slate-500 dark:text-slate-400 font-medium" style={{ marginLeft: 4 }}>{pinnedCardWidth}×{pinnedCardHeight}px</span>
+              <span style={{ fontSize: 11.5, color: 'var(--muted)', marginLeft: 4 }}>{pinnedCardWidth}×{pinnedCardHeight}px</span>
             </div>
           )}
-          <div className="flex-1 overflow-y-auto bg-slate-100 dark:bg-slate-900" style={{ display: isPinnedDrawerOpen ? 'block' : 'none' }}>
+          <div style={{ flex: 1, overflowY: 'auto', background: 'var(--bg)', display: isPinnedDrawerOpen ? 'block' : 'none' }}>
             {pinnedDocuments.length > 0 ? (
-              <div className="p-4 flex flex-wrap gap-4">
+              <div style={{ padding: 16, display: 'flex', flexWrap: 'wrap', gap: 16 }}>
                 {pinnedDocuments.map(({ doc, collectionName }) => (
                   <div
                     key={getDocId(doc)}
-                    className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 flex flex-col overflow-hidden animate-fade-in-fast"
-                    style={{ height: pinnedCardHeight, width: pinnedCardWidth, minHeight: minCardHeight, maxHeight: maxCardHeight, minWidth: minCardWidth, maxWidth: maxCardWidth, flex: '0 0 auto' }}
+                    className="qa-card"
+                    style={{ height: pinnedCardHeight, width: pinnedCardWidth, minHeight: minCardHeight, maxHeight: maxCardHeight, minWidth: minCardWidth, maxWidth: maxCardWidth, flex: '0 0 auto', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
                   >
-                    <header className="p-3 border-b border-slate-200 dark:border-slate-700 flex justify-between items-center flex-shrink-0">
+                    <header style={{ padding: '10px 12px', borderBottom: '1px solid var(--border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexShrink: 0 }}>
                       <div>
-                        <p className="text-sm font-bold text-blue-600 dark:text-blue-400">{collectionName}</p>
-                        <p className="text-xs font-mono text-slate-500 dark:text-slate-400 truncate" title={getDocId(doc)}>{getDocId(doc)}</p>
+                        <p style={{ fontSize: 12, fontWeight: 600, color: 'var(--accent)', margin: 0 }}>{collectionName}</p>
+                        <p style={{ fontSize: 11, fontFamily: 'var(--font-mono)', color: 'var(--muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', margin: 0 }} title={getDocId(doc)}>{getDocId(doc)}</p>
                       </div>
                       <button
                         onClick={() => handleTogglePin(doc, collectionName)}
-                        className="p-1.5 rounded-full text-blue-500 hover:bg-blue-100 dark:hover:bg-blue-900/50"
+                        style={{ padding: 4, borderRadius: 4, background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex' }}
                         title="Unpin document"
+                        onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--status-err)'; }}
+                        onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
                       >
-                        <XIcon className="w-4 h-4" />
+                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M3 3l10 10M13 3L3 13"/></svg>
                       </button>
                     </header>
-                    <div className="p-3 flex-grow overflow-y-auto">
+                    <div style={{ padding: 12, flexGrow: 1, overflowY: 'auto' }}>
                       <JsonDisplay data={doc} onObjectIdClick={(objId, keyCtx, openNewTab, openToSide) => handleObjectIdClick(null, objId, keyCtx, openNewTab, openToSide)} />
                     </div>
                   </div>
                 ))}
               </div>
             ) : (
-              <div className="h-full flex items-center justify-center text-slate-500 dark:text-slate-400">
+              <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--muted)', fontSize: 13 }}>
                 Pin documents to compare them here.
               </div>
             )}
@@ -1095,111 +1094,103 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
 
   const pageContent = (
     <>
-    <div className={embedded ? 'flex flex-col h-full relative' : 'flex flex-col h-screen relative'}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: embedded ? '100%' : '100vh', position: 'relative', background: 'var(--bg)', fontFamily: 'var(--font-body)' }}>
 
         {/* Loading Overlay */}
         {isLoadingDbsForAccount && (
-          <div className="absolute inset-0 z-50 bg-black/20 dark:bg-black/40 backdrop-blur-sm flex items-center justify-center">
-            <div className="bg-white dark:bg-slate-800 rounded-lg shadow-xl px-6 py-4 flex items-center gap-3 border border-slate-200 dark:border-slate-700">
-              <SpinnerIcon className="w-5 h-5 animate-spin text-blue-500" />
-              <span className="text-slate-700 dark:text-slate-200 font-medium">Switching account...</span>
+          <div style={{ position: 'absolute', inset: 0, zIndex: 50, background: 'rgba(0,0,0,0.2)', backdropFilter: 'blur(2px)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <div style={{ background: 'var(--panel)', borderRadius: 10, boxShadow: '0 8px 30px rgba(0,0,0,0.12)', padding: '14px 24px', display: 'flex', alignItems: 'center', gap: 10, border: '1px solid var(--border)' }}>
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.5" style={{ animation: 'qp-spin 0.8s linear infinite' }}>
+                <circle cx="8" cy="8" r="6" strokeOpacity="0.3"/><path d="M8 2a6 6 0 0 1 6 6"/>
+              </svg>
+              <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)' }}>Switching account...</span>
             </div>
           </div>
         )}
 
         {/* Header — hidden in embedded mode (AppTopBar handles breadcrumb) */}
-        {!embedded && <header className="flex-shrink-0 bg-white dark:bg-slate-800/50 border-b border-slate-200 dark:border-slate-700">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex items-center justify-between h-16">
-              <div className="flex items-center gap-4">
-                <MongoIcon className="w-9 h-9 text-blue-500" />
+        {!embedded && <header style={{ flexShrink: 0, background: 'var(--panel)', borderBottom: '1px solid var(--border)' }}>
+          <div style={{ maxWidth: 1280, margin: '0 auto', padding: '0 24px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', height: 64 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+                <MongoIcon className="w-9 h-9" style={{ color: 'var(--accent)' }} />
                 <div>
-                  <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">Data Explorer</h1>
-                  <div className="flex items-center gap-2 font-mono text-xs text-blue-600 dark:text-blue-400">
-                    <div className="relative" ref={accountSwitcherRef}>
+                  <h1 style={{ fontSize: 17, fontWeight: 700, color: 'var(--fg)', margin: 0 }}>Data Explorer</h1>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontFamily: 'var(--font-mono)', fontSize: 11 }}>
+                    <div style={{ position: 'relative' }} ref={accountSwitcherRef}>
                       <button
                         onClick={() => setIsAccountSwitcherOpen(!isAccountSwitcherOpen)}
                         disabled={availableAccounts.length <= 1}
-                        className="flex items-center gap-1 font-bold px-2 py-1 rounded-md hover:bg-slate-100 dark:hover:bg-slate-700/50 disabled:cursor-default disabled:hover:bg-transparent"
+                        style={{ display: 'flex', alignItems: 'center', gap: 4, fontWeight: 700, padding: '2px 6px', borderRadius: 4, background: 'none', border: 'none', cursor: availableAccounts.length <= 1 ? 'default' : 'pointer', color: 'var(--accent)', fontFamily: 'var(--font-mono)' }}
                         title="Switch account"
                       >
                         {currentAccount.name}
-                        {availableAccounts.length > 1 && <ChevronDownIcon className={`w-3 h-3 transition-transform ${isAccountSwitcherOpen ? 'rotate-180' : ''}`} />}
+                        {availableAccounts.length > 1 && <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ transform: isAccountSwitcherOpen ? 'rotate(180deg)' : 'none' }}><path d="M3 6l5 5 5-5"/></svg>}
                       </button>
                       {isAccountSwitcherOpen && (
-                        <div className="absolute top-full mt-2 w-60 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-xl z-20 animate-fade-in-fast">
-                          <div className="p-2">
-                            {availableAccounts.map(acc => (
-                              <button
-                                key={acc.id}
-                                onClick={() => handleAccountSwitch(acc)}
-                                className={`w-full text-left px-3 py-2 text-sm rounded-md ${acc.id === currentAccount.id ? 'font-bold bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300' : 'text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700'}`}
-                              >
-                                {acc.name}
-                              </button>
-                            ))}
-                          </div>
+                        <div style={{ position: 'absolute', top: '100%', marginTop: 6, width: 240, background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 10, boxShadow: '0 8px 24px rgba(0,0,0,0.1)', zIndex: 20, padding: 6 }}>
+                          {availableAccounts.map(acc => (
+                            <button
+                              key={acc.id}
+                              onClick={() => handleAccountSwitch(acc)}
+                              style={{ width: '100%', textAlign: 'left', padding: '7px 10px', fontSize: 13, borderRadius: 6, border: 'none', cursor: 'pointer', background: acc.id === currentAccount.id ? 'var(--accent-soft)' : 'none', color: acc.id === currentAccount.id ? 'var(--accent)' : 'var(--fg)', fontWeight: acc.id === currentAccount.id ? 600 : 400 }}
+                            >
+                              {acc.name}
+                            </button>
+                          ))}
                         </div>
                       )}
                     </div>
-                    <span>/</span>
-                    <div className="relative" ref={dbSwitcherRef}>
+                    <span style={{ color: 'var(--muted)' }}>/</span>
+                    <div style={{ position: 'relative' }} ref={dbSwitcherRef}>
                       <button
                         onClick={() => setIsDbSwitcherOpen(!isDbSwitcherOpen)}
                         disabled={currentAccountDbs.length <= 1 || isLoadingDbsForAccount}
-                        className="flex items-center gap-1 font-bold px-2 py-1 rounded-md hover:bg-slate-100 dark:hover:bg-slate-700/50 disabled:cursor-default disabled:hover:bg-transparent"
+                        style={{ display: 'flex', alignItems: 'center', gap: 4, fontWeight: 700, padding: '2px 6px', borderRadius: 4, background: 'none', border: 'none', cursor: currentAccountDbs.length <= 1 ? 'default' : 'pointer', color: 'var(--accent)', fontFamily: 'var(--font-mono)' }}
                         title="Switch database"
                       >
                         {isLoadingDbsForAccount ? 'Loading...' : (currentDb?.name || 'Select Database')}
-                        {!isLoadingDbsForAccount && currentAccountDbs.length > 1 && <ChevronDownIcon className={`w-3 h-3 transition-transform ${isDbSwitcherOpen ? 'rotate-180' : ''}`} />}
+                        {!isLoadingDbsForAccount && currentAccountDbs.length > 1 && <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ transform: isDbSwitcherOpen ? 'rotate(180deg)' : 'none' }}><path d="M3 6l5 5 5-5"/></svg>}
                       </button>
                       {isDbSwitcherOpen && (
-                        <div className="absolute top-full mt-2 w-60 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-xl z-20 animate-fade-in-fast">
-                          <div className="p-2">
-                            {currentAccountDbs.map(db => (
-                              <button
-                                key={db.name}
-                                onClick={() => handleDbSwitch(db)}
-                                className={`w-full text-left px-3 py-2 text-sm rounded-md ${db.name === currentDb?.name ? 'font-bold bg-blue-50 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300' : 'text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700'}`}
-                              >
-                                {db.name}
-                              </button>
-                            ))}
-                          </div>
+                        <div style={{ position: 'absolute', top: '100%', marginTop: 6, width: 240, background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 10, boxShadow: '0 8px 24px rgba(0,0,0,0.1)', zIndex: 20, padding: 6 }}>
+                          {currentAccountDbs.map(db => (
+                            <button
+                              key={db.name}
+                              onClick={() => handleDbSwitch(db)}
+                              style={{ width: '100%', textAlign: 'left', padding: '7px 10px', fontSize: 13, borderRadius: 6, border: 'none', cursor: 'pointer', background: db.name === currentDb?.name ? 'var(--accent-soft)' : 'none', color: db.name === currentDb?.name ? 'var(--accent)' : 'var(--fg)', fontWeight: db.name === currentDb?.name ? 600 : 400 }}
+                            >
+                              {db.name}
+                            </button>
+                          ))}
                         </div>
                       )}
                     </div>
                   </div>
                 </div>
               </div>
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={toggleTheme}
-                  className="h-9 w-9 flex items-center justify-center border border-slate-300 dark:border-slate-600 rounded-md text-slate-600 dark:text-slate-300 bg-white dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
-                  aria-label="Toggle theme"
-                  title="Toggle light/dark mode"
-                >
-                  {theme === 'light' ? <MoonIcon className="w-5 h-5" /> : <SunIcon className="w-5 h-5" />}
-                </button>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                 <button
                   onClick={handleClearDocCache}
                   disabled={cacheClearStatus !== 'idle'}
-                  className="h-9 w-9 flex items-center justify-center border border-slate-300 dark:border-slate-600 rounded-md text-slate-600 dark:text-slate-300 bg-white dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus:outline-none focus:ring-2 focus:ring-slate-400"
+                  className="qa-btn"
+                  style={{ width: 36, height: 36, padding: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                   title="Clear the server cache for linked document lookups"
                   aria-label="Clear cache"
                 >
-                  {cacheClearStatus === 'loading' && <SpinnerIcon className="w-5 h-5 animate-spin" />}
-                  {cacheClearStatus === 'success' && <CheckIcon className="w-5 h-5 text-green-500" />}
-                  {cacheClearStatus === 'error' && <XIcon className="w-5 h-5 text-red-500" />}
-                  {cacheClearStatus === 'idle' && <CachedIcon className="w-5 h-5" />}
+                  {cacheClearStatus === 'loading' && <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ animation: 'qp-spin 0.8s linear infinite' }}><circle cx="8" cy="8" r="6" strokeOpacity="0.3"/><path d="M8 2a6 6 0 0 1 6 6"/></svg>}
+                  {cacheClearStatus === 'success' && <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.5"><path d="M3 8l3.5 3.5L13 5"/></svg>}
+                  {cacheClearStatus === 'error' && <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="var(--status-err)" strokeWidth="1.5"><path d="M3 3l10 10M13 3L3 13"/></svg>}
+                  {cacheClearStatus === 'idle' && <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M1 4v6h6M23 20v-6h-6"/><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"/></svg>}
                 </button>
                 <button
                   onClick={onNavigateBack}
-                  className="flex items-center gap-2 px-4 py-2 border border-slate-300 dark:border-slate-600 text-sm font-medium rounded-md text-slate-600 dark:text-slate-300 bg-white dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+                  className="qa-btn"
+                  style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13 }}
                   title="Return to the query generator"
                 >
-                  <ArrowLeftIcon className="w-4 h-4" />
-                  <span>Back to Query Generator</span>
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M10 3L5 8l5 5"/></svg>
+                  Back to Query Generator
                 </button>
               </div>
             </div>
@@ -1207,95 +1198,106 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
         </header>}
 
         {/* Main Content Area */}
-        <main className="flex-grow overflow-hidden block w-full h-full relative">
-          <PanelGroup orientation="horizontal" id="querypal-panel-layout" className="w-full h-full relative">
-            {/* Column 1: Collections */}
-            <Panel defaultSize={20} minSize={10}>
-              <div className="h-full bg-slate-100 dark:bg-slate-800 overflow-y-auto">
-                <div className="p-4">
-                  <div className="flex justify-between items-center mb-4">
-                    <h2 className="text-lg font-semibold text-slate-700 dark:text-slate-200">Collections</h2>
-                    <div className="flex items-center gap-1 p-0.5 bg-slate-200 dark:bg-slate-700 rounded-md">
+        <main style={{ flexGrow: 1, overflow: 'hidden', display: 'block', width: '100%', height: '100%', position: 'relative' }}>
+          <PanelGroup orientation="horizontal" id={embedded ? 'querypal-panel-layout-embedded' : 'querypal-panel-layout'} style={{ width: '100%', height: '100%', position: 'relative' }}>
+            {/* Column 1: Collections — hidden in embedded mode (sidebar handles this) */}
+            {!embedded && <Panel defaultSize={20} minSize={10}>
+              <div style={{ height: '100%', background: 'var(--soft)', overflowY: 'auto' }}>
+                <div style={{ padding: 16 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 14 }}>
+                    <h2 style={{ fontSize: 13, fontWeight: 600, color: 'var(--fg)', margin: 0 }}>Collections</h2>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 2, padding: 2, background: 'var(--border)', borderRadius: 6 }}>
                       <button
                         onClick={() => handleSortCollections('name')}
-                        className={`flex items-center gap-1 px-2 py-1 text-xs font-semibold rounded transition-colors ${collectionSortKey === 'name' ? 'bg-white dark:bg-slate-600 text-blue-600 dark:text-blue-300 shadow' : 'text-slate-600 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-600'}`}
+                        style={{ display: 'flex', alignItems: 'center', gap: 3, padding: '3px 7px', fontSize: 11.5, fontWeight: 600, borderRadius: 4, border: 'none', cursor: 'pointer', background: collectionSortKey === 'name' ? 'var(--panel)' : 'transparent', color: collectionSortKey === 'name' ? 'var(--accent)' : 'var(--muted)', boxShadow: collectionSortKey === 'name' ? '0 1px 2px rgba(0,0,0,0.06)' : 'none' }}
                         title={`Sort by name (${collectionSortKey === 'name' && collectionSortOrder === 'asc' ? 'descending' : 'ascending'})`}
                       >
                         Name {renderSortArrow('name')}
                       </button>
                       <button
                         onClick={() => handleSortCollections('count')}
-                        className={`flex items-center gap-1 px-2 py-1 text-xs font-semibold rounded transition-colors ${collectionSortKey === 'count' ? 'bg-white dark:bg-slate-600 text-blue-600 dark:text-blue-300 shadow' : 'text-slate-600 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-600'}`}
+                        style={{ display: 'flex', alignItems: 'center', gap: 3, padding: '3px 7px', fontSize: 11.5, fontWeight: 600, borderRadius: 4, border: 'none', cursor: 'pointer', background: collectionSortKey === 'count' ? 'var(--panel)' : 'transparent', color: collectionSortKey === 'count' ? 'var(--accent)' : 'var(--muted)', boxShadow: collectionSortKey === 'count' ? '0 1px 2px rgba(0,0,0,0.06)' : 'none' }}
                         title={`Sort by count (${collectionSortKey === 'count' && collectionSortOrder === 'asc' ? 'descending' : 'ascending'})`}
                       >
                         Count {renderSortArrow('count')}
                       </button>
                     </div>
                   </div>
-                  <div className="space-y-2">
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                     {isLoadingDbsForAccount ? (
-                      <div className="text-center p-4 text-slate-500 dark:text-slate-400">Loading collections...</div>
+                      <div style={{ textAlign: 'center', padding: 16, color: 'var(--muted)', fontSize: 13 }}>Loading collections...</div>
                     ) : sortedCollections.length > 0 ? (
                       sortedCollections.map(col => (
                         <button
                           key={col.name}
                           onClick={() => handleCollectionClick(col.name)}
-                          className={`w-full text-left p-3 rounded-md text-sm font-medium transition-colors ${selectedCollection === col.name ? 'bg-blue-500 text-white shadow-md' : 'bg-white dark:bg-slate-700/50 text-slate-600 dark:text-slate-300 hover:bg-blue-50 dark:hover:bg-blue-900/20'}`}
+                          style={{ width: '100%', textAlign: 'left', padding: '9px 11px', borderRadius: 7, fontSize: 13, fontWeight: 500, border: 'none', cursor: 'pointer', background: selectedCollection === col.name ? 'var(--accent)' : 'var(--panel)', color: selectedCollection === col.name ? 'white' : 'var(--fg)' }}
+                          onMouseEnter={(e) => { if (selectedCollection !== col.name) (e.currentTarget as HTMLElement).style.background = 'var(--accent-soft)'; }}
+                          onMouseLeave={(e) => { if (selectedCollection !== col.name) (e.currentTarget as HTMLElement).style.background = 'var(--panel)'; }}
                         >
-                          <div className="flex justify-between items-center">
-                            <span className="font-bold">{col.name}</span>
-                            <span className={`text-xs px-2 py-0.5 rounded-full ${selectedCollection === col.name ? 'bg-white/20' : 'bg-slate-200 dark:bg-slate-600'}`}>{col.count.toLocaleString()}</span>
+                          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                            <span style={{ fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{col.name}</span>
+                            <span style={{ fontSize: 11, padding: '1px 6px', borderRadius: 10, background: selectedCollection === col.name ? 'rgba(255,255,255,0.2)' : 'var(--soft)', flexShrink: 0, marginLeft: 6 }}>{col.count.toLocaleString()}</span>
                           </div>
                         </button>
                       ))
                     ) : (
-                      <div className="text-center p-4 text-slate-500 dark:text-slate-400">No collections found.</div>
+                      <div style={{ textAlign: 'center', padding: 16, color: 'var(--muted)', fontSize: 13 }}>No collections found.</div>
                     )}
                   </div>
                 </div>
               </div>
-            </Panel>
+            </Panel>}
 
-            <PanelResizeHandle className="w-1 bg-slate-200 dark:bg-slate-700 hover:bg-blue-400 dark:hover:bg-blue-500 transition-colors cursor-col-resize z-10 flex-shrink-0" />
+            {!embedded && <PanelResizeHandle style={{ width: 1, background: 'var(--border)', cursor: 'col-resize', flexShrink: 0, zIndex: 10 }} />}
 
             {/* Column 2: Documents */}
-            <Panel defaultSize={20} minSize={15}>
-              <div className="h-full bg-white dark:bg-slate-800/50 flex flex-col">
-                <div className="p-4 border-b border-slate-200 dark:border-slate-700 flex-shrink-0">
-                  <div className="flex justify-between items-center mb-2">
-                    <h2 className="text-lg font-semibold text-slate-700 dark:text-slate-200">
-                      Documents {totalDocuments > 0 && `(${totalDocuments.toLocaleString()})`}
+            <Panel defaultSize={embedded ? 28 : 20} minSize={15}>
+              <div style={{ height: '100%', background: 'var(--panel)', display: 'flex', flexDirection: 'column' }}>
+                <div style={{ padding: '12px 14px', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+                    <h2 style={{ fontSize: 13, fontWeight: 600, color: 'var(--fg)', margin: 0 }}>
+                      Documents {totalDocuments > 0 && <span style={{ color: 'var(--muted)', fontWeight: 400 }}>({totalDocuments.toLocaleString()})</span>}
                     </h2>
-                    <div className="flex items-center gap-2">
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                       <button
                         onClick={handleOpenCreateDialog}
                         disabled={!selectedCollection || isLoading || isFetchingSchema}
-                        className={`p-2 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 text-slate-400 hover:text-blue-600 hover:bg-blue-100 dark:hover:bg-blue-900/40 ${isCreateDialogOpen ? 'text-blue-500 bg-blue-100 dark:bg-blue-900/50' : ''}`}
+                        style={{ padding: 5, borderRadius: 5, background: isCreateDialogOpen ? 'var(--accent-soft)' : 'none', border: 'none', cursor: !selectedCollection ? 'not-allowed' : 'pointer', color: isCreateDialogOpen ? 'var(--accent)' : 'var(--muted)', display: 'flex', opacity: !selectedCollection ? 0.5 : 1 }}
                         title="Create new document"
                         aria-label="Create new document"
+                        onMouseEnter={(e) => { if (selectedCollection) (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; }}
+                        onMouseLeave={(e) => { if (!isCreateDialogOpen) (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
                       >
-                        <NoteAddIcon className={`w-5 h-5 ${isCreateDialogOpen ? 'fill-current' : 'stroke-current'} transition-colors`} />
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/></svg>
                       </button>
                       <button
                         onClick={handleRefresh}
                         disabled={!selectedCollection || isLoading || isFetchingSchema}
-                        className="p-1.5 rounded-full text-slate-500 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: !selectedCollection ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: !selectedCollection ? 0.5 : 1 }}
                         title="Refresh documents and schema"
+                        onMouseEnter={(e) => { if (selectedCollection) (e.currentTarget as HTMLElement).style.color = 'var(--fg)'; }}
+                        onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
                       >
-                        <ClearAllIcon className={`w-4 h-4 ${(isLoading || isFetchingSchema) ? 'animate-pulse' : ''}`} />
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ animation: (isLoading || isFetchingSchema) ? 'qp-spin 1s linear infinite' : 'none' }}><path d="M1 4v6h6M23 20v-6h-6"/><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"/></svg>
                       </button>
                     </div>
                   </div>
-                  <div className="space-y-2">
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 260, overflowY: 'auto' }}>
                     {filters.map((f) => (
-                      <div key={f.id} className="flex flex-col gap-2 p-3 bg-slate-50 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-700 rounded-lg relative">
+                      <div key={f.id} style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: 10, background: 'var(--soft)', border: '1px solid var(--border)', borderRadius: 8, position: 'relative', flexShrink: 0 }}>
                         {filters.length > 1 && (
-                          <button onClick={() => removeFilter(f.id)} className="absolute -top-2 -right-2 p-1 bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-full text-slate-400 hover:text-red-500 hover:border-red-500 shadow-sm z-10 transition-colors">
-                            <XIcon className="w-3 h-3" />
+                          <button
+                            onClick={() => removeFilter(f.id)}
+                            style={{ position: 'absolute', top: -8, right: -8, padding: 3, background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: '50%', color: 'var(--muted)', display: 'flex', cursor: 'pointer', zIndex: 10 }}
+                            onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--status-err)'; (e.currentTarget as HTMLElement).style.borderColor = 'var(--status-err)'; }}
+                            onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; (e.currentTarget as HTMLElement).style.borderColor = 'var(--border)'; }}
+                          >
+                            <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M3 3l10 10M13 3L3 13"/></svg>
                           </button>
                         )}
-                        <div className="flex gap-2">
-                          <div className="flex-[2_2_0%] relative">
+                        <div style={{ display: 'flex', gap: 6 }}>
+                          <div style={{ flex: '2 2 0%', position: 'relative' }}>
                             {!f.isCustom ? (
                               <>
                                 <select
@@ -1306,11 +1308,11 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
                                     } else {
                                       const newKey = e.target.value;
                                       const isDate = newKey.toLowerCase().includes('date') || newKey.toLowerCase().includes('time');
-                                      updateFilter(f.id, { key: newKey, type: isDate ? 'date' : 'string' });
+                                      updateFilter(f.id, { key: newKey, type: isDate ? 'date' : 'string', operator: 'equals' });
                                     }
                                   }}
                                   disabled={!selectedCollection || isFetchingSchema}
-                                  className="w-full text-sm appearance-none cursor-pointer p-2 pr-8 bg-white dark:bg-slate-700/50 border border-slate-300 dark:border-slate-600 rounded-lg text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors disabled:opacity-50"
+                                  style={{ width: '100%', fontSize: 12, appearance: 'none', cursor: 'pointer', padding: '6px 26px 6px 8px', background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 6, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}
                                   title="Select a field to filter by"
                                 >
                                   <option value="all">All Fields</option>
@@ -1318,10 +1320,10 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
                                   <option disabled>──────────</option>
                                   <option value="__custom__">Type custom field...</option>
                                 </select>
-                                <ChevronDownIcon className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 dark:text-slate-500 pointer-events-none" />
+                                <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="var(--muted)" strokeWidth="2" style={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}><path d="M3 6l5 5 5-5"/></svg>
                               </>
                             ) : (
-                              <div className="flex items-center relative">
+                              <div style={{ display: 'flex', alignItems: 'center', position: 'relative' }}>
                                 <input
                                   type="text"
                                   value={f.key}
@@ -1332,73 +1334,77 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
                                   }}
                                   disabled={!selectedCollection || isFetchingSchema}
                                   placeholder="e.g. internal_info.internal_id"
-                                  className="w-full text-sm p-2 pr-8 bg-white dark:bg-slate-700/50 border border-slate-300 dark:border-slate-600 rounded-lg text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors disabled:opacity-50"
+                                  style={{ width: '100%', fontSize: 12, padding: '6px 26px 6px 8px', background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 6, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}
                                   autoFocus
                                 />
                                 <button
                                   onClick={() => updateFilter(f.id, { isCustom: false, key: 'all' })}
-                                  className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors bg-slate-200 dark:bg-slate-600"
+                                  style={{ position: 'absolute', right: 6, top: '50%', transform: 'translateY(-50%)', padding: 2, borderRadius: '50%', background: 'var(--soft)', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex' }}
                                   title="Back to dropdown"
                                 >
-                                  <XIcon className="w-3 h-3" />
+                                  <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M3 3l10 10M13 3L3 13"/></svg>
                                 </button>
                               </div>
                             )}
                           </div>
-                          {f.key !== 'all' && (
-                            <div className="flex-1 relative">
-                              <select
-                                value={f.operator || 'equals'}
-                                onChange={(e) => updateFilter(f.id, { operator: e.target.value })}
-                                disabled={!selectedCollection || isFetchingSchema}
-                                className="w-full text-sm appearance-none cursor-pointer p-2 pr-8 bg-white dark:bg-slate-700/50 border border-slate-300 dark:border-slate-600 rounded-lg text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors disabled:opacity-50"
-                              >
-                                <option value="equals">Equals</option>
-                                <option value="not_equals">Does Not Equal</option>
+                          {/* Operator always visible: "All Fields" gets contains-only; specific fields get full list */}
+                          <div style={{ flex: '1 1 0%', position: 'relative' }}>
+                            <select
+                              value={f.operator || (f.key === 'all' ? 'contains' : 'equals')}
+                              onChange={(e) => updateFilter(f.id, { operator: e.target.value })}
+                              disabled={!selectedCollection || isFetchingSchema}
+                              style={{ width: '100%', fontSize: 12, appearance: 'none', cursor: 'pointer', padding: '6px 26px 6px 8px', background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 6, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}
+                            >
+                              {f.key === 'all' ? (
                                 <option value="contains">Contains</option>
-                                <option value="greater_than">Greater Than (&gt;)</option>
-                                <option value="less_than">Less Than (&lt;)</option>
-                                <option value="exists">Exists</option>
-                                <option value="not_exists">Does Not Exist</option>
-                              </select>
-                              <ChevronDownIcon className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 dark:text-slate-500 pointer-events-none" />
-                            </div>
-                          )}
+                              ) : (
+                                <>
+                                  <option value="equals">Equals</option>
+                                  <option value="not_equals">Not Equals</option>
+                                  <option value="contains">Contains</option>
+                                  <option value="greater_than">{'>'} Greater</option>
+                                  <option value="less_than">{'<'} Less</option>
+                                  <option value="exists">Exists</option>
+                                  <option value="not_exists">Not Exists</option>
+                                </>
+                              )}
+                            </select>
+                            <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="var(--muted)" strokeWidth="2" style={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}><path d="M3 6l5 5 5-5"/></svg>
+                          </div>
                         </div>
                         {(!f.operator || (f.operator !== 'exists' && f.operator !== 'not_exists')) && (
-                          <div className="relative">
+                          <div style={{ position: 'relative' }}>
                             <input
                               type={f.type === 'date' ? 'datetime-local' : 'text'}
                               placeholder={isFetchingSchema ? 'Loading schema...' : 'Filter value...'}
                               value={f.value}
                               onChange={(e) => updateFilter(f.id, { value: e.target.value })}
                               disabled={!selectedCollection || isFetchingSchema}
-                              className="w-full pl-9 pr-4 py-2 bg-white dark:bg-slate-700/50 border border-slate-300 dark:border-slate-600 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors disabled:opacity-50"
+                              style={{ width: '100%', paddingLeft: 30, paddingRight: 8, paddingTop: 6, paddingBottom: 6, background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 6, fontSize: 12, color: 'var(--fg)', fontFamily: 'var(--font-body)', boxSizing: 'border-box' }}
                             />
-                            <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 dark:text-slate-500" />
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--muted)" strokeWidth="1.5" style={{ position: 'absolute', left: 9, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
                           </div>
                         )}
                       </div>
                     ))}
-                    <div className="flex gap-2">
+                    <div style={{ display: 'flex', gap: 6 }}>
                       <button
                         onClick={addFilter}
                         disabled={!selectedCollection || isFetchingSchema}
-                        className="flex-1 flex justify-center items-center gap-1 p-2 text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700/50 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-300 dark:border-slate-600 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="qa-btn"
+                        style={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center', fontSize: 12 }}
                       >
-                        <span>+ Add Filter</span>
+                        + Add Filter
                       </button>
                       <button
                         onClick={() => {
                           if (!selectedCollection) return;
-
                           const validFilters = debouncedFilters.map(f => ({
                             key: f.key,
                             value: getCoercedFilterValue(f.value),
                             operator: f.operator || 'equals',
                             type: f.type || 'string'
                           }));
-
                           getDocumentsQueryCode(selectedCollection, currentResource, undefined, validFilters)
                             .then((queryCodeStr) => {
                               navigator.clipboard.writeText(queryCodeStr).then(() => {
@@ -1412,44 +1418,53 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
                             });
                         }}
                         disabled={!selectedCollection || isFetchingSchema}
-                        className="flex justify-center items-center gap-2 p-2 px-3 text-sm font-medium text-slate-600 dark:text-slate-300 bg-white dark:bg-slate-700 hover:bg-slate-50 dark:hover:bg-slate-600 border border-slate-300 dark:border-slate-600 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="qa-btn"
+                        style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 5, fontSize: 12 }}
                         title="Export current filter criteria as Python script (MongoDB PyMongo)"
                       >
-                        {copiedQuery ? <CheckIcon className="w-4 h-4 text-green-500" /> : <FileCopyIcon className="w-4 h-4" />}
-                        <span>Export</span>
+                        {copiedQuery
+                          ? <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.5"><path d="M3 8l3.5 3.5L13 5"/></svg>
+                          : <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                        }
+                        Export
                       </button>
                     </div>
                   </div>
                 </div>
-                <div className="flex-grow overflow-hidden">
+                <div style={{ flexGrow: 1, overflow: 'hidden' }}>
                   {renderDocumentList()}
                 </div>
               </div>
             </Panel>
 
-            <PanelResizeHandle className="w-1 bg-slate-200 dark:bg-slate-700 hover:bg-blue-400 dark:hover:bg-blue-500 transition-colors cursor-col-resize z-10 flex-shrink-0" />
+            <PanelResizeHandle style={{ width: 1, background: 'var(--border)', cursor: 'col-resize', flexShrink: 0, zIndex: 10 }} />
 
             {/* Column 3: Document Editor */}
-            <Panel defaultSize={60} minSize={30}>
-              <div className="h-full bg-slate-100 dark:bg-slate-900/40 overflow-x-auto overflow-y-hidden flex flex-row relative">
+            <Panel defaultSize={embedded ? 72 : 60} minSize={30}>
+              <div style={{ height: '100%', background: 'var(--bg)', overflowX: 'auto', overflowY: 'hidden', display: 'flex', flexDirection: 'row', position: 'relative' }}>
                 {openDocuments.length === 0 ? (
-                  <div className="absolute inset-0 flex items-center justify-center text-slate-500 dark:text-slate-400">
+                  <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--muted)', fontSize: 13 }}>
                     <p>Select a document to open it here.</p>
                   </div>
                 ) : (
                   openDocuments.map((openDoc, index) => (
                     <div
                       key={openDoc.id}
-                      className={`h-full ${openDocuments.length === 1 ? 'w-full' : 'flex-shrink-0'} flex flex-col border-l border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800/80 shadow-sm first:border-l-0 relative group/panel`}
                       style={{
-                        width: openDocuments.length === 1 ? undefined : (docWidths[openDoc.id] || 600),
-                        minWidth: openDocuments.length === 1 ? undefined : 400
+                        height: '100%',
+                        width: openDocuments.length === 1 ? '100%' : (docWidths[openDoc.id] || 600),
+                        minWidth: openDocuments.length === 1 ? undefined : 400,
+                        flexShrink: openDocuments.length === 1 ? undefined : 0,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        borderLeft: index === 0 ? 'none' : '1px solid var(--border)',
+                        background: 'var(--panel)',
+                        position: 'relative',
                       }}
                     >
                       {openDocuments.length > 1 && (
                         <div
-                          className="absolute right-0 top-0 bottom-0 w-2 cursor-col-resize hover:bg-blue-400 dark:hover:bg-blue-500 z-20 transition-colors opacity-0 group-hover/panel:opacity-100"
-                          style={{ right: -1 }}
+                          style={{ position: 'absolute', right: -1, top: 0, bottom: 0, width: 4, cursor: 'col-resize', zIndex: 20 }}
                           onMouseDown={(e) => {
                             e.preventDefault();
                             const startX = e.clientX;
@@ -1465,181 +1480,197 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
                             window.addEventListener('mousemove', onMouseMove);
                             window.addEventListener('mouseup', onMouseUp);
                           }}
+                          onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = 'var(--accent)'; }}
+                          onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
                         />
                       )}
-                      <div className="p-4 space-y-4 flex-1 overflow-y-auto">
-                        <header className="flex flex-wrap justify-between items-center gap-3 pb-2 border-b border-transparent">
-                          <div className="flex items-center gap-3 min-w-[200px] flex-1">
-                            <h2 className="text-xl font-semibold text-slate-800 dark:text-slate-100 truncate" title={openDoc.collectionName}>{openDoc.collectionName}</h2>
-                            <span className="font-mono text-xs text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded border border-slate-200 dark:border-slate-700 truncate flex-shrink-0 shadow-sm" style={{maxWidth: '160px'}} title={getDocId(openDoc.doc)}>
+                      <div style={{ padding: 16, flex: 1, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 14 }}>
+                        <header style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'space-between', alignItems: 'center', gap: 10, paddingBottom: 10, borderBottom: '1px solid var(--border)' }}>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 200, flex: 1 }}>
+                            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'var(--fg)', margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={openDoc.collectionName}>{openDoc.collectionName}</h2>
+                            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--muted)', background: 'var(--soft)', padding: '3px 7px', borderRadius: 5, border: '1px solid var(--border)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flexShrink: 0, maxWidth: 160 }} title={getDocId(openDoc.doc)}>
                               {getDocId(openDoc.doc)}
                             </span>
                           </div>
-                          
-                          <div className="flex items-center gap-1 flex-shrink-0 ml-auto bg-slate-50/50 dark:bg-slate-800/30 p-1 rounded-xl border border-transparent hover:border-slate-200 dark:hover:border-slate-700 transition-colors">
-                              <button
-                                onClick={() => handleTogglePin(openDoc.doc, openDoc.collectionName)}
-                                className={`p-1.5 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 ${isDocumentPinned(openDoc.doc) ? 'text-blue-500 bg-blue-100 dark:bg-blue-900/50' : 'text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700 hover:text-slate-600 dark:hover:text-slate-300'}`}
-                                title={isDocumentPinned(openDoc.doc) ? 'Unpin document' : 'Pin document'}
-                              >
-                                <PinIcon className={`w-4 h-4 ${isDocumentPinned(openDoc.doc) ? 'fill-current' : 'stroke-current'} transition-colors`} />
-                              </button>
-                              <button
-                                onClick={async () => {
-                                  setIsLoading(true);
-                                  try {
-                                    const refreshed = await getSingleDocument(
-                                      currentResource.accountId,
-                                      currentResource.databaseName,
-                                      openDoc.collectionName,
-                                      getDocId(openDoc.doc)
-                                    );
 
-                                    if (openDoc.editMode && editorRefs.current[openDoc.id]) {
-                                      const editedValue = editorRefs.current[openDoc.id]!.getCurrentValue();
-                                      let isDifferent = false;
-
-                                      try {
-                                        const parsedEdited = JSON.parse(editedValue);
-                                        const ignoredKeys = ['_id', 'datetime_creation', 'datetime_last_modified'];
-                                        const editedWithoutIgnored = omit(parsedEdited, ignoredKeys);
-                                        const refreshedWithoutIgnored = omit(refreshed, ignoredKeys);
-                                        isDifferent = !isEqual(editedWithoutIgnored, refreshedWithoutIgnored);
-                                      } catch (e) {
-                                        const freshString = JSON.stringify(refreshed, null, 2);
-                                        isDifferent = editedValue !== freshString;
-                                      }
-
-                                      if (isDifferent) {
-                                        setDiffCurrentEditedText(editedValue);
-                                        setDiffIncomingDocument(refreshed);
-                                        setDiffTargetDocId(openDoc.id);
-                                        setIsDiffOverwriteDialogOpen(true);
-                                        setIsLoading(false);
-                                        return;
-                                      }
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0, marginLeft: 'auto', padding: 4, borderRadius: 8, border: '1px solid transparent' }}>
+                            <button
+                              onClick={() => handleTogglePin(openDoc.doc, openDoc.collectionName)}
+                              style={{ padding: 5, borderRadius: 5, background: isDocumentPinned(openDoc.doc) ? 'var(--accent-soft)' : 'none', border: 'none', cursor: 'pointer', color: isDocumentPinned(openDoc.doc) ? 'var(--accent)' : 'var(--muted)', display: 'flex' }}
+                              title={isDocumentPinned(openDoc.doc) ? 'Unpin document' : 'Pin document'}
+                            >
+                              <svg width="13" height="13" viewBox="0 0 16 16" fill={isDocumentPinned(openDoc.doc) ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="1.5"><path d="M9.5 1.5l5 5-1.5 1.5-1-1-3 3v4l-1.5-1.5-3-3-1.5 1.5v-4l3-3-1-1zM1.5 14.5l4-4"/></svg>
+                            </button>
+                            <button
+                              onClick={async () => {
+                                setIsLoading(true);
+                                try {
+                                  const refreshed = await getSingleDocument(
+                                    currentResource.accountId,
+                                    currentResource.databaseName,
+                                    openDoc.collectionName,
+                                    getDocId(openDoc.doc)
+                                  );
+                                  if (openDoc.editMode && editorRefs.current[openDoc.id]) {
+                                    const editedValue = editorRefs.current[openDoc.id]!.getCurrentValue();
+                                    let isDifferent = false;
+                                    try {
+                                      const parsedEdited = JSON.parse(editedValue);
+                                      const ignoredKeys = ['_id', 'datetime_creation', 'datetime_last_modified'];
+                                      const editedWithoutIgnored = omit(parsedEdited, ignoredKeys);
+                                      const refreshedWithoutIgnored = omit(refreshed, ignoredKeys);
+                                      isDifferent = !isEqual(editedWithoutIgnored, refreshedWithoutIgnored);
+                                    } catch (e) {
+                                      const freshString = JSON.stringify(refreshed, null, 2);
+                                      isDifferent = editedValue !== freshString;
                                     }
-
-                                    setOpenDocuments(prev => prev.map(od => od.id === openDoc.id ? { ...od, doc: refreshed } : od));
-                                    setPinnedDocuments(prev => prev.map(p =>
-                                      getDocId(p.doc) === getDocId(openDoc.doc) ? { ...p, doc: refreshed } : p
-                                    ));
-                                    if (openDoc.editMode && editorRefs.current[openDoc.id]) {
-                                      editorRefs.current[openDoc.id]!.setCurrentValue(JSON.stringify(refreshed, null, 2));
+                                    if (isDifferent) {
+                                      setDiffCurrentEditedText(editedValue);
+                                      setDiffIncomingDocument(refreshed);
+                                      setDiffTargetDocId(openDoc.id);
+                                      setIsDiffOverwriteDialogOpen(true);
+                                      setIsLoading(false);
+                                      return;
                                     }
-                                  } catch (e) {
-                                  } finally {
-                                    setIsLoading(false);
                                   }
-                                }}
-                                className="p-1.5 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 text-slate-400 hover:text-blue-600 hover:bg-blue-100 dark:hover:bg-blue-900/40"
-                                title="Refresh document"
-                                disabled={isLoading}
-                              >
-                                <RefreshIcon className="w-4 h-4" />
-                              </button>
-                              {!openDoc.editMode && (
-                                <>
-                                  <button
-                                    className={`p-1.5 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 ${openDoc.editMode ? 'text-blue-500 bg-blue-100 dark:bg-blue-900/50' : 'text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700 hover:text-slate-600 dark:hover:text-slate-300'}`}
-                                    onClick={() => setOpenDocuments(prev => prev.map(od => od.id === openDoc.id ? { ...od, editMode: true } : od))}
-                                    disabled={isLoading}
-                                    title="Edit document"
-                                  >
-                                    <EditIcon className={`w-4 h-4 ${openDoc.editMode ? 'fill-current' : 'stroke-current'} transition-colors`} />
-                                  </button>
-                                  <button
-                                    className="p-1.5 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 text-slate-400 hover:text-blue-600 hover:bg-blue-100 dark:hover:bg-blue-900/40"
-                                    onClick={() => {
-                                      const { _id, ...rest } = openDoc.doc;
-                                      setCreateDocInitial(rest);
-                                      setIsCreateDialogOpen(true);
-                                    }}
-                                    disabled={isLoading}
-                                    title="Insert copy as new document"
-                                  >
-                                    <FileCopyIcon className="w-4 h-4 stroke-current transition-colors" />
-                                  </button>
-                                  <button
-                                    className="p-1.5 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-red-400 text-slate-400 hover:text-red-600 hover:bg-red-100 dark:hover:bg-red-900/40"
-                                    onClick={() => {
-                                      setDeleteTargetDoc(openDoc.doc);
-                                      setIsDeleteDialogOpen(true);
-                                    }}
-                                    disabled={isLoading}
-                                    title="Delete document"
-                                  >
-                                    <TrashIcon className="w-4 h-4" />
-                                  </button>
-                                  <button
-                                    className="p-1.5 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 text-slate-400 hover:text-blue-600 hover:bg-blue-100 dark:hover:bg-blue-900/40"
-                                    onClick={() => setHistoryTargetDoc({ docId: getDocId(openDoc.doc), collectionName: openDoc.collectionName })}
-                                    disabled={isLoading}
-                                    title="View document history"
-                                  >
-                                    <HistoryIcon className="w-4 h-4" />
-                                  </button>
-                                </>
-                              )}
-                              {openDoc.editMode && (
+                                  setOpenDocuments(prev => prev.map(od => od.id === openDoc.id ? { ...od, doc: refreshed } : od));
+                                  setPinnedDocuments(prev => prev.map(p =>
+                                    getDocId(p.doc) === getDocId(openDoc.doc) ? { ...p, doc: refreshed } : p
+                                  ));
+                                  if (openDoc.editMode && editorRefs.current[openDoc.id]) {
+                                    editorRefs.current[openDoc.id]!.setCurrentValue(JSON.stringify(refreshed, null, 2));
+                                  }
+                                } catch (e) {
+                                } finally {
+                                  setIsLoading(false);
+                                }
+                              }}
+                              style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: isLoading ? 0.5 : 1 }}
+                              title="Refresh document"
+                              disabled={isLoading}
+                              onMouseEnter={(e) => { if (!isLoading) (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; }}
+                              onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
+                            >
+                              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M1 4v6h6M23 20v-6h-6"/><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"/></svg>
+                            </button>
+                            {!openDoc.editMode && (
+                              <>
                                 <button
-                                  className="p-1.5 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-600 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-slate-400"
-                                  onClick={() => handleEditCancel(openDoc.id)}
+                                  style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: isLoading ? 0.5 : 1 }}
+                                  onClick={() => setOpenDocuments(prev => prev.map(od => od.id === openDoc.id ? { ...od, editMode: true } : od))}
                                   disabled={isLoading}
-                                  title="Cancel edit"
+                                  title="Edit document"
+                                  onMouseEnter={(e) => { if (!isLoading) (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; }}
+                                  onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
                                 >
-                                  <XIcon className="w-4 h-4" />
+                                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
                                 </button>
-                              )}
+                                <button
+                                  style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: isLoading ? 0.5 : 1 }}
+                                  onClick={() => { const { _id, ...rest } = openDoc.doc; setCreateDocInitial(rest); setIsCreateDialogOpen(true); }}
+                                  disabled={isLoading}
+                                  title="Insert copy as new document"
+                                  onMouseEnter={(e) => { if (!isLoading) (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; }}
+                                  onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
+                                >
+                                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                                </button>
+                                <button
+                                  style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: isLoading ? 0.5 : 1 }}
+                                  onClick={() => { setDeleteTargetDoc(openDoc.doc); setIsDeleteDialogOpen(true); }}
+                                  disabled={isLoading}
+                                  title="Delete document"
+                                  onMouseEnter={(e) => { if (!isLoading) (e.currentTarget as HTMLElement).style.color = 'var(--status-err)'; }}
+                                  onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
+                                >
+                                  <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M2 4h12M5 4V3a1 1 0 011-1h4a1 1 0 011 1v1M6 7v5M10 7v5M3 4l1 9a1 1 0 001 1h6a1 1 0 001-1l1-9"/></svg>
+                                </button>
+                                <button
+                                  style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: isLoading ? 0.5 : 1 }}
+                                  onClick={() => setHistoryTargetDoc({ docId: getDocId(openDoc.doc), collectionName: openDoc.collectionName })}
+                                  disabled={isLoading}
+                                  title="View document history"
+                                  onMouseEnter={(e) => { if (!isLoading) (e.currentTarget as HTMLElement).style.color = 'var(--fg)'; }}
+                                  onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
+                                >
+                                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                                </button>
+                              </>
+                            )}
+                            {openDoc.editMode && (
+                              <button
+                                style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: isLoading ? 0.5 : 1 }}
+                                onClick={() => handleEditCancel(openDoc.id)}
+                                disabled={isLoading}
+                                title="Cancel edit"
+                                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--fg)'; }}
+                                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
+                              >
+                                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M3 3l10 10M13 3L3 13"/></svg>
+                              </button>
+                            )}
 
-                            <div className="w-px h-5 bg-slate-300 dark:bg-slate-600 mx-1"></div>
+                            <div style={{ width: 1, height: 18, background: 'var(--border)', margin: '0 4px' }} />
 
                             {openDocuments.length > 1 && (
-                              <div className="flex items-center bg-slate-200/50 dark:bg-slate-700/50 rounded-lg p-0.5 mx-1">
+                              <div style={{ display: 'flex', alignItems: 'center', background: 'var(--soft)', borderRadius: 6, padding: 2, margin: '0 2px' }}>
                                 <button
                                   onClick={() => handleMoveDocument(openDoc.id, 'left')}
                                   disabled={index === 0}
-                                  className="p-1 text-slate-500 hover:text-blue-600 dark:hover:text-blue-400 disabled:opacity-30 disabled:hover:text-slate-500 transition-colors bg-transparent rounded-md hover:bg-white dark:hover:bg-slate-800"
+                                  style={{ padding: 4, borderRadius: 4, background: 'none', border: 'none', cursor: index === 0 ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: index === 0 ? 0.3 : 1 }}
                                   title="Move Left"
                                 >
-                                  <ArrowLeftIcon className="w-4 h-4" />
+                                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M10 3L5 8l5 5"/></svg>
                                 </button>
                                 <button
                                   onClick={() => handleMoveDocument(openDoc.id, 'right')}
                                   disabled={index === openDocuments.length - 1}
-                                  className="p-1 text-slate-500 hover:text-blue-600 dark:hover:text-blue-400 disabled:opacity-30 disabled:hover:text-slate-500 transition-colors bg-transparent rounded-md hover:bg-white dark:hover:bg-slate-800"
+                                  style={{ padding: 4, borderRadius: 4, background: 'none', border: 'none', cursor: index === openDocuments.length - 1 ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: index === openDocuments.length - 1 ? 0.3 : 1 }}
                                   title="Move Right"
                                 >
-                                  <ArrowRightIcon className="w-4 h-4" />
+                                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M6 3l5 5-5 5"/></svg>
                                 </button>
                               </div>
                             )}
-                            <button onClick={() => setOpenDocuments(prev => prev.filter(od => od.id !== openDoc.id))} className="flex-shrink-0 p-1.5 bg-slate-200/50 dark:bg-slate-700/50 text-slate-500 hover:text-red-500 hover:bg-red-100 dark:hover:bg-red-900/40 rounded-lg transition-colors border border-transparent hover:border-red-200" title="Close tab"><XIcon className="w-4 h-4" /></button>
+                            <button
+                              onClick={() => setOpenDocuments(prev => prev.filter(od => od.id !== openDoc.id))}
+                              style={{ padding: 5, borderRadius: 5, background: 'var(--soft)', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex' }}
+                              title="Close"
+                              onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--status-err)'; (e.currentTarget as HTMLElement).style.background = 'color-mix(in oklch, #c94250 8%, var(--bg))'; }}
+                              onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                            >
+                              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M3 3l10 10M13 3L3 13"/></svg>
+                            </button>
                           </div>
                         </header>
 
                         {/* Breadcrumbs */}
                         {openDoc.breadcrumbs.length > 0 && (
-                          <div className="flex items-center flex-wrap gap-1 text-xs text-slate-500 dark:text-slate-400 p-2 bg-slate-100 dark:bg-slate-800/50 rounded-md">
+                          <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 4, fontSize: 11.5, color: 'var(--muted)', padding: '6px 10px', background: 'var(--soft)', borderRadius: 6 }}>
                             {openDoc.breadcrumbs.map((crumb, i) => (
                               <React.Fragment key={`${i}-${getDocId(crumb.document)}`}>
-                                <button onClick={() => handleBreadcrumbClick(openDoc.id, i)} className="hover:underline hover:text-blue-500 dark:hover:text-blue-400 truncate max-w-[15ch]">
-                                  <span className="font-semibold">{crumb.collectionName}</span>
-                                  <span className="font-mono"> / {getDocId(crumb.document)}</span>
+                                <button
+                                  onClick={() => handleBreadcrumbClick(openDoc.id, i)}
+                                  style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', fontFamily: 'var(--font-body)', fontSize: 11.5, padding: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '15ch' }}
+                                  onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; }}
+                                  onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
+                                >
+                                  <span style={{ fontWeight: 600 }}>{crumb.collectionName}</span>
+                                  <span style={{ fontFamily: 'var(--font-mono)' }}> / {getDocId(crumb.document)}</span>
                                 </button>
-                                <ChevronRightIcon className="w-3 h-3 text-slate-400 dark:text-slate-500 flex-shrink-0" />
+                                <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ flexShrink: 0 }}><path d="M6 3l5 5-5 5"/></svg>
                               </React.Fragment>
                             ))}
-                            <span className="font-semibold text-slate-700 dark:text-slate-200 truncate max-w-[15ch]">
-                              {openDoc.collectionName} / <span className="font-mono">{getDocId(openDoc.doc)}</span>
+                            <span style={{ fontWeight: 600, color: 'var(--fg)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '15ch' }}>
+                              {openDoc.collectionName} / <span style={{ fontFamily: 'var(--font-mono)' }}>{getDocId(openDoc.doc)}</span>
                             </span>
                           </div>
                         )}
 
                         {/* Content */}
-                        <div className={`space-y-4 flex-1 flex flex-col ${isLoading ? 'opacity-50' : 'animate-fade-in-fast'}`}>
+                        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 14, opacity: isLoading ? 0.5 : 1 }}>
                           {!openDoc.editMode && (
-                            <div className="bg-slate-50 flex-1 dark:bg-slate-900 rounded p-3 text-xs overflow-x-auto text-slate-800 dark:text-slate-100 border border-slate-200 dark:border-slate-700 shadow-inner">
+                            <div style={{ background: '#0f0e0d', flex: 1, borderRadius: 8, padding: 12, fontSize: 11.5, overflowX: 'auto', color: '#c8c4bc', fontFamily: 'var(--font-mono)', lineHeight: 1.65, border: '1px solid #2a2826' }}>
                               <JsonDisplay data={openDoc.doc} onObjectIdClick={(objId, keyCtx, openNewTab, openToSide) => handleObjectIdClick(openDoc.id, objId, keyCtx, openNewTab, openToSide)} />
                             </div>
                           )}
@@ -1719,26 +1750,13 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
         }}
       />
       <style>{`
-          @keyframes fade-in-fast { 
-            from { opacity: 0; } 
-            to { opacity: 1; } 
-          }
-          .animate-fade-in-fast { 
-            animation: fade-in-fast 0.3s ease-out forwards; 
-          }
-          @keyframes pulse {
-            0%, 100% { transform: scale(1); opacity: 1; }
-            50% { transform: scale(1.1); opacity: 0.7; }
-          }
-          .animate-pulse { 
-            animation: pulse 1s infinite; 
-          }
+        @keyframes qp-spin { to { transform: rotate(360deg); } }
       `}</style>
     </>
   );
 
   return embedded ? pageContent : (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-800 dark:text-slate-200 font-sans">
+    <div style={{ minHeight: '100vh', background: 'var(--bg)', color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
       {pageContent}
     </div>
   );

--- a/frontend/pages/DataExplorerPage.tsx
+++ b/frontend/pages/DataExplorerPage.tsx
@@ -126,7 +126,7 @@ const DeleteDocumentDialog: React.FC<{
           Confirm Delete Document
         </h2>
         <p style={{ marginBottom: 12, color: 'var(--fg)', fontSize: 13 }}>Are you sure you want to delete this document? This action cannot be undone.</p>
-        <div style={{ background: '#0f0e0d', color: '#c8c4bc', borderRadius: 8, padding: 12, fontSize: 11.5, overflowX: 'auto', maxHeight: 240, marginBottom: 16, fontFamily: 'var(--font-mono)' }}>
+        <div style={{ background: 'var(--soft)', borderRadius: 8, padding: 12, fontSize: 11.5, overflowX: 'auto', maxHeight: 240, marginBottom: 16, fontFamily: 'var(--font-mono)', border: '1px solid var(--border)' }}>
           <JsonDisplay data={document} />
         </div>
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
@@ -242,6 +242,9 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
   // --- Editor Ref ---
   const editorRefs = useRef<Record<string, DocumentEditViewRef | null>>({});
 
+  // --- Unsaved changes discard confirmation ---
+  const [discardConfirmDocId, setDiscardConfirmDocId] = useState<string | null>(null);
+
   // Helper to infer schema for new document (mimic CollectionActionPanel logic)
   const getInitialDocFromSchema = useCallback(() => {
     if (!schemaTree || schemaTree.length === 0) return {};
@@ -351,8 +354,7 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
   }, [selectedCollection, deleteTargetDoc, currentResource, setDocuments]);
 
   // --- Sorting State ---
-  const [collectionSortKey, setCollectionSortKey] = useState<'name' | 'count'>('name');
-  const [collectionSortOrder, setCollectionSortOrder] = useState<'asc' | 'desc'>('asc');
+  const [collectionSort, setCollectionSort] = useState<'name_asc' | 'name_desc' | 'count_desc' | 'count_asc'>('name_asc');
 
   // --- Navigation State ---
   // global breadcrumbs removed
@@ -633,7 +635,8 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
   // Auto-select first collection in embedded mode when none is selected
   useEffect(() => {
     if (embedded && !selectedCollection && !initialDocumentId && !sidebarSelectedCollection && currentDb && currentDb.collections.length > 0) {
-      handleCollectionClick(currentDb.collections[0].name);
+      const first = [...currentDb.collections].sort((a, b) => a.name.localeCompare(b.name))[0];
+      handleCollectionClick(first.name);
     }
   }, [embedded, selectedCollection, initialDocumentId, sidebarSelectedCollection, currentDb, handleCollectionClick]);
 
@@ -659,25 +662,15 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
     }
   };
 
-  const handleSortCollections = (key: 'name' | 'count') => {
-    if (collectionSortKey === key) {
-      setCollectionSortOrder(prev => (prev === 'asc' ? 'desc' : 'asc'));
-    } else {
-      setCollectionSortKey(key);
-      setCollectionSortOrder(key === 'name' ? 'asc' : 'desc');
-    }
-  };
-
   const sortedCollections = useMemo(() => {
     if (!currentDb) return [];
     return [...currentDb.collections].sort((a, b) => {
-      if (collectionSortKey === 'name') {
-        return a.name.localeCompare(b.name) * (collectionSortOrder === 'asc' ? 1 : -1);
-      } else {
-        return (a.count - b.count) * (collectionSortOrder === 'asc' ? 1 : -1);
-      }
+      if (collectionSort === 'name_asc') return a.name.localeCompare(b.name);
+      if (collectionSort === 'name_desc') return b.name.localeCompare(a.name);
+      if (collectionSort === 'count_desc') return b.count - a.count;
+      return a.count - b.count;
     });
-  }, [currentDb, collectionSortKey, collectionSortOrder]);
+  }, [currentDb, collectionSort]);
 
   const handleObjectIdClick = useCallback(async (openDocId: string | null, objectId: string, keyContext?: string, openInNewTab?: boolean, openToSide?: boolean) => {
     if (!currentDb) return;
@@ -762,12 +755,6 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
     }
   }, []);
 
-  const renderSortArrow = (key: 'name' | 'count') => {
-    if (collectionSortKey !== key) return null;
-    return collectionSortOrder === 'asc'
-      ? <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M8 13V3M3 8l5-5 5 5"/></svg>
-      : <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M8 3v10M3 8l5 5 5-5"/></svg>;
-  };
 
   const renderDocumentList = () => {
     if (isLoading && documents.length === 0) {
@@ -926,6 +913,7 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
           getDocId(openDoc.doc)
         );
 
+        setDiscardConfirmDocId(null);
         setOpenDocuments(prev => prev.map(od => od.id === openDocId ? { ...od, doc: refreshed, editMode: false } : od));
 
         // Sync pinned document if present
@@ -943,6 +931,20 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
   };
 
   const handleEditCancel = (openDocId: string) => {
+    const od = openDocuments.find(d => d.id === openDocId);
+    if (od && editorRefs.current[openDocId]) {
+      const currentVal = editorRefs.current[openDocId]!.getCurrentValue();
+      const original = JSON.stringify(od.doc, null, 2);
+      if (currentVal !== original) {
+        setDiscardConfirmDocId(openDocId);
+        return;
+      }
+    }
+    setOpenDocuments(prev => prev.map(od => od.id === openDocId ? { ...od, editMode: false } : od));
+  };
+
+  const confirmDiscard = (openDocId: string) => {
+    setDiscardConfirmDocId(null);
     setOpenDocuments(prev => prev.map(od => od.id === openDocId ? { ...od, editMode: false } : od));
   };
 
@@ -1206,22 +1208,17 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
                 <div style={{ padding: 16 }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 14 }}>
                     <h2 style={{ fontSize: 13, fontWeight: 600, color: 'var(--fg)', margin: 0 }}>Collections</h2>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 2, padding: 2, background: 'var(--border)', borderRadius: 6 }}>
-                      <button
-                        onClick={() => handleSortCollections('name')}
-                        style={{ display: 'flex', alignItems: 'center', gap: 3, padding: '3px 7px', fontSize: 11.5, fontWeight: 600, borderRadius: 4, border: 'none', cursor: 'pointer', background: collectionSortKey === 'name' ? 'var(--panel)' : 'transparent', color: collectionSortKey === 'name' ? 'var(--accent)' : 'var(--muted)', boxShadow: collectionSortKey === 'name' ? '0 1px 2px rgba(0,0,0,0.06)' : 'none' }}
-                        title={`Sort by name (${collectionSortKey === 'name' && collectionSortOrder === 'asc' ? 'descending' : 'ascending'})`}
-                      >
-                        Name {renderSortArrow('name')}
-                      </button>
-                      <button
-                        onClick={() => handleSortCollections('count')}
-                        style={{ display: 'flex', alignItems: 'center', gap: 3, padding: '3px 7px', fontSize: 11.5, fontWeight: 600, borderRadius: 4, border: 'none', cursor: 'pointer', background: collectionSortKey === 'count' ? 'var(--panel)' : 'transparent', color: collectionSortKey === 'count' ? 'var(--accent)' : 'var(--muted)', boxShadow: collectionSortKey === 'count' ? '0 1px 2px rgba(0,0,0,0.06)' : 'none' }}
-                        title={`Sort by count (${collectionSortKey === 'count' && collectionSortOrder === 'asc' ? 'descending' : 'ascending'})`}
-                      >
-                        Count {renderSortArrow('count')}
-                      </button>
-                    </div>
+                    <select
+                      value={collectionSort}
+                      onChange={(e) => setCollectionSort(e.target.value as typeof collectionSort)}
+                      title="Sort collections"
+                      style={{ fontSize: 11.5, fontFamily: 'var(--font-body)', color: 'var(--muted)', background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 5, padding: '2px 6px', cursor: 'pointer', outline: 'none' }}
+                    >
+                      <option value="name_asc">A → Z</option>
+                      <option value="name_desc">Z → A</option>
+                      <option value="count_desc">Most docs</option>
+                      <option value="count_asc">Fewest docs</option>
+                    </select>
                   </div>
                   <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                     {isLoadingDbsForAccount ? (
@@ -1439,12 +1436,16 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
 
             <PanelResizeHandle style={{ width: 1, background: 'var(--border)', cursor: 'col-resize', flexShrink: 0, zIndex: 10 }} />
 
-            {/* Column 3: Document Editor */}
+            {/* Column 3: Document View */}
             <Panel defaultSize={embedded ? 72 : 60} minSize={30}>
               <div style={{ height: '100%', background: 'var(--bg)', overflowX: 'auto', overflowY: 'hidden', display: 'flex', flexDirection: 'row', position: 'relative' }}>
                 {openDocuments.length === 0 ? (
-                  <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--muted)', fontSize: 13 }}>
-                    <p>Select a document to open it here.</p>
+                  <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 8, color: 'var(--muted)' }}>
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.2" style={{ opacity: 0.35 }}>
+                      <rect x="3" y="3" width="18" height="18" rx="3"/>
+                      <path d="M7 8h10M7 12h7M7 16h5"/>
+                    </svg>
+                    <span style={{ fontSize: 12.5, fontFamily: 'var(--font-body)' }}>Select a document to view it here</span>
                   </div>
                 ) : (
                   openDocuments.map((openDoc, index) => (
@@ -1462,6 +1463,7 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
                         position: 'relative',
                       }}
                     >
+                      {/* Drag-resize handle for side-by-side docs */}
                       {openDocuments.length > 1 && (
                         <div
                           style={{ position: 'absolute', right: -1, top: 0, bottom: 0, width: 4, cursor: 'col-resize', zIndex: 20 }}
@@ -1484,213 +1486,266 @@ const DataExplorerPage: React.FC<DataExplorerPageProps> = ({
                           onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
                         />
                       )}
-                      <div style={{ padding: 16, flex: 1, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 14 }}>
-                        <header style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'space-between', alignItems: 'center', gap: 10, paddingBottom: 10, borderBottom: '1px solid var(--border)' }}>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 200, flex: 1 }}>
-                            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'var(--fg)', margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={openDoc.collectionName}>{openDoc.collectionName}</h2>
-                            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--muted)', background: 'var(--soft)', padding: '3px 7px', borderRadius: 5, border: '1px solid var(--border)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flexShrink: 0, maxWidth: 160 }} title={getDocId(openDoc.doc)}>
-                              {getDocId(openDoc.doc)}
-                            </span>
-                          </div>
 
-                          <div style={{ display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0, marginLeft: 'auto', padding: 4, borderRadius: 8, border: '1px solid transparent' }}>
-                            <button
-                              onClick={() => handleTogglePin(openDoc.doc, openDoc.collectionName)}
-                              style={{ padding: 5, borderRadius: 5, background: isDocumentPinned(openDoc.doc) ? 'var(--accent-soft)' : 'none', border: 'none', cursor: 'pointer', color: isDocumentPinned(openDoc.doc) ? 'var(--accent)' : 'var(--muted)', display: 'flex' }}
-                              title={isDocumentPinned(openDoc.doc) ? 'Unpin document' : 'Pin document'}
-                            >
-                              <svg width="13" height="13" viewBox="0 0 16 16" fill={isDocumentPinned(openDoc.doc) ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="1.5"><path d="M9.5 1.5l5 5-1.5 1.5-1-1-3 3v4l-1.5-1.5-3-3-1.5 1.5v-4l3-3-1-1zM1.5 14.5l4-4"/></svg>
-                            </button>
-                            <button
-                              onClick={async () => {
-                                setIsLoading(true);
-                                try {
-                                  const refreshed = await getSingleDocument(
-                                    currentResource.accountId,
-                                    currentResource.databaseName,
-                                    openDoc.collectionName,
-                                    getDocId(openDoc.doc)
-                                  );
-                                  if (openDoc.editMode && editorRefs.current[openDoc.id]) {
-                                    const editedValue = editorRefs.current[openDoc.id]!.getCurrentValue();
-                                    let isDifferent = false;
-                                    try {
-                                      const parsedEdited = JSON.parse(editedValue);
-                                      const ignoredKeys = ['_id', 'datetime_creation', 'datetime_last_modified'];
-                                      const editedWithoutIgnored = omit(parsedEdited, ignoredKeys);
-                                      const refreshedWithoutIgnored = omit(refreshed, ignoredKeys);
-                                      isDifferent = !isEqual(editedWithoutIgnored, refreshedWithoutIgnored);
-                                    } catch (e) {
-                                      const freshString = JSON.stringify(refreshed, null, 2);
-                                      isDifferent = editedValue !== freshString;
-                                    }
-                                    if (isDifferent) {
-                                      setDiffCurrentEditedText(editedValue);
-                                      setDiffIncomingDocument(refreshed);
-                                      setDiffTargetDocId(openDoc.id);
-                                      setIsDiffOverwriteDialogOpen(true);
-                                      setIsLoading(false);
-                                      return;
-                                    }
+                      {/* Header bar */}
+                      <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8, padding: '0 14px', height: 44, borderBottom: '1px solid var(--border)', background: 'var(--panel)' }}>
+                        {/* Title: collection + id */}
+                        <div style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+                          <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--fg)', fontFamily: 'var(--font-body)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flexShrink: 0, maxWidth: '40%' }} title={openDoc.collectionName}>
+                            {openDoc.collectionName}
+                          </span>
+                          <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="var(--border)" strokeWidth="2" style={{ flexShrink: 0 }}><path d="M6 3l5 5-5 5"/></svg>
+                          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={getDocId(openDoc.doc)}>
+                            {getDocId(openDoc.doc)}
+                          </span>
+                        </div>
+
+                        {/* Toolbar */}
+                        <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 1 }}>
+                          {/* Pin */}
+                          <button
+                            onClick={() => handleTogglePin(openDoc.doc, openDoc.collectionName)}
+                            title={isDocumentPinned(openDoc.doc) ? 'Unpin document' : 'Pin document'}
+                            style={{ padding: '5px 6px', borderRadius: 6, border: 'none', cursor: 'pointer', display: 'flex', alignItems: 'center', background: isDocumentPinned(openDoc.doc) ? 'var(--accent-soft)' : 'transparent', color: isDocumentPinned(openDoc.doc) ? 'var(--accent)' : 'var(--muted)' }}
+                            onMouseEnter={(e) => { if (!isDocumentPinned(openDoc.doc)) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                            onMouseLeave={(e) => { if (!isDocumentPinned(openDoc.doc)) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                          >
+                            <svg width="13" height="13" viewBox="0 0 16 16" fill={isDocumentPinned(openDoc.doc) ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="1.5"><path d="M9.5 1.5l5 5-1.5 1.5-1-1-3 3v4l-1.5-1.5-3-3-1.5 1.5v-4l3-3-1-1zM1.5 14.5l4-4"/></svg>
+                          </button>
+
+                          {/* Refresh */}
+                          <button
+                            onClick={async () => {
+                              setIsLoading(true);
+                              try {
+                                const refreshed = await getSingleDocument(
+                                  currentResource.accountId,
+                                  currentResource.databaseName,
+                                  openDoc.collectionName,
+                                  getDocId(openDoc.doc)
+                                );
+                                if (openDoc.editMode && editorRefs.current[openDoc.id]) {
+                                  const editedValue = editorRefs.current[openDoc.id]!.getCurrentValue();
+                                  let isDifferent = false;
+                                  try {
+                                    const parsedEdited = JSON.parse(editedValue);
+                                    const ignoredKeys = ['_id', 'datetime_creation', 'datetime_last_modified'];
+                                    const editedWithoutIgnored = omit(parsedEdited, ignoredKeys);
+                                    const refreshedWithoutIgnored = omit(refreshed, ignoredKeys);
+                                    isDifferent = !isEqual(editedWithoutIgnored, refreshedWithoutIgnored);
+                                  } catch (e) {
+                                    const freshString = JSON.stringify(refreshed, null, 2);
+                                    isDifferent = editedValue !== freshString;
                                   }
-                                  setOpenDocuments(prev => prev.map(od => od.id === openDoc.id ? { ...od, doc: refreshed } : od));
-                                  setPinnedDocuments(prev => prev.map(p =>
-                                    getDocId(p.doc) === getDocId(openDoc.doc) ? { ...p, doc: refreshed } : p
-                                  ));
-                                  if (openDoc.editMode && editorRefs.current[openDoc.id]) {
-                                    editorRefs.current[openDoc.id]!.setCurrentValue(JSON.stringify(refreshed, null, 2));
+                                  if (isDifferent) {
+                                    setDiffCurrentEditedText(editedValue);
+                                    setDiffIncomingDocument(refreshed);
+                                    setDiffTargetDocId(openDoc.id);
+                                    setIsDiffOverwriteDialogOpen(true);
+                                    setIsLoading(false);
+                                    return;
                                   }
-                                } catch (e) {
-                                } finally {
-                                  setIsLoading(false);
                                 }
-                              }}
-                              style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: isLoading ? 0.5 : 1 }}
-                              title="Refresh document"
-                              disabled={isLoading}
-                              onMouseEnter={(e) => { if (!isLoading) (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; }}
-                              onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
-                            >
-                              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M1 4v6h6M23 20v-6h-6"/><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"/></svg>
-                            </button>
-                            {!openDoc.editMode && (
-                              <>
-                                <button
-                                  style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: isLoading ? 0.5 : 1 }}
-                                  onClick={() => setOpenDocuments(prev => prev.map(od => od.id === openDoc.id ? { ...od, editMode: true } : od))}
-                                  disabled={isLoading}
-                                  title="Edit document"
-                                  onMouseEnter={(e) => { if (!isLoading) (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; }}
-                                  onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
-                                >
-                                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
-                                </button>
-                                <button
-                                  style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: isLoading ? 0.5 : 1 }}
-                                  onClick={() => { const { _id, ...rest } = openDoc.doc; setCreateDocInitial(rest); setIsCreateDialogOpen(true); }}
-                                  disabled={isLoading}
-                                  title="Insert copy as new document"
-                                  onMouseEnter={(e) => { if (!isLoading) (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; }}
-                                  onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
-                                >
-                                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
-                                </button>
-                                <button
-                                  style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: isLoading ? 0.5 : 1 }}
-                                  onClick={() => { setDeleteTargetDoc(openDoc.doc); setIsDeleteDialogOpen(true); }}
-                                  disabled={isLoading}
-                                  title="Delete document"
-                                  onMouseEnter={(e) => { if (!isLoading) (e.currentTarget as HTMLElement).style.color = 'var(--status-err)'; }}
-                                  onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
-                                >
-                                  <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M2 4h12M5 4V3a1 1 0 011-1h4a1 1 0 011 1v1M6 7v5M10 7v5M3 4l1 9a1 1 0 001 1h6a1 1 0 001-1l1-9"/></svg>
-                                </button>
-                                <button
-                                  style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: isLoading ? 0.5 : 1 }}
-                                  onClick={() => setHistoryTargetDoc({ docId: getDocId(openDoc.doc), collectionName: openDoc.collectionName })}
-                                  disabled={isLoading}
-                                  title="View document history"
-                                  onMouseEnter={(e) => { if (!isLoading) (e.currentTarget as HTMLElement).style.color = 'var(--fg)'; }}
-                                  onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
-                                >
-                                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-                                </button>
-                              </>
-                            )}
-                            {openDoc.editMode && (
+                                setOpenDocuments(prev => prev.map(od => od.id === openDoc.id ? { ...od, doc: refreshed } : od));
+                                setPinnedDocuments(prev => prev.map(p =>
+                                  getDocId(p.doc) === getDocId(openDoc.doc) ? { ...p, doc: refreshed } : p
+                                ));
+                                if (openDoc.editMode && editorRefs.current[openDoc.id]) {
+                                  editorRefs.current[openDoc.id]!.setCurrentValue(JSON.stringify(refreshed, null, 2));
+                                }
+                              } catch (e) {
+                              } finally {
+                                setIsLoading(false);
+                              }
+                            }}
+                            title="Refresh document"
+                            disabled={isLoading}
+                            style={{ padding: '5px 6px', borderRadius: 6, border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', background: 'transparent', color: 'var(--muted)', opacity: isLoading ? 0.4 : 1 }}
+                            onMouseEnter={(e) => { if (!isLoading) { (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; } }}
+                            onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
+                          >
+                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M1 4v6h6M23 20v-6h-6"/><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"/></svg>
+                          </button>
+
+                          {!openDoc.editMode && (
+                            <>
+                              {/* Edit */}
                               <button
-                                style={{ padding: 5, borderRadius: 5, background: 'none', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: isLoading ? 0.5 : 1 }}
-                                onClick={() => handleEditCancel(openDoc.id)}
+                                onClick={() => setOpenDocuments(prev => prev.map(od => od.id === openDoc.id ? { ...od, editMode: true } : od))}
                                 disabled={isLoading}
-                                title="Cancel edit"
-                                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--fg)'; }}
+                                title="Edit document"
+                                style={{ padding: '5px 6px', borderRadius: 6, border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', background: 'transparent', color: 'var(--muted)', opacity: isLoading ? 0.4 : 1 }}
+                                onMouseEnter={(e) => { if (!isLoading) { (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; } }}
+                                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
+                              >
+                                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                              </button>
+                              {/* Duplicate */}
+                              <button
+                                onClick={() => { const { _id, ...rest } = openDoc.doc; setCreateDocInitial(rest); setIsCreateDialogOpen(true); }}
+                                disabled={isLoading}
+                                title="Insert copy as new document"
+                                style={{ padding: '5px 6px', borderRadius: 6, border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', background: 'transparent', color: 'var(--muted)', opacity: isLoading ? 0.4 : 1 }}
+                                onMouseEnter={(e) => { if (!isLoading) { (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; } }}
+                                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
+                              >
+                                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                              </button>
+                              {/* History */}
+                              <button
+                                onClick={() => setHistoryTargetDoc({ docId: getDocId(openDoc.doc), collectionName: openDoc.collectionName })}
+                                disabled={isLoading}
+                                title="View document history"
+                                style={{ padding: '5px 6px', borderRadius: 6, border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', background: 'transparent', color: 'var(--muted)', opacity: isLoading ? 0.4 : 1 }}
+                                onMouseEnter={(e) => { if (!isLoading) { (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; (e.currentTarget as HTMLElement).style.color = 'var(--fg)'; } }}
+                                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
+                              >
+                                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                              </button>
+                              {/* Delete */}
+                              <button
+                                onClick={() => { setDeleteTargetDoc(openDoc.doc); setIsDeleteDialogOpen(true); }}
+                                disabled={isLoading}
+                                title="Delete document"
+                                style={{ padding: '5px 6px', borderRadius: 6, border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', background: 'transparent', color: 'var(--muted)', opacity: isLoading ? 0.4 : 1 }}
+                                onMouseEnter={(e) => { if (!isLoading) { (e.currentTarget as HTMLElement).style.background = 'color-mix(in oklch, var(--status-err) 8%, var(--bg))'; (e.currentTarget as HTMLElement).style.color = 'var(--status-err)'; } }}
+                                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
+                              >
+                                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M2 4h12M5 4V3a1 1 0 011-1h4a1 1 0 011 1v1M6 7v5M10 7v5M3 4l1 9a1 1 0 001 1h6a1 1 0 001-1l1-9"/></svg>
+                              </button>
+                            </>
+                          )}
+
+                          {openDoc.editMode && (
+                            /* Cancel edit */
+                            <button
+                              onClick={() => handleEditCancel(openDoc.id)}
+                              disabled={isLoading}
+                              title="Cancel edit"
+                              style={{ padding: '5px 6px', borderRadius: 6, border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', background: 'transparent', color: 'var(--muted)', opacity: isLoading ? 0.4 : 1 }}
+                              onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; (e.currentTarget as HTMLElement).style.color = 'var(--fg)'; }}
+                              onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
+                            >
+                              <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M3 3l10 10M13 3L3 13"/></svg>
+                            </button>
+                          )}
+
+                          {/* Divider */}
+                          <div style={{ width: 1, height: 16, background: 'var(--border)', margin: '0 3px' }} />
+
+                          {/* Move left/right (multi-doc) */}
+                          {openDocuments.length > 1 && (
+                            <>
+                              <button
+                                onClick={() => handleMoveDocument(openDoc.id, 'left')}
+                                disabled={index === 0}
+                                title="Move left"
+                                style={{ padding: '5px 6px', borderRadius: 6, border: 'none', cursor: index === 0 ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', background: 'transparent', color: 'var(--muted)', opacity: index === 0 ? 0.3 : 1 }}
+                                onMouseEnter={(e) => { if (index !== 0) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                              >
+                                <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M10 3L5 8l5 5"/></svg>
+                              </button>
+                              <button
+                                onClick={() => handleMoveDocument(openDoc.id, 'right')}
+                                disabled={index === openDocuments.length - 1}
+                                title="Move right"
+                                style={{ padding: '5px 6px', borderRadius: 6, border: 'none', cursor: index === openDocuments.length - 1 ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', background: 'transparent', color: 'var(--muted)', opacity: index === openDocuments.length - 1 ? 0.3 : 1 }}
+                                onMouseEnter={(e) => { if (index !== openDocuments.length - 1) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                              >
+                                <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M6 3l5 5-5 5"/></svg>
+                              </button>
+                            </>
+                          )}
+
+                          {/* Close — disabled while editing */}
+                          <button
+                            onClick={() => setOpenDocuments(prev => prev.filter(od => od.id !== openDoc.id))}
+                            title={openDoc.editMode ? 'Exit edit mode before closing' : 'Close'}
+                            disabled={openDoc.editMode}
+                            style={{ padding: '5px 6px', borderRadius: 6, border: 'none', cursor: openDoc.editMode ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', background: 'var(--soft)', color: 'var(--muted)', opacity: openDoc.editMode ? 0.35 : 1 }}
+                            onMouseEnter={(e) => { if (!openDoc.editMode) { (e.currentTarget as HTMLElement).style.background = 'color-mix(in oklch, var(--status-err) 10%, var(--bg))'; (e.currentTarget as HTMLElement).style.color = 'var(--status-err)'; } }}
+                            onMouseLeave={(e) => { if (!openDoc.editMode) { (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; } }}
+                          >
+                            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M3 3l10 10M13 3L3 13"/></svg>
+                          </button>
+                        </div>
+                      </div>
+
+                      {/* Breadcrumb trail (linked-doc navigation) */}
+                      {openDoc.breadcrumbs.length > 0 && (
+                        <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 3, padding: '5px 14px', background: 'var(--soft)', borderBottom: '1px solid var(--border)', fontSize: 11.5, color: 'var(--muted)' }}>
+                          {openDoc.breadcrumbs.map((crumb, i) => (
+                            <React.Fragment key={`${i}-${getDocId(crumb.document)}`}>
+                              <button
+                                onClick={() => handleBreadcrumbClick(openDoc.id, i)}
+                                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', fontFamily: 'var(--font-body)', fontSize: 11.5, padding: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '14ch' }}
+                                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; }}
                                 onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
                               >
-                                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M3 3l10 10M13 3L3 13"/></svg>
+                                <span style={{ fontWeight: 600 }}>{crumb.collectionName}</span>
+                                <span style={{ fontFamily: 'var(--font-mono)', marginLeft: 3 }}>/ {getDocId(crumb.document)}</span>
                               </button>
-                            )}
+                              <svg width="9" height="9" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2.5" style={{ flexShrink: 0, opacity: 0.4 }}><path d="M6 3l5 5-5 5"/></svg>
+                            </React.Fragment>
+                          ))}
+                          <span style={{ fontWeight: 600, color: 'var(--fg)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '14ch' }}>
+                            {openDoc.collectionName}<span style={{ fontFamily: 'var(--font-mono)', fontWeight: 400, marginLeft: 3 }}>/ {getDocId(openDoc.doc)}</span>
+                          </span>
+                        </div>
+                      )}
 
-                            <div style={{ width: 1, height: 18, background: 'var(--border)', margin: '0 4px' }} />
-
-                            {openDocuments.length > 1 && (
-                              <div style={{ display: 'flex', alignItems: 'center', background: 'var(--soft)', borderRadius: 6, padding: 2, margin: '0 2px' }}>
-                                <button
-                                  onClick={() => handleMoveDocument(openDoc.id, 'left')}
-                                  disabled={index === 0}
-                                  style={{ padding: 4, borderRadius: 4, background: 'none', border: 'none', cursor: index === 0 ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: index === 0 ? 0.3 : 1 }}
-                                  title="Move Left"
-                                >
-                                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M10 3L5 8l5 5"/></svg>
-                                </button>
-                                <button
-                                  onClick={() => handleMoveDocument(openDoc.id, 'right')}
-                                  disabled={index === openDocuments.length - 1}
-                                  style={{ padding: 4, borderRadius: 4, background: 'none', border: 'none', cursor: index === openDocuments.length - 1 ? 'not-allowed' : 'pointer', color: 'var(--muted)', display: 'flex', opacity: index === openDocuments.length - 1 ? 0.3 : 1 }}
-                                  title="Move Right"
-                                >
-                                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M6 3l5 5-5 5"/></svg>
-                                </button>
-                              </div>
-                            )}
-                            <button
-                              onClick={() => setOpenDocuments(prev => prev.filter(od => od.id !== openDoc.id))}
-                              style={{ padding: 5, borderRadius: 5, background: 'var(--soft)', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex' }}
-                              title="Close"
-                              onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--status-err)'; (e.currentTarget as HTMLElement).style.background = 'color-mix(in oklch, #c94250 8%, var(--bg))'; }}
-                              onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
-                            >
-                              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M3 3l10 10M13 3L3 13"/></svg>
-                            </button>
-                          </div>
-                        </header>
-
-                        {/* Breadcrumbs */}
-                        {openDoc.breadcrumbs.length > 0 && (
-                          <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 4, fontSize: 11.5, color: 'var(--muted)', padding: '6px 10px', background: 'var(--soft)', borderRadius: 6 }}>
-                            {openDoc.breadcrumbs.map((crumb, i) => (
-                              <React.Fragment key={`${i}-${getDocId(crumb.document)}`}>
-                                <button
-                                  onClick={() => handleBreadcrumbClick(openDoc.id, i)}
-                                  style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', fontFamily: 'var(--font-body)', fontSize: 11.5, padding: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '15ch' }}
-                                  onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--accent)'; }}
-                                  onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = 'var(--muted)'; }}
-                                >
-                                  <span style={{ fontWeight: 600 }}>{crumb.collectionName}</span>
-                                  <span style={{ fontFamily: 'var(--font-mono)' }}> / {getDocId(crumb.document)}</span>
-                                </button>
-                                <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ flexShrink: 0 }}><path d="M6 3l5 5-5 5"/></svg>
-                              </React.Fragment>
-                            ))}
-                            <span style={{ fontWeight: 600, color: 'var(--fg)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '15ch' }}>
-                              {openDoc.collectionName} / <span style={{ fontFamily: 'var(--font-mono)' }}>{getDocId(openDoc.doc)}</span>
-                            </span>
+                      {/* Document content */}
+                      <div style={{ flex: 1, overflowY: 'auto', padding: 14, display: 'flex', flexDirection: 'column', gap: 12, opacity: isLoading ? 0.45 : 1 }}>
+                        {!openDoc.editMode && (
+                          <div style={{ background: 'var(--soft)', flex: 1, borderRadius: 8, padding: '12px 14px', fontSize: 11.5, overflowX: 'auto', fontFamily: 'var(--font-mono)', lineHeight: 1.7, border: '1px solid var(--border)' }}>
+                            <JsonDisplay data={openDoc.doc} onObjectIdClick={(objId, keyCtx, openNewTab, openToSide) => handleObjectIdClick(openDoc.id, objId, keyCtx, openNewTab, openToSide)} />
                           </div>
                         )}
-
-                        {/* Content */}
-                        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 14, opacity: isLoading ? 0.5 : 1 }}>
-                          {!openDoc.editMode && (
-                            <div style={{ background: '#0f0e0d', flex: 1, borderRadius: 8, padding: 12, fontSize: 11.5, overflowX: 'auto', color: '#c8c4bc', fontFamily: 'var(--font-mono)', lineHeight: 1.65, border: '1px solid #2a2826' }}>
-                              <JsonDisplay data={openDoc.doc} onObjectIdClick={(objId, keyCtx, openNewTab, openToSide) => handleObjectIdClick(openDoc.id, objId, keyCtx, openNewTab, openToSide)} />
-                            </div>
-                          )}
-                          {openDoc.editMode && (
-                            <DocumentEditView
-                              ref={(el) => {
-                                if (el) editorRefs.current[openDoc.id] = el;
-                                else delete editorRefs.current[openDoc.id];
-                              }}
-                              accountId={currentResource.accountId}
-                              databaseName={currentResource.databaseName}
-                              document={openDoc.doc}
-                              collection={openDoc.collectionName}
-                              docId={getDocId(openDoc.doc)}
-                              loading={isLoading}
-                              onCancel={() => handleEditCancel(openDoc.id)}
-                              onSave={() => handleEditSave(openDoc.id)}
-                            />
-                          )}
-                        </div>
+                        {openDoc.editMode && discardConfirmDocId === openDoc.id && (
+                          <div style={{
+                            padding: '10px 14px', borderRadius: 8, flexShrink: 0,
+                            background: 'color-mix(in oklch, var(--status-err) 9%, var(--panel))',
+                            border: '1px solid color-mix(in oklch, var(--status-err) 28%, var(--border))',
+                            display: 'flex', alignItems: 'center', gap: 10,
+                          }}>
+                            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="var(--status-err)" strokeWidth="1.5" style={{ flexShrink: 0 }}>
+                              <path d="M8 1L15 14H1L8 1z"/><path d="M8 6v4M8 11.5v.5"/>
+                            </svg>
+                            <span style={{ flex: 1, fontSize: 12.5, color: 'var(--status-err)', fontFamily: 'var(--font-body)' }}>
+                              You have unsaved changes. Discard them?
+                            </span>
+                            <button
+                              onClick={() => setDiscardConfirmDocId(null)}
+                              style={{ fontSize: 12, fontWeight: 500, padding: '4px 10px', borderRadius: 6, border: '1px solid color-mix(in oklch, var(--status-err) 28%, var(--border))', background: 'var(--panel)', color: 'var(--fg)', cursor: 'pointer', fontFamily: 'var(--font-body)' }}
+                            >
+                              Keep editing
+                            </button>
+                            <button
+                              onClick={() => confirmDiscard(openDoc.id)}
+                              style={{ fontSize: 12, fontWeight: 600, padding: '4px 10px', borderRadius: 6, border: '1px solid var(--status-err)', background: 'var(--status-err)', color: '#fff', cursor: 'pointer', fontFamily: 'var(--font-body)' }}
+                            >
+                              Discard
+                            </button>
+                          </div>
+                        )}
+                        {openDoc.editMode && (
+                          <DocumentEditView
+                            ref={(el) => {
+                              if (el) editorRefs.current[openDoc.id] = el;
+                              else delete editorRefs.current[openDoc.id];
+                            }}
+                            accountId={currentResource.accountId}
+                            databaseName={currentResource.databaseName}
+                            document={openDoc.doc}
+                            collection={openDoc.collectionName}
+                            docId={getDocId(openDoc.doc)}
+                            loading={isLoading}
+                            onCancel={() => handleEditCancel(openDoc.id)}
+                            onSave={() => handleEditSave(openDoc.id)}
+                          />
+                        )}
                       </div>
                     </div>
                   ))

--- a/frontend/pages/DataExplorerPageWrapper.tsx
+++ b/frontend/pages/DataExplorerPageWrapper.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import DataExplorerPage from './DataExplorerPage';
 import AppLayout from '../components/AppLayout';
-import { SelectedResource, DbInfo, CosmosDBAccount } from '../types';
+import { SelectedResource, DbInfo, CosmosDBAccount, CollectionSummary } from '../types';
 import { getAzureCosmosAccounts, getDatabasesForAccount } from '../services/dbService';
 
 interface LocationState {
@@ -24,6 +24,15 @@ const DataExplorerPageWrapper: React.FC = () => {
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [activeCollection, setActiveCollection] = useState<string | undefined>(undefined);
+
+  // Used to keep sidebar populated during the async load so there's no visual flash
+  const [sessionCache] = useState<{ accountName?: string; collections?: CollectionSummary[]; availableAccounts?: CosmosDBAccount[]; availableDbs?: DbInfo[] } | null>(() => {
+    try {
+      const saved = sessionStorage.getItem('qp_connection');
+      return saved ? JSON.parse(saved) : null;
+    } catch { return null; }
+  });
   const [pageData, setPageData] = useState<{
     resource: SelectedResource;
     dbInfo: DbInfo;
@@ -32,6 +41,17 @@ const DataExplorerPageWrapper: React.FC = () => {
     availableAccounts: CosmosDBAccount[];
     initialDocumentId?: string;
   } | null>(null);
+
+  // Reset active collection when DB/account changes so the new page starts fresh
+  const prevConnectionKey = React.useRef<string | null>(null);
+  React.useEffect(() => {
+    if (!pageData) return;
+    const key = `${pageData.resource.accountId}/${pageData.dbInfo.name}`;
+    if (prevConnectionKey.current !== null && prevConnectionKey.current !== key) {
+      setActiveCollection(undefined);
+    }
+    prevConnectionKey.current = key;
+  }, [pageData]);
 
   useEffect(() => {
     const initializePageData = async () => {
@@ -67,6 +87,14 @@ const DataExplorerPageWrapper: React.FC = () => {
 
         // If we have state from navigation, use it
         if (state?.dbInfo && state?.accountName && state?.availableDbs && state?.availableAccounts) {
+          sessionStorage.setItem('qp_connection', JSON.stringify({
+            accountId: decodedAccountId,
+            databaseName: decodedDatabaseName,
+            accountName: state.accountName,
+            collections: state.dbInfo.collections,
+            availableAccounts: state.availableAccounts,
+            availableDbs: state.availableDbs,
+          }));
           setPageData({
             resource,
             dbInfo: state.dbInfo,
@@ -93,6 +121,14 @@ const DataExplorerPageWrapper: React.FC = () => {
             throw new Error(`Database '${decodedDatabaseName}' not found in account '${account.name}'`);
           }
 
+          sessionStorage.setItem('qp_connection', JSON.stringify({
+            accountId: decodedAccountId,
+            databaseName: decodedDatabaseName,
+            accountName: account.name,
+            collections: database.collections,
+            availableAccounts: accounts,
+            availableDbs: databases,
+          }));
           setPageData({
             resource,
             dbInfo: database,
@@ -117,111 +153,79 @@ const DataExplorerPageWrapper: React.FC = () => {
     navigate('/query-generator');
   };
 
+  const handleSwitchDatabase = useCallback((db: DbInfo) => {
+    if (!pageData) return;
+    navigate(`/data-explorer/${encodeURIComponent(pageData.resource.accountId)}/${encodeURIComponent(db.name)}`, {
+      state: {
+        dbInfo: db,
+        accountName: pageData.accountName,
+        availableDbs: pageData.availableDbs,
+        availableAccounts: pageData.availableAccounts,
+      },
+    });
+  }, [pageData, navigate]);
+
+  const handleSwitchAccount = useCallback(async (account: CosmosDBAccount) => {
+    if (!pageData || account.id === pageData.resource.accountId) return;
+    try {
+      const databases = await getDatabasesForAccount(account.id);
+      if (!databases.length) return;
+      navigate(`/data-explorer/${encodeURIComponent(account.id)}/${encodeURIComponent(databases[0].name)}`, {
+        state: {
+          dbInfo: databases[0],
+          accountName: account.name,
+          availableDbs: databases,
+          availableAccounts: pageData.availableAccounts,
+        },
+      });
+    } catch (e) {
+      console.error('Failed to switch account:', e);
+    }
+  }, [pageData, navigate]);
+
   if (loading) {
+    const decodedAccountId = accountId ? decodeURIComponent(accountId) : undefined;
+    const decodedDatabaseName = databaseName ? decodeURIComponent(databaseName) : undefined;
     return (
-      <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-800 dark:text-slate-200 font-sans">
-        <div className="flex flex-col h-screen relative">
-          
-          {/* Loading Overlay */}
-          <div className="absolute inset-0 z-50 bg-black/20 dark:bg-black/40 backdrop-blur-sm flex items-center justify-center">
-            <div className="bg-white dark:bg-slate-800 rounded-lg shadow-xl px-6 py-4 flex items-center gap-3 border border-slate-200 dark:border-slate-700">
-              <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-              </svg>
-              <span className="text-slate-700 dark:text-slate-200 font-medium">Loading database information...</span>
-            </div>
+      <AppLayout
+        accountId={decodedAccountId}
+        databaseName={decodedDatabaseName}
+        accountName={sessionCache?.accountName}
+        collections={sessionCache?.collections}
+        availableAccounts={sessionCache?.availableAccounts}
+        availableDbs={sessionCache?.availableDbs}
+      >
+        <style>{`@keyframes qp-spin { to { transform: rotate(360deg); } }`}</style>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', background: 'var(--bg)' }}>
+          <div style={{
+            background: 'var(--panel)', borderRadius: 10, padding: '16px 24px',
+            display: 'flex', alignItems: 'center', gap: 12,
+            border: '1px solid var(--border)', boxShadow: '0 4px 16px rgba(0,0,0,0.06)',
+          }}>
+            <div style={{
+              width: 18, height: 18, borderRadius: '50%',
+              border: '2px solid var(--border)', borderTopColor: 'var(--accent)',
+              animation: 'qp-spin 0.7s linear infinite', flexShrink: 0,
+            }} />
+            <span style={{ fontSize: 13.5, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
+              Loading database information...
+            </span>
           </div>
-          
-          {/* Skeleton Layout */}
-          <header className="flex-shrink-0 bg-white dark:bg-slate-800/50 border-b border-slate-200 dark:border-slate-700">
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-              <div className="flex items-center justify-between h-16">
-                <div className="flex items-center gap-4">
-                  <div className="w-9 h-9 bg-blue-500 rounded"></div>
-                  <div>
-                    <div className="w-32 h-6 bg-slate-300 dark:bg-slate-600 rounded animate-pulse"></div>
-                    <div className="w-48 h-4 bg-slate-200 dark:bg-slate-700 rounded animate-pulse mt-1"></div>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <div className="w-9 h-9 bg-slate-200 dark:bg-slate-700 rounded animate-pulse"></div>
-                  <div className="w-9 h-9 bg-slate-200 dark:bg-slate-700 rounded animate-pulse"></div>
-                  <div className="w-40 h-9 bg-slate-200 dark:bg-slate-700 rounded animate-pulse"></div>
-                </div>
-              </div>
-            </div>
-          </header>
-
-          <main className="flex-grow flex overflow-hidden">
-            {/* Skeleton Collections Column */}
-            <div className="w-1/4 xl:w-1/5 bg-slate-100 dark:bg-slate-800 border-r border-slate-200 dark:border-slate-700 overflow-y-auto">
-              <div className="p-4">
-                <div className="w-24 h-6 bg-slate-300 dark:bg-slate-600 rounded animate-pulse mb-4"></div>
-                <div className="space-y-2">
-                  {[1, 2, 3, 4, 5].map(i => (
-                    <div key={i} className="w-full h-12 bg-slate-200 dark:bg-slate-700 rounded animate-pulse"></div>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            {/* Skeleton Documents Column */}
-            <div className="w-1/4 xl:w-1/5 bg-white dark:bg-slate-800/50 border-r border-slate-200 dark:border-slate-700 flex flex-col">
-              <div className="p-4 border-b border-slate-200 dark:border-slate-700">
-                <div className="w-28 h-6 bg-slate-300 dark:bg-slate-600 rounded animate-pulse mb-2"></div>
-                <div className="space-y-2">
-                  <div className="w-full h-10 bg-slate-200 dark:bg-slate-700 rounded animate-pulse"></div>
-                  <div className="w-full h-10 bg-slate-200 dark:bg-slate-700 rounded animate-pulse"></div>
-                </div>
-              </div>
-              <div className="flex-grow p-4 space-y-2">
-                {[1, 2, 3, 4, 5].map(i => (
-                  <div key={i} className="w-full h-8 bg-slate-100 dark:bg-slate-700 rounded animate-pulse"></div>
-                ))}
-              </div>
-            </div>
-
-            {/* Skeleton Editor Column */}
-            <div className="w-2/4 xl:w-3/5 bg-slate-50 dark:bg-slate-900 overflow-y-auto">
-              <div className="p-4 space-y-4">
-                <div className="w-20 h-6 bg-slate-300 dark:bg-slate-600 rounded animate-pulse"></div>
-                <div className="w-full h-64 bg-slate-200 dark:bg-slate-700 rounded animate-pulse"></div>
-              </div>
-            </div>
-          </main>
         </div>
-      </div>
+      </AppLayout>
     );
   }
 
   if (error) {
     return (
-      <div style={{ 
-        display: 'flex', 
-        flexDirection: 'column',
-        justifyContent: 'center', 
-        alignItems: 'center', 
-        height: '100vh',
-        backgroundColor: '#121212',
-        color: 'white',
-        gap: '20px'
-      }}>
-        <div>Error: {error}</div>
-        <button 
-          onClick={onNavigateBack}
-          style={{
-            padding: '10px 20px',
-            backgroundColor: '#1976d2',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            cursor: 'pointer'
-          }}
-        >
-          Back to Query Generator
-        </button>
-      </div>
+      <AppLayout>
+        <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', height: '100%', gap: 16, background: 'var(--bg)' }}>
+          <div style={{ color: 'var(--status-err)', fontSize: 14, fontFamily: 'var(--font-body)' }}>Error: {error}</div>
+          <button onClick={onNavigateBack} className="qa-btn primary" style={{ fontSize: 13 }}>
+            Back to Query Generator
+          </button>
+        </div>
+      </AppLayout>
     );
   }
 
@@ -232,10 +236,19 @@ const DataExplorerPageWrapper: React.FC = () => {
   return (
     <AppLayout
       accountName={pageData.accountName}
+      accountId={pageData.resource.accountId}
       databaseName={pageData.dbInfo.name}
+      collectionName={activeCollection}
       collections={pageData.dbInfo.collections}
+      activeCollection={activeCollection}
+      onCollectionSelect={setActiveCollection}
+      availableDbs={pageData.availableDbs}
+      onSwitchDatabase={handleSwitchDatabase}
+      availableAccounts={pageData.availableAccounts}
+      onSwitchAccount={handleSwitchAccount}
     >
       <DataExplorerPage
+        key={`${pageData.resource.accountId}/${pageData.dbInfo.name}`}
         resource={pageData.resource}
         dbInfo={pageData.dbInfo}
         accountName={pageData.accountName}
@@ -243,6 +256,8 @@ const DataExplorerPageWrapper: React.FC = () => {
         availableAccounts={pageData.availableAccounts}
         initialDocumentId={pageData.initialDocumentId}
         onNavigateBack={onNavigateBack}
+        onCollectionChange={setActiveCollection}
+        sidebarSelectedCollection={activeCollection}
         embedded
       />
     </AppLayout>

--- a/frontend/pages/DataExplorerPageWrapper.tsx
+++ b/frontend/pages/DataExplorerPageWrapper.tsx
@@ -4,6 +4,7 @@ import DataExplorerPage from './DataExplorerPage';
 import AppLayout from '../components/AppLayout';
 import { SelectedResource, DbInfo, CosmosDBAccount, CollectionSummary } from '../types';
 import { getAzureCosmosAccounts, getDatabasesForAccount } from '../services/dbService';
+import { FilterState } from '../utils/queryHandover';
 
 interface LocationState {
   dbInfo?: DbInfo;
@@ -11,6 +12,7 @@ interface LocationState {
   availableDbs?: DbInfo[];
   availableAccounts?: CosmosDBAccount[];
   initialCollection?: string;
+  initialFilters?: FilterState[];
 }
 
 const DataExplorerPageWrapper: React.FC = () => {
@@ -43,6 +45,7 @@ const DataExplorerPageWrapper: React.FC = () => {
     availableDbs: DbInfo[];
     availableAccounts: CosmosDBAccount[];
     initialDocumentId?: string;
+    initialFilters?: FilterState[];
   } | null>(null);
 
   // Reset active collection when DB/account changes so the new page starts fresh
@@ -108,6 +111,7 @@ const DataExplorerPageWrapper: React.FC = () => {
               availableDbs: sessionConn.availableDbs,
               availableAccounts: sessionConn.availableAccounts,
               initialDocumentId: decodedDocumentId,
+              initialFilters: state?.initialFilters,
             });
             return;
           }
@@ -129,7 +133,8 @@ const DataExplorerPageWrapper: React.FC = () => {
             accountName: state.accountName,
             availableDbs: state.availableDbs,
             availableAccounts: state.availableAccounts,
-            initialDocumentId: decodedDocumentId
+            initialDocumentId: decodedDocumentId,
+            initialFilters: state.initialFilters,
           });
         } else {
           // Otherwise, fetch the data we need
@@ -283,6 +288,7 @@ const DataExplorerPageWrapper: React.FC = () => {
         availableDbs={pageData.availableDbs}
         availableAccounts={pageData.availableAccounts}
         initialDocumentId={pageData.initialDocumentId}
+        initialFilters={pageData.initialFilters}
         onNavigateBack={onNavigateBack}
         onCollectionChange={setActiveCollection}
         sidebarSelectedCollection={activeCollection}

--- a/frontend/pages/DataExplorerPageWrapper.tsx
+++ b/frontend/pages/DataExplorerPageWrapper.tsx
@@ -85,6 +85,31 @@ const DataExplorerPageWrapper: React.FC = () => {
           databaseName: decodedDatabaseName
         };
 
+        // Fast path: sessionStorage already has a matching connection — skip API calls
+        const sessionConn = (() => {
+          try { return JSON.parse(sessionStorage.getItem('qp_connection') ?? 'null'); }
+          catch { return null; }
+        })();
+        if (
+          sessionConn?.accountId === decodedAccountId &&
+          sessionConn?.databaseName === decodedDatabaseName &&
+          sessionConn?.availableAccounts?.length &&
+          sessionConn?.availableDbs?.length
+        ) {
+          const dbInfo = sessionConn.availableDbs.find((d: DbInfo) => d.name === decodedDatabaseName);
+          if (dbInfo) {
+            setPageData({
+              resource,
+              dbInfo,
+              accountName: sessionConn.accountName,
+              availableDbs: sessionConn.availableDbs,
+              availableAccounts: sessionConn.availableAccounts,
+              initialDocumentId: decodedDocumentId,
+            });
+            return;
+          }
+        }
+
         // If we have state from navigation, use it
         if (state?.dbInfo && state?.accountName && state?.availableDbs && state?.availableAccounts) {
           sessionStorage.setItem('qp_connection', JSON.stringify({

--- a/frontend/pages/DataExplorerPageWrapper.tsx
+++ b/frontend/pages/DataExplorerPageWrapper.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import DataExplorerPage from './DataExplorerPage';
+import AppLayout from '../components/AppLayout';
 import { SelectedResource, DbInfo, CosmosDBAccount } from '../types';
 import { getAzureCosmosAccounts, getDatabasesForAccount } from '../services/dbService';
-import Loader from '../components/Loader';
 
 interface LocationState {
   dbInfo?: DbInfo;
@@ -230,15 +230,22 @@ const DataExplorerPageWrapper: React.FC = () => {
   }
 
   return (
-    <DataExplorerPage
-      resource={pageData.resource}
-      dbInfo={pageData.dbInfo}
+    <AppLayout
       accountName={pageData.accountName}
-      availableDbs={pageData.availableDbs}
-      availableAccounts={pageData.availableAccounts}
-      initialDocumentId={pageData.initialDocumentId}
-      onNavigateBack={onNavigateBack}
-    />
+      databaseName={pageData.dbInfo.name}
+      collections={pageData.dbInfo.collections}
+    >
+      <DataExplorerPage
+        resource={pageData.resource}
+        dbInfo={pageData.dbInfo}
+        accountName={pageData.accountName}
+        availableDbs={pageData.availableDbs}
+        availableAccounts={pageData.availableAccounts}
+        initialDocumentId={pageData.initialDocumentId}
+        onNavigateBack={onNavigateBack}
+        embedded
+      />
+    </AppLayout>
   );
 };
 

--- a/frontend/pages/DataExplorerPageWrapper.tsx
+++ b/frontend/pages/DataExplorerPageWrapper.tsx
@@ -219,14 +219,22 @@ const DataExplorerPageWrapper: React.FC = () => {
   if (loading) {
     const decodedAccountId = accountId ? decodeURIComponent(accountId) : undefined;
     const decodedDatabaseName = databaseName ? decodeURIComponent(databaseName) : undefined;
+    // sessionCache is initialised once from localStorage at mount; pageData holds the last
+    // successful load and works as a fallback when the user arrived via Hub (no prior session).
+    const sidebarFallback = sessionCache ?? (pageData ? {
+      accountName: pageData.accountName,
+      collections: pageData.dbInfo.collections,
+      availableAccounts: pageData.availableAccounts,
+      availableDbs: pageData.availableDbs,
+    } : null);
     return (
       <AppLayout
         accountId={decodedAccountId}
         databaseName={decodedDatabaseName}
-        accountName={sessionCache?.accountName}
-        collections={sessionCache?.collections}
-        availableAccounts={sessionCache?.availableAccounts}
-        availableDbs={sessionCache?.availableDbs}
+        accountName={sidebarFallback?.accountName}
+        collections={sidebarFallback?.collections}
+        availableAccounts={sidebarFallback?.availableAccounts}
+        availableDbs={sidebarFallback?.availableDbs}
       >
         <style>{`@keyframes qp-spin { to { transform: rotate(360deg); } }`}</style>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', background: 'var(--bg)' }}>

--- a/frontend/pages/DataExplorerPageWrapper.tsx
+++ b/frontend/pages/DataExplorerPageWrapper.tsx
@@ -10,6 +10,7 @@ interface LocationState {
   accountName?: string;
   availableDbs?: DbInfo[];
   availableAccounts?: CosmosDBAccount[];
+  initialCollection?: string;
 }
 
 const DataExplorerPageWrapper: React.FC = () => {
@@ -24,7 +25,9 @@ const DataExplorerPageWrapper: React.FC = () => {
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [activeCollection, setActiveCollection] = useState<string | undefined>(undefined);
+  const [activeCollection, setActiveCollection] = useState<string | undefined>(
+    (location.state as LocationState)?.initialCollection
+  );
 
   // Used to keep sidebar populated during the async load so there's no visual flash
   const [sessionCache] = useState<{ accountName?: string; collections?: CollectionSummary[]; availableAccounts?: CosmosDBAccount[]; availableDbs?: DbInfo[] } | null>(() => {

--- a/frontend/pages/HubPage.tsx
+++ b/frontend/pages/HubPage.tsx
@@ -210,7 +210,6 @@ const HubPage: React.FC = () => {
           {[
             { label: 'Home', href: '/hub', active: true },
             { label: 'Analytics', href: '/analytics', active: false },
-            { label: 'Audit Log', href: '/audit', active: false },
           ].map((item) => (
             <Link
               key={item.href}

--- a/frontend/pages/HubPage.tsx
+++ b/frontend/pages/HubPage.tsx
@@ -198,7 +198,6 @@ const HubPage: React.FC = () => {
         <nav style={{ display: 'flex', alignItems: 'center', gap: 2, marginLeft: 8 }}>
           {[
             { label: 'Home', href: '/hub', active: true },
-            { label: 'Workspace', href: '/query-generator', active: false },
             { label: 'Analytics', href: '/analytics', active: false },
             { label: 'Audit Log', href: '/audit', active: false },
           ].map((item) => (

--- a/frontend/pages/HubPage.tsx
+++ b/frontend/pages/HubPage.tsx
@@ -85,10 +85,10 @@ const DB_ENGINES = [
     markBg: '#326690',
     label: 'PostgreSQL',
     sub: 'Azure Flexible Server',
-    badge: 'Private preview',
+    badge: 'Unavailable',
     badgeOk: false,
     locked: true,
-    opacity: 0.65,
+    opacity: 0.4,
   },
   {
     key: 'snow',
@@ -96,7 +96,7 @@ const DB_ENGINES = [
     markBg: '#5da4d6',
     label: 'Snowflake',
     sub: 'Data Cloud',
-    badge: 'Vote',
+    badge: 'Unavailable',
     badgeOk: false,
     locked: true,
     opacity: 0.4,
@@ -107,7 +107,7 @@ const DB_ENGINES = [
     markBg: '#3f6acb',
     label: 'BigQuery',
     sub: 'Google Cloud',
-    badge: 'Vote',
+    badge: 'Unavailable',
     badgeOk: false,
     locked: true,
     opacity: 0.4,
@@ -118,7 +118,7 @@ const DB_ENGINES = [
     markBg: '#d4a52a',
     label: 'ClickHouse',
     sub: 'Open source OLAP',
-    badge: 'Vote',
+    badge: 'Unavailable',
     badgeOk: false,
     locked: true,
     opacity: 0.4,
@@ -331,10 +331,6 @@ const HubPage: React.FC = () => {
             <h2 style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--muted)', margin: 0 }}>
               Available databases
             </h2>
-            <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>
-              Don't see yours?{' '}
-              <a href="mailto:support@querypal.dev" style={{ color: 'var(--accent)', textDecoration: 'none' }}>Tell us</a>
-            </span>
           </div>
 
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 12 }}>

--- a/frontend/pages/HubPage.tsx
+++ b/frontend/pages/HubPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
 import { useTheme } from '../contexts/ThemeContext';
-import { getAzureCosmosAccounts } from '../services/dbService';
+import { getAzureCosmosAccounts, getDatabasesForAccount } from '../services/dbService';
 import { CosmosDBAccount } from '../types';
 import { API_BASE_URL } from '../app.config';
 
@@ -186,6 +186,17 @@ const HubPage: React.FC = () => {
     navigate('/query-generator', { state: { preselectedAccountId: account.id, preselectedAccountName: account.name } });
   };
 
+  const handleOpenExplorer = async (account: CosmosDBAccount) => {
+    try {
+      const databases = await getDatabasesForAccount(account.id);
+      if (databases.length === 0) return;
+      const firstDb = databases[0];
+      navigate(`/data-explorer/${encodeURIComponent(account.id)}/${encodeURIComponent(firstDb.name)}`);
+    } catch (e) {
+      console.error('Failed to open explorer:', e);
+    }
+  };
+
   return (
     <div style={s.page}>
       {/* Top bar */}
@@ -310,7 +321,7 @@ const HubPage: React.FC = () => {
               </div>
             )}
             {accounts.map((account) => (
-              <ConnectionCard key={account.id} account={account} onOpen={handleOpenAccount} />
+              <ConnectionCard key={account.id} account={account} onOpen={handleOpenAccount} onOpenExplorer={handleOpenExplorer} />
             ))}
           </div>
         </section>
@@ -397,11 +408,15 @@ const HubPage: React.FC = () => {
 };
 
 /* ── Connection card ── */
-const ConnectionCard: React.FC<{ account: CosmosDBAccount; onOpen: (a: CosmosDBAccount) => void }> = ({ account, onOpen }) => {
+const ConnectionCard: React.FC<{
+  account: CosmosDBAccount;
+  onOpen: (a: CosmosDBAccount) => void;
+  onOpenExplorer: (a: CosmosDBAccount) => void;
+}> = ({ account, onOpen, onOpenExplorer }) => {
   const [hovered, setHovered] = useState(false);
+  const [explorerHovered, setExplorerHovered] = useState(false);
   return (
     <div
-      onClick={() => onOpen(account)}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
@@ -409,7 +424,6 @@ const ConnectionCard: React.FC<{ account: CosmosDBAccount; onOpen: (a: CosmosDBA
         border: `1px solid ${hovered ? 'color-mix(in oklch, var(--accent) 35%, var(--border))' : 'var(--border)'}`,
         borderRadius: 14, padding: 22,
         display: 'flex', flexDirection: 'column', gap: 14,
-        cursor: 'pointer',
         transform: hovered ? 'translateY(-1px)' : 'none',
         boxShadow: hovered ? '0 12px 24px -16px rgba(20,18,14,0.18)' : 'none',
         transition: 'transform 0.12s, border-color 0.12s, box-shadow 0.12s',
@@ -435,14 +449,43 @@ const ConnectionCard: React.FC<{ account: CosmosDBAccount; onOpen: (a: CosmosDBA
         </div>
       </div>
 
-      <div style={{ paddingTop: 12, borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <div style={{ paddingTop: 12, borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
         <span className="qa-chip ok">● live</span>
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: 'var(--accent)', fontSize: 12.5 }}>
-          Open
-          <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
-            <path d="M3 8h10M9 4l4 4-4 4"/>
-          </svg>
-        </span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <button
+            onClick={() => onOpenExplorer(account)}
+            onMouseEnter={() => setExplorerHovered(true)}
+            onMouseLeave={() => setExplorerHovered(false)}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 4,
+              fontSize: 12, padding: '5px 10px', borderRadius: 6,
+              border: `1px solid ${explorerHovered ? 'var(--accent)' : 'var(--border)'}`,
+              background: explorerHovered ? 'var(--accent-soft)' : 'var(--soft)',
+              color: explorerHovered ? 'var(--accent)' : 'var(--muted)',
+              cursor: 'pointer', fontFamily: 'var(--font-body)',
+              transition: 'border-color 0.12s, background 0.12s, color 0.12s',
+            }}
+          >
+            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M2 3h12v3H2zM2 7h12v3H2zM2 11h12v3H2z"/>
+            </svg>
+            Explorer
+          </button>
+          <button
+            onClick={() => onOpen(account)}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 4,
+              fontSize: 12.5, padding: '5px 10px', borderRadius: 6,
+              border: 'none', background: 'none',
+              color: 'var(--accent)', cursor: 'pointer', fontFamily: 'var(--font-body)',
+            }}
+          >
+            Open
+            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
+              <path d="M3 8h10M9 4l4 4-4 4"/>
+            </svg>
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/pages/HubPage.tsx
+++ b/frontend/pages/HubPage.tsx
@@ -1,0 +1,488 @@
+import React, { useState, useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
+import { useTheme } from '../contexts/ThemeContext';
+import { getAzureCosmosAccounts } from '../services/dbService';
+import { CosmosDBAccount } from '../types';
+import { API_BASE_URL } from '../app.config';
+
+interface RecentActivityItem {
+  database_name: string;
+  collection_name: string;
+  operation: string;
+  document_id: string;
+  user_email: string;
+  timestamp_utc: string;
+}
+
+/* ── tiny inline styles matching Direction A design tokens ── */
+const s = {
+  page: {
+    minHeight: '100vh',
+    background: 'var(--bg)',
+    fontFamily: 'var(--font-body)',
+    color: 'var(--fg)',
+  } as React.CSSProperties,
+
+  topbar: {
+    height: 54,
+    padding: '0 28px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 14,
+    borderBottom: '1px solid var(--border)',
+    background: 'var(--panel)',
+  } as React.CSSProperties,
+
+  brand: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 9,
+    textDecoration: 'none',
+    color: 'var(--fg)',
+  } as React.CSSProperties,
+
+  brandMark: {
+    width: 24,
+    height: 24,
+    borderRadius: 7,
+    background: 'var(--fg)',
+    color: 'var(--bg)',
+    display: 'grid',
+    placeItems: 'center',
+    fontFamily: 'var(--font-display)',
+    fontWeight: 600,
+    fontSize: 14,
+    letterSpacing: '-0.04em',
+    flexShrink: 0,
+  } as React.CSSProperties,
+
+  body: {
+    maxWidth: 1100,
+    margin: '0 auto',
+    padding: '52px 64px 80px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 48,
+  } as React.CSSProperties,
+};
+
+/* ── DB engine cards (static config) ── */
+const DB_ENGINES = [
+  {
+    key: 'cosmos',
+    mark: 'C',
+    markBg: '#1a4f8c',
+    label: 'Azure Cosmos DB',
+    sub: 'MongoDB API',
+    badge: 'Generally available',
+    badgeOk: true,
+    locked: false,
+  },
+  {
+    key: 'pg',
+    mark: 'P',
+    markBg: '#326690',
+    label: 'PostgreSQL',
+    sub: 'Azure Flexible Server',
+    badge: 'Private preview',
+    badgeOk: false,
+    locked: true,
+    opacity: 0.65,
+  },
+  {
+    key: 'snow',
+    mark: 'S',
+    markBg: '#5da4d6',
+    label: 'Snowflake',
+    sub: 'Data Cloud',
+    badge: 'Vote',
+    badgeOk: false,
+    locked: true,
+    opacity: 0.4,
+  },
+  {
+    key: 'bq',
+    mark: 'B',
+    markBg: '#3f6acb',
+    label: 'BigQuery',
+    sub: 'Google Cloud',
+    badge: 'Vote',
+    badgeOk: false,
+    locked: true,
+    opacity: 0.4,
+  },
+  {
+    key: 'ch',
+    mark: 'Ch',
+    markBg: '#d4a52a',
+    label: 'ClickHouse',
+    sub: 'Open source OLAP',
+    badge: 'Vote',
+    badgeOk: false,
+    locked: true,
+    opacity: 0.4,
+  },
+];
+
+/* ──────────────────────────────────────────────────────────── */
+
+function formatRelativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days === 1) return 'yesterday';
+  return `${days}d ago`;
+}
+
+const HubPage: React.FC = () => {
+  const { user, logout, getToken } = useUnifiedAuth();
+  const { theme, toggleTheme } = useTheme();
+  const navigate = useNavigate();
+
+  const [accounts, setAccounts] = useState<CosmosDBAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [recentActivity, setRecentActivity] = useState<RecentActivityItem[]>([]);
+
+  useEffect(() => {
+    getAzureCosmosAccounts()
+      .then((accs) => { setAccounts(accs); })
+      .catch((err) => { setError(err.message || 'Failed to load accounts'); })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    const fetchRecent = async () => {
+      try {
+        const token = await getToken();
+        const res = await fetch(`${API_BASE_URL}/audit/recent?limit=8`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setRecentActivity(data);
+        }
+      } catch {
+        // silently ignore — recent activity is non-critical
+      }
+    };
+    fetchRecent();
+  }, []);
+
+  const firstName = user?.name?.split(' ')[0] || 'there';
+  const hour = new Date().getHours();
+  const greeting = hour < 12 ? 'Good morning' : hour < 17 ? 'Good afternoon' : 'Good evening';
+
+  const initials = user?.name
+    ? user.name.split(' ').map((n) => n[0]).join('').slice(0, 2).toUpperCase()
+    : 'U';
+
+  const handleOpenAccount = (account: CosmosDBAccount) => {
+    navigate('/query-generator', { state: { preselectedAccountId: account.id, preselectedAccountName: account.name } });
+  };
+
+  return (
+    <div style={s.page}>
+      {/* Top bar */}
+      <header style={s.topbar}>
+        <Link to="/hub" style={s.brand}>
+          <span style={s.brandMark}>Q</span>
+          <span style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 14.5 }}>QueryPal</span>
+        </Link>
+
+        <nav style={{ display: 'flex', alignItems: 'center', gap: 2, marginLeft: 8 }}>
+          {[
+            { label: 'Home', href: '/hub', active: true },
+            { label: 'Workspace', href: '/query-generator', active: false },
+            { label: 'Analytics', href: '/analytics', active: false },
+            { label: 'Audit Log', href: '/audit', active: false },
+          ].map((item) => (
+            <Link
+              key={item.href}
+              to={item.href}
+              style={{
+                fontSize: 12.5,
+                color: item.active ? 'var(--fg)' : 'var(--muted)',
+                textDecoration: 'none',
+                padding: '6px 9px',
+                borderRadius: 6,
+                fontWeight: item.active ? 500 : 400,
+                background: item.active ? 'var(--soft)' : 'transparent',
+              }}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+          {/* Theme toggle — shows icon for what you'll switch TO */}
+          <button
+            onClick={toggleTheme}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex', padding: 5, borderRadius: 6 }}
+            title="Toggle theme"
+          >
+            {theme === 'light' ? (
+              /* Moon: click to go dark */
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+              </svg>
+            ) : (
+              /* Sun: click to go light */
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="4"/>
+                <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+              </svg>
+            )}
+          </button>
+          {/* User avatar */}
+          <div
+            style={{
+              width: 28, height: 28, borderRadius: '50%',
+              background: 'var(--accent-soft)', color: 'var(--accent)',
+              display: 'grid', placeItems: 'center',
+              fontSize: 11, fontWeight: 600, fontFamily: 'var(--font-body)',
+            }}
+            title={user?.name || user?.email}
+          >
+            {initials}
+          </div>
+          <button
+            onClick={logout}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', fontSize: 12, fontFamily: 'var(--font-body)' }}
+          >
+            Sign out
+          </button>
+        </div>
+      </header>
+
+      {/* Body */}
+      <div style={s.body}>
+        {/* Greeting */}
+        <div>
+          <h1 style={{
+            fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 36,
+            lineHeight: 1.05, letterSpacing: '-0.025em', margin: 0,
+          }}>
+            {greeting},{' '}
+            <em style={{ fontStyle: 'italic', color: 'var(--accent)', fontWeight: 500 }}>{firstName}</em>
+          </h1>
+          <p style={{ fontSize: 13.5, color: 'var(--muted)', margin: '8px 0 0', lineHeight: 1.5 }}>
+            Pick a connection to start querying.
+          </p>
+        </div>
+
+        {/* Connections */}
+        <section>
+          <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 14 }}>
+            <h2 style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--muted)', margin: 0 }}>
+              Your connections
+            </h2>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))', gap: 14 }}>
+            {loading && (
+              <div style={{
+                background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 14,
+                padding: 22, gridColumn: '1 / -1', color: 'var(--muted)', fontSize: 13,
+              }}>
+                Loading connections…
+              </div>
+            )}
+            {error && (
+              <div style={{
+                background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 14,
+                padding: 22, gridColumn: '1 / -1', color: 'var(--status-err)', fontSize: 13,
+              }}>
+                {error}
+              </div>
+            )}
+            {!loading && !error && accounts.length === 0 && (
+              <div style={{
+                background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 14,
+                padding: 22, color: 'var(--muted)', fontSize: 13,
+              }}>
+                No Cosmos DB accounts found. Add a connection below.
+              </div>
+            )}
+            {accounts.map((account) => (
+              <ConnectionCard key={account.id} account={account} onOpen={handleOpenAccount} />
+            ))}
+          </div>
+        </section>
+
+        {/* Available databases */}
+        <section>
+          <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 14 }}>
+            <h2 style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--muted)', margin: 0 }}>
+              Available databases
+            </h2>
+            <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>
+              Don't see yours?{' '}
+              <a href="mailto:support@querypal.dev" style={{ color: 'var(--accent)', textDecoration: 'none' }}>Tell us</a>
+            </span>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 12 }}>
+            {DB_ENGINES.map((engine) => (
+              <DbEngineCard key={engine.key} engine={engine} />
+            ))}
+          </div>
+        </section>
+
+        {/* Recent activity */}
+        <section>
+          <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 14 }}>
+            <h2 style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--muted)', margin: 0 }}>
+              Recent activity
+            </h2>
+            <Link to="/audit" style={{ fontSize: 12, color: 'var(--accent)', textDecoration: 'none' }}>
+              View all →
+            </Link>
+          </div>
+
+          <div style={{ background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 12, overflow: 'hidden' }}>
+            {/* Header row */}
+            <div style={{
+              display: 'grid', gridTemplateColumns: '1.6fr 1.4fr 0.7fr 0.8fr 0.7fr',
+              gap: 14, padding: '8px 16px',
+              fontSize: 10.5, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: '0.07em',
+              borderBottom: '1px solid var(--border)',
+            }}>
+              {['Database · Collection', 'Document', 'Op', 'User', 'When'].map((h) => (
+                <span key={h}>{h}</span>
+              ))}
+            </div>
+            {recentActivity.length === 0 && (
+              <div style={{ padding: '20px 16px', fontSize: 12.5, color: 'var(--muted)', textAlign: 'center' }}>
+                No recent activity found.
+              </div>
+            )}
+            {recentActivity.map((row, i) => (
+              <div
+                key={i}
+                style={{
+                  display: 'grid', gridTemplateColumns: '1.6fr 1.4fr 0.7fr 0.8fr 0.7fr',
+                  gap: 14, padding: '11px 16px', alignItems: 'center',
+                  fontSize: 12.5, borderBottom: i < recentActivity.length - 1 ? '1px solid var(--border)' : 'none',
+                  transition: 'background 0.1s', cursor: 'default',
+                }}
+                onMouseEnter={(e) => (e.currentTarget as HTMLDivElement).style.background = 'var(--soft)'}
+                onMouseLeave={(e) => (e.currentTarget as HTMLDivElement).style.background = 'transparent'}
+              >
+                <span style={{ color: 'var(--muted)', fontFamily: 'var(--font-mono)', fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {row.database_name} · {row.collection_name}
+                </span>
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--fg)' }}>
+                  {row.document_id}
+                </span>
+                <span>
+                  <span className={`qa-chip${row.operation === 'insert' ? ' ok' : row.operation === 'delete' ? ' err' : ''}`} style={{ fontSize: 10 }}>
+                    {row.operation}
+                  </span>
+                </span>
+                <span style={{ color: 'var(--muted)', fontSize: 11.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{row.user_email}</span>
+                <span style={{ color: 'var(--muted)', fontSize: 11.5 }}>{formatRelativeTime(row.timestamp_utc)}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+/* ── Connection card ── */
+const ConnectionCard: React.FC<{ account: CosmosDBAccount; onOpen: (a: CosmosDBAccount) => void }> = ({ account, onOpen }) => {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <div
+      onClick={() => onOpen(account)}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        background: 'var(--panel)',
+        border: `1px solid ${hovered ? 'color-mix(in oklch, var(--accent) 35%, var(--border))' : 'var(--border)'}`,
+        borderRadius: 14, padding: 22,
+        display: 'flex', flexDirection: 'column', gap: 14,
+        cursor: 'pointer',
+        transform: hovered ? 'translateY(-1px)' : 'none',
+        boxShadow: hovered ? '0 12px 24px -16px rgba(20,18,14,0.18)' : 'none',
+        transition: 'transform 0.12s, border-color 0.12s, box-shadow 0.12s',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <div style={{
+          width: 38, height: 38, borderRadius: 9, background: '#1a4f8c', color: '#fff',
+          display: 'grid', placeItems: 'center',
+          fontFamily: 'var(--font-display)', fontSize: 18, fontWeight: 500, letterSpacing: '-0.03em',
+          flexShrink: 0,
+        }}>C</div>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontSize: 15, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {account.name}
+          </div>
+          <div style={{
+            fontSize: 11.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)',
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginTop: 2,
+          }}>
+            {account.id}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ paddingTop: 12, borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span className="qa-chip ok">● live</span>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: 'var(--accent)', fontSize: 12.5 }}>
+          Open
+          <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
+            <path d="M3 8h10M9 4l4 4-4 4"/>
+          </svg>
+        </span>
+      </div>
+    </div>
+  );
+};
+
+/* ── DB engine card ── */
+const DbEngineCard: React.FC<{ engine: typeof DB_ENGINES[0] }> = ({ engine }) => {
+  return (
+    <div
+      style={{
+        background: engine.locked ? 'var(--soft)' : 'var(--panel)',
+        border: '1px solid var(--border)', borderRadius: 12,
+        padding: 18, display: 'flex', flexDirection: 'column', gap: 10,
+        minHeight: 160, opacity: engine.opacity ?? 1,
+        cursor: engine.locked ? 'default' : 'pointer',
+      }}
+    >
+      <div style={{
+        width: 34, height: 34, borderRadius: 8,
+        background: engine.markBg, color: '#fff',
+        display: 'grid', placeItems: 'center',
+        fontFamily: 'var(--font-display)', fontSize: 15, fontWeight: 600,
+      }}>
+        {engine.mark}
+      </div>
+      <div>
+        <div style={{ fontSize: 13, fontWeight: 500, marginBottom: 2 }}>{engine.label}</div>
+        <div style={{ fontSize: 11.5, color: 'var(--muted)' }}>{engine.sub}</div>
+      </div>
+      <div style={{ marginTop: 'auto' }}>
+        <span
+          className={`qa-chip${engine.badgeOk ? ' ok' : ''}`}
+          style={!engine.badgeOk ? { fontSize: 10.5 } : { fontSize: 10.5 }}
+        >
+          {engine.badge}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default HubPage;

--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -65,11 +65,11 @@ const MsalLoginPage: React.FC = () => {
         console.log('MSAL Login Page - isAuthenticated:', isAuthenticated, 'accounts:', accounts);
         if (isAuthenticated && accounts.length > 0) {
             // Check if there's a saved location to redirect to
-            const from = location.state?.from?.pathname || '/query-generator';
+            const from = location.state?.from?.pathname || '/hub';
             const search = location.state?.from?.search || '';
             const hash = location.state?.from?.hash || '';
             const redirectPath = from + search + hash;
-            
+
             console.log('User is authenticated, navigating to:', redirectPath);
             navigate(redirectPath, { replace: true });
         }
@@ -86,7 +86,7 @@ const MsalLoginPage: React.FC = () => {
     if (isAuthenticated && accounts.length > 0) {
         return (
             <div className="min-h-screen bg-slate-50 dark:bg-slate-900 flex flex-col justify-center items-center p-4 text-slate-800 dark:text-slate-200">
-                <div>Redirecting to Query Generator...</div>
+                <div>Redirecting…</div>
             </div>
         );
     }
@@ -104,11 +104,11 @@ const BypassLoginPage: React.FC = () => {
         // Navigate using React Router instead of window.location
         setTimeout(() => {
             // Check if there's a saved location to redirect to
-            const from = location.state?.from?.pathname || '/query-generator';
+            const from = location.state?.from?.pathname || '/hub';
             const search = location.state?.from?.search || '';
             const hash = location.state?.from?.hash || '';
             const redirectPath = from + search + hash;
-            
+
             navigate(redirectPath, { replace: true });
         }, 100);
     };

--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -1,125 +1,289 @@
-
 import React, { useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
-import { loginRequest } from "../authConfig";
-import MongoIcon from '../components/icons/MongoIcon';
+import { useMsal, useIsAuthenticated } from '@azure/msal-react';
+import { loginRequest } from '../authConfig';
 import { USE_MSAL_AUTH } from '../app.config';
 import { useAuth } from '../contexts/AuthContext';
-import { UserIcon, MicrosoftIcon } from '../components/icons/material-icons-imports';
 
-// --- UI Component (Shared) ---
-interface LoginUIProps {
-    onLogin: () => void;
-    buttonText: string;
-    ButtonIcon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-}
+// ── Icons ────────────────────────────────────────────────────────────────────
 
-const LoginUI: React.FC<LoginUIProps> = ({ onLogin, buttonText, ButtonIcon }) => (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 flex flex-col justify-center items-center p-4 text-slate-800 dark:text-slate-200">
-        <div className="max-w-md w-full mx-auto bg-white dark:bg-slate-800/50 dark:ring-1 dark:ring-slate-700 rounded-xl shadow-lg dark:shadow-black/20 p-6 sm:p-8 text-center">
-            <header className="flex flex-col items-center justify-center space-y-4 mb-8">
-                <MongoIcon className="w-16 h-16 text-blue-500" />
-                <div>
-                    <h1 className="text-3xl sm:text-4xl font-bold bg-gradient-to-r from-violet-600 to-blue-600 bg-clip-text text-transparent">QueryPal</h1>
-                    <p className="text-slate-500 dark:text-slate-400 mt-2">Your AI-Powered Database Assistant</p>
-                </div>
-            </header>
-
-            <main className="space-y-6">
-                <button
-                    onClick={onLogin}
-                    className="w-full flex justify-center items-center gap-3 px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-violet-600 hover:bg-violet-700 disabled:bg-slate-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-violet-500 transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.99]"
-                    title={buttonText}
-                >
-                    <ButtonIcon className="w-6 h-6" />
-                    {buttonText}
-                </button>
-                <p className="text-xs text-slate-500 dark:text-slate-400">
-                    {USE_MSAL_AUTH 
-                        ? "You will be redirected to the Microsoft login page for authentication."
-                        : "Using developer sign-in. No credentials required."
-                    }
-                </p>
-            </main>
-        </div>
-                <footer className="text-center mt-8 text-slate-500 dark:text-slate-400 text-sm">
-            <p>Powered by Microsoft Azure and Google Gemini. For internal use only.</p>
-            <p className="text-xs max-w-md mx-auto">
-                AI features use the Google Gemini API. Your data is not used to train their models. See the <a href="https://ai.google.dev/gemini-api/terms" target="_blank" rel="noopener noreferrer" className="underline hover:text-slate-700 dark:hover:text-slate-200">Terms of Service</a>.
-            </p>
-        </footer>
-    </div>
+const MicrosoftLogo = () => (
+  <svg width="16" height="16" viewBox="0 0 21 21" style={{ flexShrink: 0 }}>
+    <rect x="1" y="1" width="9" height="9" fill="#f25022" />
+    <rect x="11" y="1" width="9" height="9" fill="#7fba00" />
+    <rect x="1" y="11" width="9" height="9" fill="#00a4ef" />
+    <rect x="11" y="11" width="9" height="9" fill="#ffb900" />
+  </svg>
 );
 
+const DevIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" style={{ flexShrink: 0 }}>
+    <circle cx="8" cy="5.5" r="2.5" />
+    <path d="M2.5 13.5c0-3.038 2.462-5.5 5.5-5.5s5.5 2.462 5.5 5.5" />
+  </svg>
+);
 
-// --- Container Components ---
+// ── Feature list ─────────────────────────────────────────────────────────────
+
+const FEATURES = [
+  {
+    icon: (
+      <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
+        <path d="M2 4h12M2 8h8M2 12h5" />
+      </svg>
+    ),
+    label: 'AI query generation',
+  },
+  {
+    icon: (
+      <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+        <path d="M2 3h12v3H2zM2 7h12v3H2zM2 11h12v3H2z" />
+      </svg>
+    ),
+    label: 'Data explorer',
+  },
+  {
+    icon: (
+      <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+        <path d="M3 2h7l3 3v9H3zM6 7h5M6 9h5M6 11h3" />
+      </svg>
+    ),
+    label: 'Audit log',
+  },
+  {
+    icon: (
+      <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
+        <path d="M2 13h12M4 11V6M7 11V3M10 11V8M13 11V5" />
+      </svg>
+    ),
+    label: 'Analytics',
+  },
+];
+
+// ── Shared UI ─────────────────────────────────────────────────────────────────
+
+interface LoginUIProps {
+  onLogin: () => void;
+  buttonText: string;
+  buttonIcon: React.ReactNode;
+  note: string;
+}
+
+const LoginUI: React.FC<LoginUIProps> = ({ onLogin, buttonText, buttonIcon, note }) => (
+  <div style={{
+    minHeight: '100vh',
+    background: 'var(--bg)',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '32px 20px',
+    fontFamily: 'var(--font-body)',
+    color: 'var(--fg)',
+  }}>
+    <div style={{ width: '100%', maxWidth: 380, display: 'flex', flexDirection: 'column', gap: 28 }}>
+
+      {/* Brand */}
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+        <div style={{
+          width: 48, height: 48, borderRadius: 14,
+          background: 'var(--fg)', color: 'var(--bg)',
+          display: 'grid', placeItems: 'center',
+          fontFamily: 'var(--font-display)', fontWeight: 700,
+          fontSize: 26, letterSpacing: '-0.05em',
+          boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+        }}>Q</div>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{
+            fontFamily: 'var(--font-display)', fontWeight: 600,
+            fontSize: 26, letterSpacing: '-0.02em', color: 'var(--fg)',
+            lineHeight: 1.1,
+          }}>QueryPal</div>
+          <div style={{
+            fontSize: 13, color: 'var(--muted)', marginTop: 5,
+            fontFamily: 'var(--font-body)',
+          }}>
+            AI-powered queries for Azure Cosmos DB
+          </div>
+        </div>
+      </div>
+
+      {/* Card */}
+      <div style={{
+        background: 'var(--panel)',
+        border: '1px solid var(--border)',
+        borderRadius: 'var(--radius-lg)',
+        padding: '28px 28px 24px',
+        boxShadow: '0 2px 12px rgba(0,0,0,0.06)',
+        display: 'flex', flexDirection: 'column', gap: 20,
+      }}>
+        <div>
+          <div style={{
+            fontFamily: 'var(--font-display)', fontWeight: 600,
+            fontSize: 18, color: 'var(--fg)', letterSpacing: '-0.01em',
+          }}>
+            Welcome back
+          </div>
+          <div style={{ fontSize: 13, color: 'var(--muted)', marginTop: 5, lineHeight: 1.5 }}>
+            Sign in to access your workspace and databases.
+          </div>
+        </div>
+
+        {/* Sign in button */}
+        <button
+          onClick={onLogin}
+          style={{
+            width: '100%', height: 44,
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 10,
+            background: 'var(--accent)', color: '#fff',
+            border: 'none', borderRadius: 9,
+            fontSize: 13.5, fontWeight: 600, fontFamily: 'var(--font-body)',
+            cursor: 'pointer',
+            transition: 'opacity 0.15s, transform 0.1s',
+            letterSpacing: '-0.01em',
+          }}
+          onMouseEnter={e => { (e.currentTarget as HTMLElement).style.opacity = '0.88'; }}
+          onMouseLeave={e => { (e.currentTarget as HTMLElement).style.opacity = '1'; }}
+          onMouseDown={e => { (e.currentTarget as HTMLElement).style.transform = 'scale(0.987)'; }}
+          onMouseUp={e => { (e.currentTarget as HTMLElement).style.transform = 'scale(1)'; }}
+        >
+          {buttonIcon}
+          {buttonText}
+        </button>
+
+        {/* Note */}
+        <div style={{
+          fontSize: 11.5, color: 'var(--muted)',
+          textAlign: 'center', lineHeight: 1.55,
+          borderTop: '1px solid var(--border)',
+          paddingTop: 16,
+        }}>
+          {note}
+        </div>
+      </div>
+
+      {/* Feature chips */}
+      <div style={{
+        display: 'flex', flexWrap: 'wrap',
+        gap: 8, justifyContent: 'center',
+      }}>
+        {FEATURES.map(f => (
+          <span key={f.label} style={{
+            display: 'inline-flex', alignItems: 'center', gap: 5,
+            padding: '4px 10px',
+            background: 'var(--panel)',
+            border: '1px solid var(--border)',
+            borderRadius: 99,
+            fontSize: 11.5, color: 'var(--muted)',
+            fontFamily: 'var(--font-body)',
+          }}>
+            <span style={{ color: 'var(--accent)', display: 'flex' }}>{f.icon}</span>
+            {f.label}
+          </span>
+        ))}
+      </div>
+
+      {/* Footer */}
+      <div style={{
+        textAlign: 'center',
+        fontSize: 11, color: 'var(--muted)',
+        lineHeight: 1.6,
+      }}>
+        <div>Powered by Microsoft Azure &amp; Google Gemini</div>
+        <div>
+          AI features are subject to the{' '}
+          <a
+            href="https://ai.google.dev/gemini-api/terms"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'var(--accent)', textDecoration: 'none' }}
+            onMouseEnter={e => { (e.currentTarget as HTMLElement).style.textDecoration = 'underline'; }}
+            onMouseLeave={e => { (e.currentTarget as HTMLElement).style.textDecoration = 'none'; }}
+          >
+            Gemini API Terms of Service
+          </a>
+          . For internal use only.
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+// ── Redirecting state ─────────────────────────────────────────────────────────
+
+const RedirectingScreen = () => (
+  <div style={{
+    minHeight: '100vh', background: 'var(--bg)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    fontFamily: 'var(--font-body)', color: 'var(--muted)', fontSize: 13,
+    gap: 10,
+  }}>
+    <style>{`@keyframes qp-spin { to { transform: rotate(360deg); } }`}</style>
+    <div style={{
+      width: 14, height: 14, borderRadius: '50%',
+      border: '2px solid var(--border)', borderTopColor: 'var(--accent)',
+      animation: 'qp-spin 0.7s linear infinite',
+    }} />
+    Redirecting…
+  </div>
+);
+
+// ── Container components ──────────────────────────────────────────────────────
 
 const MsalLoginPage: React.FC = () => {
-    const { instance, accounts } = useMsal();
-    const isAuthenticated = useIsAuthenticated();
-    const navigate = useNavigate();
-    const location = useLocation();
+  const { instance, accounts } = useMsal();
+  const isAuthenticated = useIsAuthenticated();
+  const navigate = useNavigate();
+  const location = useLocation();
 
-    useEffect(() => {
-        console.log('MSAL Login Page - isAuthenticated:', isAuthenticated, 'accounts:', accounts);
-        if (isAuthenticated && accounts.length > 0) {
-            // Check if there's a saved location to redirect to
-            const from = location.state?.from?.pathname || '/hub';
-            const search = location.state?.from?.search || '';
-            const hash = location.state?.from?.hash || '';
-            const redirectPath = from + search + hash;
-
-            console.log('User is authenticated, navigating to:', redirectPath);
-            navigate(redirectPath, { replace: true });
-        }
-    }, [isAuthenticated, accounts, navigate, location.state]);
-
-    const handleLogin = () => {
-        console.log('Starting MSAL login redirect');
-        instance.loginRedirect(loginRequest).catch(e => {
-            console.error('MSAL login error:', e);
-        });
-    }
-
-    // Show loading state if we're in the middle of processing authentication
+  useEffect(() => {
     if (isAuthenticated && accounts.length > 0) {
-        return (
-            <div className="min-h-screen bg-slate-50 dark:bg-slate-900 flex flex-col justify-center items-center p-4 text-slate-800 dark:text-slate-200">
-                <div>Redirecting…</div>
-            </div>
-        );
+      const from = location.state?.from?.pathname || '/hub';
+      const search = location.state?.from?.search || '';
+      const hash = location.state?.from?.hash || '';
+      navigate(from + search + hash, { replace: true });
     }
+  }, [isAuthenticated, accounts, navigate, location.state]);
 
-    return <LoginUI onLogin={handleLogin} buttonText="Sign In with Microsoft Entra ID" ButtonIcon={MicrosoftIcon} />;
+  if (isAuthenticated && accounts.length > 0) return <RedirectingScreen />;
+
+  return (
+    <LoginUI
+      onLogin={() => instance.loginRedirect(loginRequest).catch(console.error)}
+      buttonText="Continue with Microsoft Entra ID"
+      buttonIcon={<MicrosoftLogo />}
+      note="You'll be redirected to Microsoft's secure sign-in page to authenticate."
+    />
+  );
 };
 
 const BypassLoginPage: React.FC = () => {
-    const { login } = useAuth();
-    const navigate = useNavigate();
-    const location = useLocation();
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
 
-    const handleLogin = () => {
-        login();
-        // Navigate using React Router instead of window.location
-        setTimeout(() => {
-            // Check if there's a saved location to redirect to
-            const from = location.state?.from?.pathname || '/hub';
-            const search = location.state?.from?.search || '';
-            const hash = location.state?.from?.hash || '';
-            const redirectPath = from + search + hash;
+  const handleLogin = () => {
+    login();
+    setTimeout(() => {
+      const from = location.state?.from?.pathname || '/hub';
+      const search = location.state?.from?.search || '';
+      const hash = location.state?.from?.hash || '';
+      navigate(from + search + hash, { replace: true });
+    }, 100);
+  };
 
-            navigate(redirectPath, { replace: true });
-        }, 100);
-    };
-
-    return <LoginUI onLogin={handleLogin} buttonText="Sign In as Developer" ButtonIcon={UserIcon} />;
-}
-
-// --- Main Exported Component (Router) ---
-
-const LoginPage: React.FC = () => {
-    return USE_MSAL_AUTH ? <MsalLoginPage /> : <BypassLoginPage />;
+  return (
+    <LoginUI
+      onLogin={handleLogin}
+      buttonText="Continue as Developer"
+      buttonIcon={<DevIcon />}
+      note="Developer sign-in bypass is active. No credentials required."
+    />
+  );
 };
+
+// ── Export ────────────────────────────────────────────────────────────────────
+
+const LoginPage: React.FC = () => USE_MSAL_AUTH ? <MsalLoginPage /> : <BypassLoginPage />;
 
 export default LoginPage;

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -5,7 +5,7 @@ import { generateMongoQuery, debugMongoQuery, analyzeQueryResult, inferSchemaRel
 import { getAzureCosmosAccounts, getDatabasesForAccount, runMongoQuery, getCollectionInfo, clearSystemCache } from '../services/dbService';
 import { getSavedQueries, saveQuery, updateSavedQuery, deleteSavedQuery } from '../services/userDataService';
 import { generateIpynbContent, downloadFile } from '../services/notebookService';
-import { QueryResultData, DbInfo, CollectionInfo, CosmosDBAccount, SelectedResource, DebuggingResult, AnalysisResult, NotebookStep, SavedQuery, SchemaRelationshipsResponse } from '../types';
+import { QueryResultData, DbInfo, CollectionInfo, CosmosDBAccount, SelectedResource, DebuggingResult, AnalysisResult, NotebookStep, SavedQuery, SchemaRelationshipsResponse, CollectionSummary } from '../types';
 import { mockECommerceDbInfo, mockCollectionInfoMap, mockFindUsersQuery, mockUserFindResult, mockSavedQueries } from '../services/mockData';
 import { getAuthErrorMessage, isAuthenticationExpiredError } from '../utils/authErrorHandler';
 import QueryDisplay from '../components/QueryDisplay';
@@ -401,15 +401,25 @@ export interface QueryGeneratorPageProps {
   email?: string;
   onLogout: () => void;
   onNavigateToExplorer: (connection: { resource: SelectedResource; dbInfo: DbInfo; accountName: string; availableDbs: DbInfo[], availableAccounts: CosmosDBAccount[] }) => void;
+  onConnectionChange?: (accountId: string | null, databaseName: string | null, accountName?: string | null, collections?: CollectionSummary[], availableAccounts?: CosmosDBAccount[], availableDbs?: DbInfo[]) => void;
   embedded?: boolean;
   preselectedAccountId?: string;
 }
 
 // --- Main Page Component ---
-const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, onLogout, onNavigateToExplorer, embedded = false, preselectedAccountId }) => {
+const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, onLogout, onNavigateToExplorer, onConnectionChange, embedded = false, preselectedAccountId }) => {
   const [userInput, setUserInput] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Restore previous connection from sessionStorage (when navigating away and back, not from Hub)
+  const [initialConnection] = useState<{ accountId: string; databaseName: string } | null>(() => {
+    if (preselectedAccountId) return null;
+    try {
+      const saved = sessionStorage.getItem('qp_connection');
+      return saved ? JSON.parse(saved) : null;
+    } catch { return null; }
+  });
 
   // State for DB resources & connection
   const [azureAccounts, setAzureAccounts] = useState<CosmosDBAccount[]>([]);
@@ -631,11 +641,13 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
   const handleDisconnect = useCallback(() => {
     setConnectedDbInfo(null);
     setConnectedResource(null);
+    sessionStorage.removeItem('qp_connection');
+    onConnectionChange?.(null, null, null, undefined);
     clearQueryState();
     setUserInput('');
     setSelectedCollections([]);
     setCollectionDetailsMap({});
-  }, [clearQueryState]);
+  }, [clearQueryState, onConnectionChange]);
 
   const handleSelectAccount = useCallback(async (accountId: string) => {
     if (selectedAccountId === accountId) {
@@ -657,8 +669,8 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
       return;
     }
 
-    // If an old database was connected from another account, disconnect it
-    if (connectedResource?.accountId !== account.id) {
+    // If a database from a different account is connected, disconnect it first
+    if (connectedResource && connectedResource.accountId !== account.id) {
       handleDisconnect();
     }
 
@@ -696,30 +708,40 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
       databaseName: dbInfo.name,
     });
     setConnectedDbInfo(dbInfo);
+    sessionStorage.setItem('qp_connection', JSON.stringify({ accountId: account.id, databaseName: dbInfo.name, accountName: account.name, collections: dbInfo.collections, availableAccounts: azureAccounts, availableDbs: accountDatabases }));
+    onConnectionChange?.(account.id, dbInfo.name, account.name, dbInfo.collections, azureAccounts, accountDatabases);
     clearQueryState();
     setIsConnectingToDb(null);
-  }, [selectedAccountId, azureAccounts, clearQueryState]);
+  }, [selectedAccountId, azureAccounts, clearQueryState, onConnectionChange]);
 
-  // Auto-select the account passed from Hub navigation
+  // Auto-select account from Hub navigation or restored session
   useEffect(() => {
-    if (preselectedAccountId && azureAccounts.length > 0 && !connectedResource && !selectedAccountId) {
-      handleSelectAccount(preselectedAccountId);
+    const targetAccountId = preselectedAccountId ?? initialConnection?.accountId;
+    if (targetAccountId && azureAccounts.length > 0 && !connectedResource && !selectedAccountId) {
+      handleSelectAccount(targetAccountId);
     }
-  }, [preselectedAccountId, azureAccounts, connectedResource, selectedAccountId, handleSelectAccount]);
+  }, [preselectedAccountId, initialConnection, azureAccounts, connectedResource, selectedAccountId, handleSelectAccount]);
 
-  // Auto-connect when the preselected account has exactly one database
+  // Auto-connect database after account is selected
   useEffect(() => {
+    const targetAccountId = preselectedAccountId ?? initialConnection?.accountId;
+    const targetDatabaseName = initialConnection?.databaseName;
     if (
-      preselectedAccountId &&
-      selectedAccountId === preselectedAccountId &&
-      accountDatabases.length === 1 &&
+      targetAccountId &&
+      selectedAccountId === targetAccountId &&
+      accountDatabases.length > 0 &&
       !connectedResource &&
       !isLoadingDatabases &&
       !isConnectingToDb
     ) {
-      handleConnectDatabase(accountDatabases[0]);
+      if (targetDatabaseName) {
+        const db = accountDatabases.find(d => d.name === targetDatabaseName) ?? accountDatabases[0];
+        handleConnectDatabase(db);
+      } else if (accountDatabases.length === 1) {
+        handleConnectDatabase(accountDatabases[0]);
+      }
     }
-  }, [preselectedAccountId, selectedAccountId, accountDatabases, connectedResource, isLoadingDatabases, isConnectingToDb, handleConnectDatabase]);
+  }, [preselectedAccountId, initialConnection, selectedAccountId, accountDatabases, connectedResource, isLoadingDatabases, isConnectingToDb, handleConnectDatabase]);
 
   const handleGenerateQuery = useCallback(async (prompt: string, collectionCtx?: CollectionInfo) => {
     if (!prompt.trim()) {

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { parseQueryForHandover } from '../utils/queryHandover';
 import { generateMongoQuery, debugMongoQuery, analyzeQueryResult, inferSchemaRelationships, evaluateWriteResult } from '../services/geminiService';
 import { getAzureCosmosAccounts, getDatabasesForAccount, runMongoQuery, getCollectionInfo, clearSystemCache } from '../services/dbService';
 import { getSavedQueries, saveQuery, updateSavedQuery, deleteSavedQuery } from '../services/userDataService';
@@ -408,7 +409,16 @@ export interface QueryGeneratorPageProps {
 
 // --- Main Page Component ---
 const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, onLogout, onNavigateToExplorer, onConnectionChange, embedded = false, preselectedAccountId }) => {
-  const [userInput, setUserInput] = useState<string>('');
+  const navigate = useNavigate();
+
+  const [userInput, setUserInput] = useState<string>(() => {
+    try {
+      const ws = JSON.parse(sessionStorage.getItem('qp_workspace') ?? 'null');
+      const conn = JSON.parse(sessionStorage.getItem('qp_connection') ?? 'null');
+      if (ws && conn && ws.accountId === conn.accountId && ws.databaseName === conn.databaseName) return ws.userInput ?? '';
+    } catch { /* ignore */ }
+    return '';
+  });
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -434,16 +444,44 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
   const [quickExploringAccountId, setQuickExploringAccountId] = useState<string | null>(null);
 
   // State for AI query generation
-  const [_queryResult, setQueryResult] = useState<QueryResultData | null>(null);
-  const [querySourceCollection, setQuerySourceCollection] = useState<string | null>(null);
-  const [editableCode, setEditableCode] = useState<string>('');
+  const [_queryResult, setQueryResult] = useState<QueryResultData | null>(() => {
+    try {
+      const ws = JSON.parse(sessionStorage.getItem('qp_workspace') ?? 'null');
+      const conn = JSON.parse(sessionStorage.getItem('qp_connection') ?? 'null');
+      if (ws && conn && ws.accountId === conn.accountId && ws.databaseName === conn.databaseName) return ws.queryResult ?? null;
+    } catch { /* ignore */ }
+    return null;
+  });
+  const [querySourceCollection, setQuerySourceCollection] = useState<string | null>(() => {
+    try {
+      const ws = JSON.parse(sessionStorage.getItem('qp_workspace') ?? 'null');
+      const conn = JSON.parse(sessionStorage.getItem('qp_connection') ?? 'null');
+      if (ws && conn && ws.accountId === conn.accountId && ws.databaseName === conn.databaseName) return ws.querySourceCollection ?? null;
+    } catch { /* ignore */ }
+    return null;
+  });
+  const [editableCode, setEditableCode] = useState<string>(() => {
+    try {
+      const ws = JSON.parse(sessionStorage.getItem('qp_workspace') ?? 'null');
+      const conn = JSON.parse(sessionStorage.getItem('qp_connection') ?? 'null');
+      if (ws && conn && ws.accountId === conn.accountId && ws.databaseName === conn.databaseName) return ws.editableCode ?? '';
+    } catch { /* ignore */ }
+    return '';
+  });
   const [codeHistory, setCodeHistory] = useState<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState<number>(-1);
   const [lastSuccessfulPrompt, setLastSuccessfulPrompt] = useState<string>('');
 
   // State for query execution
   const [isExecuting, setIsExecuting] = useState<boolean>(false);
-  const [executionResult, setExecutionResult] = useState<any | null>(null);
+  const [executionResult, setExecutionResult] = useState<any | null>(() => {
+    try {
+      const ws = JSON.parse(sessionStorage.getItem('qp_workspace') ?? 'null');
+      const conn = JSON.parse(sessionStorage.getItem('qp_connection') ?? 'null');
+      if (ws && conn && ws.accountId === conn.accountId && ws.databaseName === conn.databaseName) return ws.executionResult ?? null;
+    } catch { /* ignore */ }
+    return null;
+  });
   const [executionError, setExecutionError] = useState<string | null>(null);
 
   // State for intermediate context (multi-step queries)
@@ -525,6 +563,50 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     if (!connectedResource) return '';
     return azureAccounts.find(acc => acc.id === connectedResource.accountId)?.name ?? 'Unknown Account';
   }, [connectedResource, azureAccounts]);
+
+  // Query handover — detect transferable find() queries for "Open in Explorer"
+  const handover = useMemo(
+    () => editableCode && !_queryResult?.is_write_action ? parseQueryForHandover(editableCode) : null,
+    [editableCode, _queryResult]
+  );
+
+  const handleOpenInExplorer = useCallback(() => {
+    if (!handover || !connectedResource || !connectedDbInfo) return;
+    navigate(
+      `/data-explorer/${encodeURIComponent(connectedResource.accountId)}/${encodeURIComponent(connectedResource.databaseName)}`,
+      {
+        state: {
+          dbInfo: connectedDbInfo,
+          accountName: connectedAccountName,
+          availableDbs: accountDatabases,
+          availableAccounts: azureAccounts,
+          initialCollection: handover.collection,
+          initialFilters: handover.filters,
+        },
+      }
+    );
+  }, [handover, connectedResource, connectedDbInfo, connectedAccountName, accountDatabases, azureAccounts, navigate]);
+
+  // Persist workspace state so it survives sidebar tab switches
+  useEffect(() => {
+    if (!connectedResource) return;
+    try {
+      const payload: Record<string, unknown> = {
+        accountId: connectedResource.accountId,
+        databaseName: connectedResource.databaseName,
+        userInput,
+        editableCode,
+        querySourceCollection,
+        queryResult: _queryResult,
+      };
+      // Only persist executionResult if it's under 1 MB to avoid quota errors
+      if (executionResult !== null) {
+        const resultStr = JSON.stringify(executionResult);
+        if (resultStr.length < 1_000_000) payload.executionResult = executionResult;
+      }
+      sessionStorage.setItem('qp_workspace', JSON.stringify(payload));
+    } catch { /* ignore */ }
+  }, [userInput, editableCode, querySourceCollection, connectedResource, _queryResult, executionResult]);
 
   const [isWaitingForAuth, setIsWaitingForAuth] = useState<boolean>(false);
 
@@ -636,6 +718,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     setCurrentQueryContextSource(null);
     setRelationships(null); // Clear relationships
     setRelationshipError(null); // Clear relationship error
+    sessionStorage.removeItem('qp_workspace');
   }, []);
 
   const handleDisconnect = useCallback(() => {
@@ -695,7 +778,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     }
   }, [selectedAccountId, connectedResource, azureAccounts, handleDisconnect]);
 
-  const handleConnectDatabase = useCallback(async (dbInfo: DbInfo) => {
+  const handleConnectDatabase = useCallback(async (dbInfo: DbInfo, preserveWorkspace = false) => {
     const account = azureAccounts.find(acc => acc.id === selectedAccountId);
     if (!account) return;
 
@@ -708,7 +791,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     setConnectedDbInfo(dbInfo);
     sessionStorage.setItem('qp_connection', JSON.stringify({ accountId: account.id, databaseName: dbInfo.name, accountName: account.name, collections: dbInfo.collections, availableAccounts: azureAccounts, availableDbs: accountDatabases }));
     onConnectionChange?.(account.id, dbInfo.name, account.name, dbInfo.collections, azureAccounts, accountDatabases);
-    clearQueryState();
+    if (!preserveWorkspace) clearQueryState();
     setIsConnectingToDb(null);
   }, [selectedAccountId, azureAccounts, clearQueryState, onConnectionChange]);
 
@@ -741,9 +824,9 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     ) {
       if (targetDatabaseName) {
         const db = accountDatabases.find(d => d.name === targetDatabaseName) ?? accountDatabases[0];
-        handleConnectDatabase(db);
+        handleConnectDatabase(db, true);
       } else if (accountDatabases.length === 1) {
-        handleConnectDatabase(accountDatabases[0]);
+        handleConnectDatabase(accountDatabases[0], true);
       }
     }
   }, [preselectedAccountId, initialConnection, selectedAccountId, accountDatabases, connectedResource, isLoadingDatabases, isConnectingToDb, handleConnectDatabase]);
@@ -2389,7 +2472,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
           {(!isLoading && !error && !isDemoModeForResultsStep && !isDemoModeForDebugStep && !isDemoModeForContextActiveStep && !isDemoModeForRunStep && !isDemoModeForSaveStep) && (
             editableCode ? (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-                <QueryDisplay code={editableCode} onCodeChange={setEditableCode} onRunQuery={handleRunQuery} onSaveQuery={handleOpenSaveDialog} isExecuting={isExecuting} historyCount={codeHistory.length} historyIndex={historyIndex} onNavigateHistory={handleNavigateHistory} />
+                <QueryDisplay code={editableCode} onCodeChange={setEditableCode} onRunQuery={handleRunQuery} onSaveQuery={handleOpenSaveDialog} isExecuting={isExecuting} historyCount={codeHistory.length} historyIndex={historyIndex} onNavigateHistory={handleNavigateHistory} isTransferable={!!handover} onOpenInExplorer={handleOpenInExplorer} />
                 <QueryResult isExecuting={isExecuting} executionError={executionError} executionResult={executionResult} onDebug={handleDebugQuery} isDebugging={isDebugging} debuggingResult={debuggingResult} debugError={debugError} sourceCollection={querySourceCollection} onSetIntermediateContext={handleSetIntermediateContext} intermediateContext={intermediateContext} onAnalyze={handleAnalyzeQuery} isAnalyzing={isAnalyzing} analysisResult={analysisResult} analysisError={analysisError} onEvaluateWrite={handleEvaluateWrite} isEvaluatingWrite={isEvaluatingWrite} writeEvaluationResult={writeEvaluationResult} writeEvaluationError={writeEvaluationError} />
               </div>
             ) : (

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import { useSearchParams } from 'react-router-dom';
 import { generateMongoQuery, debugMongoQuery, analyzeQueryResult, inferSchemaRelationships, evaluateWriteResult } from '../services/geminiService';
 import { getAzureCosmosAccounts, getDatabasesForAccount, runMongoQuery, getCollectionInfo, clearSystemCache } from '../services/dbService';
 import { getSavedQueries, saveQuery, updateSavedQuery, deleteSavedQuery } from '../services/userDataService';
@@ -194,21 +195,28 @@ const NotebookStepCard: React.FC<NotebookStepCardProps> = ({ step, index, onRemo
 
   if (step.type === 'note') {
     return (
-      <div className="bg-slate-800/70 p-4 rounded-lg border border-slate-700 space-y-3 group">
-        <div className="flex justify-between items-center mb-2">
-          <h4 className="font-bold text-slate-200">Note</h4>
-          <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+      <div className="qa-card" style={{ padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <span style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)', fontWeight: 500 }}>Note</span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
             {step.isEditing ? (
-              <button onClick={handleSave} className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-blue-600 text-white hover:bg-blue-700" title="Save changes">
-                <CheckIcon className="w-3 h-3" /> Save
+              <button onClick={handleSave} className="qa-btn" style={{ fontSize: 11, padding: '3px 8px' }}>
+                <CheckIcon className="w-3 h-3" style={{ width: 12, height: 12 }} /> Save
               </button>
             ) : (
-              <button onClick={() => onSetEditing(step.id, true)} className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-slate-600 text-slate-200 hover:bg-slate-500" title="Edit note">
-                <EditIcon className="w-3 h-3" /> Edit
+              <button onClick={() => onSetEditing(step.id, true)} className="qa-btn" style={{ fontSize: 11, padding: '3px 8px' }}>
+                <EditIcon className="w-3 h-3" style={{ width: 12, height: 12 }} /> Edit
               </button>
             )}
-            <button onClick={() => onRemove(step.id)} className="p-1 rounded-full text-slate-500 hover:bg-red-900/50 hover:text-red-400" aria-label="Remove note" title="Remove step">
-              <TrashIcon className="w-4 h-4" />
+            <button
+              onClick={() => onRemove(step.id)}
+              aria-label="Remove note"
+              style={{
+                background: 'none', border: 'none', cursor: 'pointer', padding: 4, borderRadius: 4,
+                color: 'var(--muted)', display: 'flex',
+              }}
+            >
+              <TrashIcon className="w-4 h-4" style={{ width: 14, height: 14 }} />
             </button>
           </div>
         </div>
@@ -216,13 +224,21 @@ const NotebookStepCard: React.FC<NotebookStepCardProps> = ({ step, index, onRemo
           <textarea
             value={step.prompt}
             onChange={(e) => onUpdate(step.id, e.target.value)}
-            className="w-full h-28 bg-black/50 text-slate-200 p-2 rounded-md font-sans text-sm border border-slate-600 focus:border-blue-500 focus:ring-blue-500"
+            style={{
+              width: '100%', height: 96, padding: '8px 10px', background: 'var(--soft)',
+              color: 'var(--fg)', border: '1px solid var(--border)', borderRadius: 6,
+              fontFamily: 'var(--font-body)', fontSize: 12.5, resize: 'vertical', outline: 'none',
+              boxSizing: 'border-box',
+            }}
             placeholder="Enter your note here... (Markdown is supported on export)"
             autoFocus
           />
         ) : (
-          <div className="text-sm text-slate-300 whitespace-pre-wrap p-2 rounded-md bg-black/20 min-h-[4rem]">
-            {step.prompt || <span className="text-slate-500">Empty note</span>}
+          <div style={{
+            fontSize: 12.5, color: 'var(--fg)', whiteSpace: 'pre-wrap', lineHeight: 1.55,
+            padding: '6px 8px', background: 'var(--soft)', borderRadius: 5, minHeight: 48,
+          }}>
+            {step.prompt || <span style={{ color: 'var(--muted)', fontStyle: 'italic' }}>Empty note</span>}
           </div>
         )}
       </div>
@@ -231,29 +247,43 @@ const NotebookStepCard: React.FC<NotebookStepCardProps> = ({ step, index, onRemo
 
   // Render Query Step
   return (
-    <div className="bg-slate-800/70 p-4 rounded-lg border border-slate-700 space-y-3 relative group">
-      <div className="flex justify-between items-start">
-        <h4 className="font-bold text-slate-200">Step {index + 1}</h4>
+    <div className="qa-card" style={{ padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)', fontWeight: 500 }}>
+          Step {index + 1}
+        </span>
         <button
           onClick={() => onRemove(step.id)}
-          className="p-1 rounded-full text-slate-500 hover:bg-red-900/50 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity"
           aria-label="Remove step"
-          title="Remove step"
+          style={{
+            background: 'none', border: 'none', cursor: 'pointer', padding: 4, borderRadius: 4,
+            color: 'var(--muted)', display: 'flex',
+          }}
         >
-          <TrashIcon className="w-4 h-4" />
+          <TrashIcon className="w-4 h-4" style={{ width: 14, height: 14 }} />
         </button>
       </div>
       {step.contextSource && (
-        <div className="text-xs text-blue-300 bg-blue-900/50 border border-blue-500/30 px-2 py-1 rounded-md">
-          <strong>Context Used:</strong> Output from <em>{step.contextSource}</em>
+        <div style={{
+          fontSize: 11, color: 'var(--accent)', background: 'var(--accent-soft)',
+          padding: '4px 8px', borderRadius: 5,
+        }}>
+          Context: output from <em>{step.contextSource}</em>
         </div>
       )}
-      <blockquote className="border-l-4 border-blue-400 pl-3 text-sm italic text-slate-400">
+      <blockquote style={{
+        borderLeft: '2px solid var(--accent)', paddingLeft: 10, margin: 0,
+        fontSize: 12.5, fontStyle: 'italic', color: 'var(--muted)', lineHeight: 1.5,
+      }}>
         {step.prompt}
       </blockquote>
       <div>
-        <p className="text-xs font-semibold uppercase text-slate-500 mb-1">Query</p>
-        <pre className="bg-black/50 p-2 rounded-md text-xs font-mono text-cyan-300 overflow-x-auto">
+        <div style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)', marginBottom: 5 }}>Query</div>
+        <pre style={{
+          margin: 0, padding: '8px 10px', background: '#0f0e0d', color: '#c8c4bc',
+          fontFamily: 'var(--font-mono)', fontSize: 11, lineHeight: 1.6, borderRadius: 6,
+          overflowX: 'auto',
+        }}>
           <code>{step.query}</code>
         </pre>
       </div>
@@ -276,32 +306,67 @@ const NotebookPanel: React.FC<NotebookPanelProps> = ({ steps, onClose, onExport,
   <>
     <div
       onClick={onClose}
-      className="fixed inset-0 bg-black bg-opacity-60 z-40 animate-fade-in-fast"
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.35)', zIndex: 40 }}
       aria-hidden="true"
-    ></div>
-    <aside id="tutorial-notebook-panel" className="fixed top-0 right-0 h-full w-full md:w-[450px] bg-slate-900 shadow-2xl z-50 flex flex-col animate-slide-in-drawer">
-      <header className="flex items-center justify-between p-4 border-b border-slate-700 flex-shrink-0">
-        <h3 className="text-lg font-semibold text-white flex items-center gap-3">
-          <NotebookIcon className="w-5 h-5 text-blue-400" />
-          Query Notebook
-        </h3>
+    />
+    <aside
+      id="tutorial-notebook-panel"
+      className="qp-drawer"
+      style={{
+        position: 'fixed', top: 0, right: 0, height: '100%', width: 440,
+        maxWidth: '100vw', background: 'var(--panel)', borderLeft: '1px solid var(--border)',
+        zIndex: 50, display: 'flex', flexDirection: 'column',
+        fontFamily: 'var(--font-body)',
+      }}
+    >
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px',
+        borderBottom: '1px solid var(--border)', flexShrink: 0,
+      }}>
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.4">
+          <rect x="2" y="1" width="12" height="14" rx="2"/>
+          <path d="M5 5h6M5 8h6M5 11h4"/>
+        </svg>
+        <span style={{ fontSize: 13.5, fontWeight: 500, color: 'var(--fg)' }}>Query Notebook</span>
         <button
           onClick={onClose}
-          className="p-1.5 rounded-full text-slate-400 hover:bg-slate-700 hover:text-white transition-colors"
           aria-label="Close notebook panel"
-          title="Close notebook"
+          style={{
+            marginLeft: 'auto', background: 'none', border: 'none', cursor: 'pointer',
+            color: 'var(--muted)', display: 'flex', padding: 4, borderRadius: 5,
+          }}
         >
-          <XIcon className="w-5 h-5" />
+          <XIcon className="w-5 h-5" style={{ width: 16, height: 16 }} />
         </button>
-      </header>
-      <div className="flex-shrink-0 p-4 border-b border-slate-700 flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <button onClick={onAddNote} className="flex items-center gap-2 px-3 py-1.5 border border-slate-600 text-sm font-medium rounded-md text-slate-300 bg-slate-800 hover:bg-slate-700 transition-colors" title="Add a new markdown note"><PlusCircleIcon className="w-4 h-4" />Add Note</button>
-          <button onClick={onClear} disabled={steps.length === 0} className="flex items-center gap-2 px-3 py-1.5 border border-slate-600 text-sm font-medium rounded-md text-slate-300 bg-slate-800 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors" title="Clear all steps"><TrashIcon className="w-4 h-4" />Clear All</button>
-        </div>
-        <button onClick={onExport} disabled={steps.length === 0} className="flex items-center gap-2 px-4 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors" title="Export as .ipynb notebook"><DownloadIcon className="w-4 h-4" />Export .ipynb</button>
       </div>
-      <div className="flex-grow overflow-auto p-4 space-y-4">
+
+      {/* Toolbar */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 6, padding: '10px 16px',
+        borderBottom: '1px solid var(--border)', flexShrink: 0,
+      }}>
+        <button onClick={onAddNote} className="qa-btn" style={{ fontSize: 12 }}>
+          <PlusCircleIcon className="w-4 h-4" style={{ width: 14, height: 14 }} />
+          Add note
+        </button>
+        <button onClick={onClear} disabled={steps.length === 0} className="qa-btn" style={{ fontSize: 12, opacity: steps.length === 0 ? 0.4 : 1 }}>
+          <TrashIcon className="w-4 h-4" style={{ width: 14, height: 14 }} />
+          Clear all
+        </button>
+        <button
+          onClick={onExport}
+          disabled={steps.length === 0}
+          className="qa-btn primary"
+          style={{ fontSize: 12, marginLeft: 'auto', opacity: steps.length === 0 ? 0.4 : 1 }}
+        >
+          <DownloadIcon className="w-4 h-4" style={{ width: 14, height: 14 }} />
+          Export .ipynb
+        </button>
+      </div>
+
+      {/* Steps */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 10 }}>
         {steps.length > 0 ? (
           steps.map((step, index) => (
             <NotebookStepCard
@@ -314,9 +379,16 @@ const NotebookPanel: React.FC<NotebookPanelProps> = ({ steps, onClose, onExport,
             />
           ))
         ) : (
-          <div className="text-center text-slate-500 h-full flex flex-col items-center justify-center">
-            <p className="font-semibold">No steps recorded yet.</p>
-            <p className="text-sm">Run a query or add a note to begin.</p>
+          <div style={{
+            flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center',
+            justifyContent: 'center', gap: 6, color: 'var(--muted)',
+          }}>
+            <svg width="32" height="32" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1" opacity="0.4">
+              <rect x="2" y="1" width="12" height="14" rx="2"/>
+              <path d="M5 5h6M5 8h6M5 11h4"/>
+            </svg>
+            <p style={{ fontSize: 13, fontWeight: 500, margin: 0 }}>No steps yet</p>
+            <p style={{ fontSize: 12, margin: 0 }}>Run a query or add a note to begin.</p>
           </div>
         )}
       </div>
@@ -419,6 +491,15 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
   const [isLoadingSavedQueries, setIsLoadingSavedQueries] = useState<boolean>(false);
   const [isSavedQueriesPanelOpen, setIsSavedQueriesPanelOpen] = useState<boolean>(false);
+
+  // Open saved queries panel from sidebar URL param
+  const [searchParams, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    if (searchParams.get('panel') === 'saved') {
+      setIsSavedQueriesPanelOpen(true);
+      setSearchParams({}, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
   const [saveDialogState, setSaveDialogState] = useState<{ isOpen: boolean; data?: Partial<SavedQuery> & { prompt: string; code: string } }>({ isOpen: false });
   const [shareDialogState, setShareDialogState] = useState<{ isOpen: boolean; query?: SavedQuery }>({ isOpen: false });
   const [isSavingQuery, setIsSavingQuery] = useState(false);
@@ -2210,7 +2291,10 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
               {isLoading ? 'Generating…' : isPromptUnchanged ? 'Generated ✓' : 'Generate query'}
             </button>
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>Iterations:</span>
+              <span
+                style={{ fontSize: 11.5, color: 'var(--muted)', cursor: 'default' }}
+                title="More iterations let the AI agent self-correct by re-generating and re-testing the query when it detects errors. Higher values improve accuracy for complex queries but take longer. Max: 10."
+              >Iterations:</span>
               <input
                 id="max-iterations-slider"
                 type="range" min={1} max={10} step={1}
@@ -2219,6 +2303,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                 disabled={isLoading || isQuerySectionDisabled}
                 className="accent-blue-600 disabled:opacity-40 cursor-pointer"
                 style={{ width: 72, accentColor: 'var(--accent)' }}
+                title={`Agent iterations: ${maxIterations} — more iterations allow self-correction but take longer`}
               />
               <span style={{ fontSize: 11.5, color: 'var(--accent)', fontFamily: 'var(--font-mono)', minWidth: 14 }}>{maxIterations}</span>
             </div>

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -700,8 +700,6 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     if (!account) return;
 
     setIsConnectingToDb(dbInfo.name);
-    // Simulate connection delay for better UX
-    await new Promise(resolve => setTimeout(resolve, 800));
 
     setConnectedResource({
       accountId: account.id,
@@ -714,13 +712,20 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     setIsConnectingToDb(null);
   }, [selectedAccountId, azureAccounts, clearQueryState, onConnectionChange]);
 
-  // Auto-select account from Hub navigation or restored session
+  // Auto-select account from Hub navigation, restored session, or chip-based account switch
   useEffect(() => {
     const targetAccountId = preselectedAccountId ?? initialConnection?.accountId;
-    if (targetAccountId && azureAccounts.length > 0 && !connectedResource && !selectedAccountId) {
+    if (!targetAccountId || azureAccounts.length === 0) return;
+    const switchingToDifferentAccount =
+      preselectedAccountId &&
+      connectedResource &&
+      connectedResource.accountId !== preselectedAccountId &&
+      !isLoadingDatabases &&
+      !isConnectingToDb;
+    if ((!connectedResource && !selectedAccountId) || switchingToDifferentAccount) {
       handleSelectAccount(targetAccountId);
     }
-  }, [preselectedAccountId, initialConnection, azureAccounts, connectedResource, selectedAccountId, handleSelectAccount]);
+  }, [preselectedAccountId, initialConnection, azureAccounts, connectedResource, selectedAccountId, isLoadingDatabases, isConnectingToDb, handleSelectAccount]);
 
   // Auto-connect database after account is selected
   useEffect(() => {

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -330,10 +330,11 @@ export interface QueryGeneratorPageProps {
   onLogout: () => void;
   onNavigateToExplorer: (connection: { resource: SelectedResource; dbInfo: DbInfo; accountName: string; availableDbs: DbInfo[], availableAccounts: CosmosDBAccount[] }) => void;
   embedded?: boolean;
+  preselectedAccountId?: string;
 }
 
 // --- Main Page Component ---
-const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, onLogout, onNavigateToExplorer, embedded = false }) => {
+const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, onLogout, onNavigateToExplorer, embedded = false, preselectedAccountId }) => {
   const [userInput, setUserInput] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -351,7 +352,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
   const [quickExploringAccountId, setQuickExploringAccountId] = useState<string | null>(null);
 
   // State for AI query generation
-  const [queryResult, setQueryResult] = useState<QueryResultData | null>(null);
+  const [_queryResult, setQueryResult] = useState<QueryResultData | null>(null);
   const [querySourceCollection, setQuerySourceCollection] = useState<string | null>(null);
   const [editableCode, setEditableCode] = useState<string>('');
   const [codeHistory, setCodeHistory] = useState<string[]>([]);
@@ -393,7 +394,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
   const [collectionDetailsMap, setCollectionDetailsMap] = useState<Record<string, CollectionInfo>>({});
   const [loadingCollections, setLoadingCollections] = useState<Record<string, boolean>>({});
   const [expandedCollectionSchemas, setExpandedCollectionSchemas] = useState<Record<string, boolean>>({}); // Track open/close state for stacking
-  const [collectionInfoError, setCollectionInfoError] = useState<string | null>(null);
+  const [collectionInfoError, _setCollectionInfoError] = useState<string | null>(null);
 
   // State for relationship inference
   const [relationships, setRelationships] = useState<SchemaRelationshipsResponse | null>(null);
@@ -424,6 +425,9 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
 
   // State for Keyboard Shortcuts
   const [isShortcutCheatsheetOpen, setIsShortcutCheatsheetOpen] = useState(false);
+
+  // State for DB switcher dropdown (embedded workspace)
+  const [isDbSwitcherOpen, setIsDbSwitcherOpen] = useState(false);
 
 
   const connectedAccountName = useMemo(() => {
@@ -614,6 +618,27 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     clearQueryState();
     setIsConnectingToDb(null);
   }, [selectedAccountId, azureAccounts, clearQueryState]);
+
+  // Auto-select the account passed from Hub navigation
+  useEffect(() => {
+    if (preselectedAccountId && azureAccounts.length > 0 && !connectedResource && !selectedAccountId) {
+      handleSelectAccount(preselectedAccountId);
+    }
+  }, [preselectedAccountId, azureAccounts, connectedResource, selectedAccountId, handleSelectAccount]);
+
+  // Auto-connect when the preselected account has exactly one database
+  useEffect(() => {
+    if (
+      preselectedAccountId &&
+      selectedAccountId === preselectedAccountId &&
+      accountDatabases.length === 1 &&
+      !connectedResource &&
+      !isLoadingDatabases &&
+      !isConnectingToDb
+    ) {
+      handleConnectDatabase(accountDatabases[0]);
+    }
+  }, [preselectedAccountId, selectedAccountId, accountDatabases, connectedResource, isLoadingDatabases, isConnectingToDb, handleConnectDatabase]);
 
   const handleGenerateQuery = useCallback(async (prompt: string, collectionCtx?: CollectionInfo) => {
     if (!prompt.trim()) {
@@ -1264,7 +1289,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
 
   const innerContent = (
     <>
-      <div className="max-w-4xl mx-auto">
+      <div style={{ maxWidth: 860, margin: '0 auto' }}>
 
         {!embedded && (
           <HeaderUI
@@ -1282,20 +1307,20 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
 
         <main className="space-y-8">
           {/* Connection Manager */}
-          <div id="tutorial-account-section" className="bg-white dark:bg-slate-800 rounded-xl shadow-md p-6">
+          <div id="tutorial-account-section" style={{ background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)', padding: 24, marginBottom: 16 }}>
             {isConnectedForRender && dbInfoForRender ? (
               <div className="animate-fade-in">
                 <div className="flex justify-between items-start">
                   <div>
-                    <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">Database Information</h2>
-                    <p className="text-blue-600 dark:text-blue-400 font-mono text-sm">
+                    <h2 style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 18, color: 'var(--fg)' }}>Database Information</h2>
+                    <p style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--muted)', marginTop: 2 }}>
                       Connected to: {accountNameForRender} / <span className="font-bold">{dbInfoForRender.name}</span>
                     </p>
                   </div>
                   <div className="flex items-center gap-2">
                     <button
                       onClick={() => connectedDbInfo && connectedResource && handleLaunchExplorer(connectedDbInfo, azureAccounts.find(a => a.id === connectedResource.accountId) || azureAccounts[0])}
-                      className="px-3 py-1.5 border border-slate-300 dark:border-slate-600 text-sm font-medium rounded-md text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors flex items-center gap-2"
+                      className="qa-btn"
                       title="Open in Data Explorer"
                     >
                       <DataGridIcon className="w-4 h-4" />
@@ -1303,7 +1328,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                     </button>
                     <button
                       onClick={handleDisconnect}
-                      className="px-3 py-1.5 border border-red-300 text-sm font-medium rounded-md text-red-600 hover:bg-red-50 hover:text-red-700 dark:border-red-500/50 dark:text-red-400 dark:hover:bg-red-900/40 transition-colors"
+                      style={{ padding: '5px 10px', border: '1px solid color-mix(in oklch, var(--status-err) 30%, var(--border))', borderRadius: 'var(--radius-sm)', background: 'none', color: 'var(--status-err)', fontSize: 12.5, fontWeight: 500, cursor: 'pointer', fontFamily: 'var(--font-body)' }}
                       title="Disconnect from database"
                     >
                       Disconnect
@@ -1311,16 +1336,16 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                   </div>
                 </div>
                 <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
-                  <div className="bg-slate-100 dark:bg-slate-700/50 p-3 rounded-lg">
-                    <p className="text-slate-500 dark:text-slate-400">Total Documents</p>
-                    <p className="text-slate-900 dark:text-slate-100 font-semibold text-lg">{dbInfoForRender.totalDocuments.toLocaleString()}</p>
+                  <div style={{ background: 'var(--soft)', padding: 12, borderRadius: 8 }}>
+                    <p style={{ color: 'var(--muted)', fontSize: 12 }}>Total Documents</p>
+                    <p style={{ color: 'var(--fg)', fontWeight: 600, fontSize: 18 }}>{dbInfoForRender.totalDocuments.toLocaleString()}</p>
                   </div>
-                  <div className="bg-slate-100 dark:bg-slate-700/50 p-3 rounded-lg">
-                    <p className="text-slate-500 dark:text-slate-400">Database Size</p>
-                    <p className="text-slate-900 dark:text-slate-100 font-semibold text-lg">{dbInfoForRender.size ?? 'N/A'}</p>
+                  <div style={{ background: 'var(--soft)', padding: 12, borderRadius: 8 }}>
+                    <p style={{ color: 'var(--muted)', fontSize: 12 }}>Database Size</p>
+                    <p style={{ color: 'var(--fg)', fontWeight: 600, fontSize: 18 }}>{dbInfoForRender.size ?? 'N/A'}</p>
                   </div>
-                  <div className="bg-slate-100 dark:bg-slate-700/50 p-3 rounded-lg col-span-1 md:col-span-3">
-                    <p className="text-slate-600 dark:text-slate-300 mb-2 flex items-center gap-2 font-medium">
+                  <div style={{ background: 'var(--soft)', padding: 12, borderRadius: 8 }} className="col-span-1 md:col-span-3">
+                    <p style={{ color: 'var(--fg)', fontSize: 13, fontWeight: 500 }} className="mb-2 flex items-center gap-2">
                       <ServerIcon className="w-4 h-4" /> Collections
                       <span className="text-xs font-normal text-slate-400 dark:text-slate-500">(Hold Ctrl/Cmd to select multiple)</span>
                     </p>
@@ -1329,7 +1354,17 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                         <button
                           key={col.name}
                           onClick={(e) => handleCollectionClick(col.name, e)}
-                          className={`text-xs font-mono px-3 py-1 rounded-full transition-all duration-200 ${selectedCollectionsForRender.includes(col.name) ? 'bg-blue-500 text-white font-bold ring-2 ring-blue-300 dark:bg-blue-600 dark:ring-blue-500' : 'bg-slate-200 text-slate-700 hover:bg-slate-300 dark:bg-slate-700 dark:text-slate-200 dark:hover:bg-slate-600'}`}
+                          style={{
+                            fontFamily: 'var(--font-mono)',
+                            fontSize: 11,
+                            padding: '3px 10px',
+                            borderRadius: 99,
+                            border: selectedCollectionsForRender.includes(col.name) ? '1.5px solid var(--accent)' : '1px solid var(--border)',
+                            background: selectedCollectionsForRender.includes(col.name) ? 'var(--accent)' : 'var(--soft)',
+                            color: selectedCollectionsForRender.includes(col.name) ? '#fff' : 'var(--fg)',
+                            cursor: 'pointer',
+                            transition: 'all 0.1s',
+                          }}
                           title={`View details for the ${col.name} collection`}
                         >
                           {col.name}
@@ -1341,7 +1376,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
 
                 {/* Multi-Collection Analysis Panel */}
                 {selectedCollectionsForRender.length > 1 && (
-                  <div className="mt-6 bg-slate-50 dark:bg-slate-700/30 rounded-lg p-4 border border-slate-200 dark:border-slate-700 animate-fade-in">
+                  <div style={{ marginTop: 20, background: 'var(--soft)', borderRadius: 'var(--radius-md)', padding: 16, border: '1px solid var(--border)' }} className="animate-fade-in">
                     <div className="flex items-center justify-between mb-4">
                       <h3 className="text-md font-bold text-slate-800 dark:text-slate-200 flex items-center gap-2">
                         <span className="text-blue-500">🔗</span> Schema Connections
@@ -1395,10 +1430,10 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                       const isExpanded = expandedCollectionSchemas[colName] || (selectedCollectionsForRender.length === 1); // Default expanded if single
 
                       return (
-                        <div key={colName} className="bg-slate-50 dark:bg-slate-800/30 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
+                        <div key={colName} style={{ background: 'var(--bg)', borderRadius: 'var(--radius-md)', border: '1px solid var(--border)', overflow: 'hidden' }}>
                           <button
                             onClick={() => setExpandedCollectionSchemas(prev => ({ ...prev, [colName]: !prev[colName] }))}
-                            className="w-full flex items-center justify-between p-3 text-left hover:bg-slate-100 dark:hover:bg-slate-700/50 transition-colors"
+                            style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 14px', textAlign: 'left', background: 'none', border: 'none', cursor: 'pointer', color: 'var(--fg)', fontFamily: 'var(--font-body)' }}
                           >
                             <div className="flex items-center gap-2">
                               <ChevronDownIcon className={`w-5 h-5 text-slate-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
@@ -1435,7 +1470,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
               </div>
             ) : (
               <div>
-                <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100 flex items-center gap-2"><DatabaseIcon className="w-6 h-6 text-blue-500" /> Select a Database to Connect</h2>
+                <h2 style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 18, color: 'var(--fg)', display: 'flex', alignItems: 'center', gap: 8, marginBottom: 0 }}><DatabaseIcon className="w-6 h-6 text-blue-500" /> Select a Database to Connect</h2>
                 {dbError && !isLoadingAccounts && !isLoadingDatabases && (
                   <p className="text-red-600 bg-red-50 border border-red-200 text-sm mt-4 p-3 rounded-md dark:bg-red-900/30 dark:border-red-500/50 dark:text-red-300">{dbError}</p>
                 )}
@@ -1456,12 +1491,12 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                 ) : (
                   <div className="mt-4 space-y-4">
                     {azureAccounts.map(account => (
-                      <div key={account.id} className="bg-slate-50 dark:bg-slate-800/50 p-4 rounded-lg border dark:border-slate-700">
+                      <div key={account.id} style={{ background: 'var(--soft)', padding: 14, borderRadius: 10, border: '1px solid var(--border)' }}>
                         <div className="flex items-center justify-between gap-2">
                           <button
                             onClick={() => handleSelectAccount(account.id)}
                             disabled={isLoadingDatabases}
-                            className="flex-grow text-left font-bold text-slate-800 dark:text-slate-100 flex items-center gap-2 disabled:cursor-not-allowed disabled:opacity-60 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                            style={{ background: 'none', border: 'none', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 8, fontWeight: 500, fontSize: 14, color: 'var(--fg)', flex: 1, textAlign: 'left' }}
                             title={`Load databases for ${account.name}`}
                           >
                             <CloudIcon className="w-5 h-5 text-slate-500" />
@@ -1473,7 +1508,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                           <button
                             onClick={(e) => { e.stopPropagation(); handleQuickExploreAccount(account); }}
                             disabled={quickExploringAccountId !== null}
-                            className={`flex items-center gap-1.5 px-2 py-1.5 text-xs font-medium text-blue-600 dark:text-blue-400 bg-white dark:bg-slate-700 hover:bg-blue-50 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-md transition-colors shadow-sm ml-2 ${quickExploringAccountId !== null && quickExploringAccountId !== account.id ? 'opacity-50' : ''}`}
+                            className="qa-btn"
                             title={`Quickly open Data Explorer for ${account.name} (first database)`}
                           >
                             {quickExploringAccountId === account.id ? (
@@ -1500,7 +1535,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                                     type="button"
                                     onClick={() => handleConnectDatabase(db)}
                                     disabled={isConnectingToDb !== null}
-                                    className={`px-4 py-2 border border-blue-600 dark:border-blue-500 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-50 dark:focus:ring-offset-slate-800 focus:ring-blue-500 transition-colors flex items-center gap-2 ${isConnectingToDb !== null && isConnectingToDb !== db.name ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                    className="qa-btn primary"
                                     title={`Connect to the ${db.name} database`}
                                   >
                                     {isConnectingToDb === db.name ? (
@@ -1528,14 +1563,14 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
           </div>
 
           {/* Query Generator */}
-          <div id="tutorial-prompt-section" className={`bg-white dark:bg-slate-800 rounded-xl shadow-md p-6 transition-opacity duration-500 ${isQuerySectionDisabled ? 'opacity-40 pointer-events-none' : 'opacity-100'}`}>
+          <div id="tutorial-prompt-section" style={{ background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)', padding: 24, opacity: isQuerySectionDisabled ? 0.4 : 1, pointerEvents: isQuerySectionDisabled ? 'none' : 'auto', transition: 'opacity 0.3s' }}>
             {showContextBanner && contextForRender && (
-              <div id="tutorial-context-banner" className="relative bg-blue-50 dark:bg-slate-800/60 border border-blue-200 dark:border-blue-500/30 rounded-lg p-4 mb-6 animate-fade-in">
+              <div id="tutorial-context-banner" style={{ position: 'relative', background: 'var(--accent-soft)', border: '1px solid color-mix(in oklch, var(--accent) 25%, var(--border))', borderRadius: 'var(--radius-md)', padding: 16, marginBottom: 24 }} className="animate-fade-in">
                 <div className="flex items-start justify-between">
                   <div className="flex items-center gap-3">
                     <PinIcon className="w-6 h-6 text-blue-500 flex-shrink-0" />
                     <div>
-                      <h4 className="font-bold text-blue-800 dark:text-blue-300">Query Context Active</h4>
+                      <h4 style={{ fontWeight: 600, fontSize: 13.5, color: 'var(--accent)' }}>Query Context Active</h4>
                       <p className="text-sm text-blue-700 dark:text-blue-200/80">
                         Using results from <strong className="font-mono">{contextForRender.source}</strong> ({Array.isArray(contextForRender.data) ? contextForRender.data.length : 1} items) as context for the next query.
                       </p>
@@ -1550,7 +1585,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
             )}
 
             <div className="space-y-4">
-              <label htmlFor="userInput" className="block text-lg font-medium text-slate-700 dark:text-slate-300">
+              <label htmlFor="userInput" style={{ display: 'block', fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 14, color: 'var(--muted)', marginBottom: 8 }}>
                 Enter your command:
               </label>
               <textarea
@@ -1566,7 +1601,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                   }
                 }}
                 placeholder={isQuerySectionDisabled ? "Connect to a database to begin..." : (selectedCollections.length > 0 ? `Querying ${selectedCollections.length > 1 ? `${selectedCollections.length} collections` : `'${selectedCollections[0]}'`}... e.g., 'Find all users from Canada'` : "e.g., 'Find all users from Canada and sort them by name'")}
-                className="w-full h-28 p-4 bg-slate-50 dark:bg-slate-700/50 border border-slate-300 dark:border-slate-600 rounded-lg text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors duration-200 placeholder-slate-400 dark:placeholder-slate-500 resize-none"
+                style={{ width: '100%', height: 112, padding: 14, background: 'var(--soft)', border: '1px solid var(--border)', borderRadius: 'var(--radius-md)', fontSize: 14, fontFamily: 'var(--font-body)', color: 'var(--fg)', outline: 'none', resize: 'none', boxSizing: 'border-box' }}
                 disabled={isLoading || isQuerySectionDisabled}
               />
               {/* Agent iterations control */}
@@ -1574,7 +1609,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                 <div className="flex items-center gap-1.5">
                   <label
                     htmlFor="max-iterations-slider"
-                    className="text-sm font-medium text-slate-600 dark:text-slate-400 whitespace-nowrap"
+                    style={{ fontSize: 12.5, color: 'var(--muted)', whiteSpace: 'nowrap' }}
                   >
                     Agent Iterations: <span className="text-blue-600 dark:text-blue-400 font-semibold">{maxIterations}</span>
                   </label>
@@ -1608,7 +1643,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
               <button
                 onClick={handleGenerateQueryClick}
                 disabled={isLoading || !userInput.trim() || isQuerySectionDisabled || isPromptUnchanged}
-                className="w-full flex justify-center items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-slate-300 dark:disabled:bg-slate-600 disabled:text-slate-500 dark:disabled:text-slate-400 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.99]"
+                style={{ width: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center', padding: '10px 24px', border: 'none', borderRadius: 'var(--radius-md)', fontFamily: 'var(--font-body)', fontSize: 14, fontWeight: 500, cursor: 'pointer', background: 'var(--accent)', color: '#fff', opacity: (isLoading || !userInput.trim() || isQuerySectionDisabled || isPromptUnchanged) ? 0.45 : 1, transition: 'opacity 0.15s' }}
                 title={isPromptUnchanged ? "The current query matches the prompt. Modify the prompt to generate a new query." : "Generate MongoDB code from your natural language command (⌘ + G)"}
               >
                 {generateButtonText}
@@ -1617,13 +1652,13 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
 
             <div id="tutorial-results-area" className="mt-8">
               <div className={`flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-4 ${isQuerySectionDisabled ? 'hidden' : ''}`}>
-                <h3 className="text-lg font-medium text-slate-700 dark:text-slate-300">
+                <h3 style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 15, color: 'var(--fg)' }}>
                   Query Output
                 </h3>
                 <button
                   id="tutorial-notebook-button"
                   onClick={() => setIsNotebookPanelOpen(true)}
-                  className="flex items-center gap-2 px-4 py-2 border border-slate-300 dark:border-slate-600 text-sm font-medium rounded-md text-slate-600 dark:text-slate-300 bg-white dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-800 dark:hover:text-slate-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-slate-800 focus:ring-blue-500 transition-colors"
+                  className="qa-btn"
                   title="View your session as a reproducible Jupyter Notebook"
                 >
                   <NotebookIcon className="w-5 h-5" />
@@ -1779,7 +1814,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
           </div>
         </main>
 
-        <footer className="text-center mt-8 text-slate-500 dark:text-slate-400 text-sm space-y-1">
+        <footer style={{ textAlign: 'center', marginTop: 32, color: 'var(--muted)', fontSize: 12 }}>
           <p>Powered by Microsoft Azure and Google Gemini. For internal use only.</p>
           <p className="text-xs">
             AI features use the Google Gemini API. Your data is not used to train their models. See the <a href="https://ai.google.dev/gemini-api/terms" target="_blank" rel="noopener noreferrer" className="underline hover:text-slate-700 dark:hover:text-slate-200">Terms of Service</a>.
@@ -1829,14 +1864,428 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     </>
   );
 
-  return embedded ? (
-    <div style={{ fontFamily: 'var(--font-body)', color: 'var(--fg)', padding: '16px 24px', minHeight: '100%' }}>
-      {innerContent}
+  // Portals and animations shared by all embedded layouts
+  const sharedTail = (
+    <>
+      <Tutorial
+        isActive={isTutorialActive}
+        onStepChange={setTutorialStepIndex}
+        onClose={() => {
+          setIsTutorialActive(false);
+          localStorage.setItem('hasSeenTutorial', 'true');
+        }}
+      />
+      {contextViewerDrawer}
+      {notebookPanelDrawer}
+      {savedQueriesPanelDrawer}
+      {saveQueryDialog}
+      {shareQueryDialog}
+      {shortcutCheatsheet}
+      <style>{`
+        @keyframes fade-in { from { opacity: 0; transform: translateY(-10px); } to { opacity: 1; transform: translateY(0); } }
+        .animate-fade-in { animation: fade-in 0.5s ease-out forwards; }
+        @keyframes fade-in-fast { from { opacity: 0; } to { opacity: 1; } }
+        .animate-fade-in-fast { animation: fade-in-fast 0.3s ease-out forwards; }
+        @keyframes slide-in-drawer { from { transform: translateX(100%); } to { transform: translateX(0); } }
+        .animate-slide-in-drawer { animation: slide-in-drawer 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
+      `}</style>
+    </>
+  );
+
+  if (!embedded) {
+    return (
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-800 dark:text-slate-200 font-sans p-4 sm:p-6 lg:p-8">
+        {innerContent}
+      </div>
+    );
+  }
+
+  // ── Embedded: not yet connected ───────────────────────────────────────
+  if (!isConnectedForRender) {
+    return (
+      <>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '60vh', gap: 24, fontFamily: 'var(--font-body)', color: 'var(--fg)', padding: '40px 32px' }}>
+          {(isLoadingAccounts || isLoadingDatabases || isConnectingToDb) ? (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, color: 'var(--muted)', fontSize: 13 }}>
+              <svg className="animate-spin" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
+              </svg>
+              {isConnectingToDb ? `Connecting to ${isConnectingToDb}…` : isLoadingDatabases ? 'Loading databases…' : 'Loading accounts…'}
+            </div>
+          ) : dbError ? (
+            <div style={{ color: 'var(--status-err)', fontSize: 13, textAlign: 'center', maxWidth: 400 }}>{dbError}</div>
+          ) : accountDatabases.length > 0 ? (
+            <>
+              <div>
+                <div style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 20, textAlign: 'center', marginBottom: 6 }}>Select a database</div>
+                <div style={{ color: 'var(--muted)', fontSize: 13, textAlign: 'center' }}>Choose which database to query</div>
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, justifyContent: 'center' }}>
+                {accountDatabases.map(db => (
+                  <button
+                    key={db.name}
+                    onClick={() => handleConnectDatabase(db)}
+                    disabled={isConnectingToDb !== null}
+                    className="qa-btn primary"
+                    style={{ fontSize: 14, padding: '8px 20px', height: 'auto' }}
+                  >
+                    {db.name}
+                  </button>
+                ))}
+              </div>
+            </>
+          ) : (
+            <>
+              <div style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 20, textAlign: 'center' }}>No database selected</div>
+              <div style={{ color: 'var(--muted)', fontSize: 13, textAlign: 'center', maxWidth: 320 }}>
+                Go back to Hub and click a connection to start querying.
+              </div>
+            </>
+          )}
+        </div>
+        {sharedTail}
+      </>
+    );
+  }
+
+  // ── Embedded: connected — 2-column workspace layout ──────────────────
+  const insightsRail = (
+    <aside style={{
+      width: 300, flexShrink: 0,
+      borderLeft: '1px solid var(--border)',
+      overflow: 'auto',
+      padding: '16px 14px',
+      background: 'var(--bg)',
+      display: 'flex', flexDirection: 'column', gap: 12,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+          <path d="M8 2l1.6 4.4L14 8l-4.4 1.6L8 14l-1.6-4.4L2 8l4.4-1.6z"/>
+        </svg>
+        <span style={{ fontFamily: 'var(--font-display)', fontSize: 14, fontWeight: 500 }}>Insights</span>
+        <span className="qa-chip" style={{ marginLeft: 'auto', fontSize: 10 }}>auto</span>
+      </div>
+
+      {/* Analysis result */}
+      {analysisResult && (
+        <div className="qa-card animate-fade-in" style={{ padding: '10px 12px' }}>
+          <div style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--accent)', marginBottom: 6 }}>Analysis</div>
+          <div style={{ fontSize: 12.5, lineHeight: 1.55, color: 'var(--fg)' }}>{analysisResult.insight}</div>
+        </div>
+      )}
+
+      {/* Debug result */}
+      {debuggingResult && (
+        <div className="qa-card animate-fade-in" style={{ padding: '10px 12px' }}>
+          <div style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--status-warn)', marginBottom: 6 }}>Debug suggestion</div>
+          <div style={{ fontSize: 12.5, lineHeight: 1.55, color: 'var(--fg)' }}>{debuggingResult.suggestion}</div>
+        </div>
+      )}
+
+      {/* Write evaluation */}
+      {writeEvaluationResult && (
+        <div className="qa-card animate-fade-in" style={{ padding: '10px 12px' }}>
+          <div style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--status-warn)', marginBottom: 6 }}>Write evaluation</div>
+          <div style={{ fontSize: 12.5, lineHeight: 1.55, color: 'var(--fg)' }}>{writeEvaluationResult.evaluation}</div>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!analysisResult && !debuggingResult && !writeEvaluationResult && (
+        <div style={{ background: 'var(--soft)', border: '1px dashed var(--border)', borderRadius: 'var(--radius-md)', padding: '12px 14px' }}>
+          <div style={{ fontSize: 11, color: 'var(--muted)', marginBottom: 6 }}>Run a query to see AI insights</div>
+          <div style={{ fontSize: 12, color: 'var(--muted)', lineHeight: 1.5 }}>After executing, use "Analyze" on the results to get patterns, anomalies, and follow-up suggestions.</div>
+        </div>
+      )}
+
+      {/* Notebook shortcut */}
+      <button
+        onClick={() => setIsNotebookPanelOpen(true)}
+        className="qa-btn"
+        style={{ width: '100%', justifyContent: 'center', marginTop: 'auto' }}
+      >
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+          <path d="M4 2h8a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1zM6 6h4M6 9h4M6 12h2"/>
+        </svg>
+        View notebook
+      </button>
+    </aside>
+  );
+
+  const queryColumn = (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'auto', padding: '16px 20px', gap: 12, minWidth: 0 }}>
+      {/* DB switcher + collection selector strip */}
+      {dbInfoForRender && (
+        <div id="tutorial-account-section" style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          {/* Database switcher */}
+          {accountDatabases.length > 1 && connectedDbInfo && (
+            <div style={{ position: 'relative' }}>
+              <button
+                onClick={() => setIsDbSwitcherOpen(o => !o)}
+                className="qa-btn"
+                style={{ fontSize: 11.5, gap: 5 }}
+                title="Switch database"
+              >
+                <DatabaseIcon className="w-3 h-3" />
+                {connectedDbInfo.name}
+                <ChevronDownIcon className={`w-3 h-3 transition-transform ${isDbSwitcherOpen ? 'rotate-180' : ''}`} />
+              </button>
+              {isDbSwitcherOpen && (
+                <div style={{
+                  position: 'absolute', top: '100%', left: 0, marginTop: 4, zIndex: 20,
+                  background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 'var(--radius-md)',
+                  boxShadow: '0 8px 24px -8px rgba(20,18,14,0.15)', minWidth: 160, overflow: 'hidden',
+                }}>
+                  {accountDatabases.map(db => (
+                    <button
+                      key={db.name}
+                      onClick={() => { handleConnectDatabase(db); setIsDbSwitcherOpen(false); }}
+                      style={{
+                        width: '100%', textAlign: 'left', padding: '8px 12px',
+                        background: db.name === connectedDbInfo.name ? 'var(--soft)' : 'none',
+                        border: 'none', borderBottom: '1px solid var(--border)',
+                        fontFamily: 'var(--font-mono)', fontSize: 12,
+                        color: db.name === connectedDbInfo.name ? 'var(--accent)' : 'var(--fg)',
+                        cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6,
+                      }}
+                    >
+                      {db.name === connectedDbInfo.name && (
+                        <CheckIcon className="w-3 h-3" style={{ color: 'var(--accent)', flexShrink: 0 }} />
+                      )}
+                      {db.name}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          <span style={{ fontSize: 11, color: 'var(--muted)', fontFamily: 'var(--font-mono)' }}>
+            {accountDatabases.length > 1 ? '›' : <><DatabaseIcon className="w-3 h-3" style={{ display: 'inline', marginRight: 3 }} />{connectedDbInfo?.name}</>}
+          </span>
+
+          {dbInfoForRender.collections.map(col => (
+            <button
+              key={col.name}
+              onClick={(e) => handleCollectionClick(col.name, e)}
+              title={`Select ${col.name} (hold ⌘/Ctrl for multi-select)`}
+              style={{
+                fontFamily: 'var(--font-mono)', fontSize: 11,
+                padding: '3px 10px', borderRadius: 99,
+                border: selectedCollectionsForRender.includes(col.name) ? '1.5px solid var(--accent)' : '1px solid var(--border)',
+                background: selectedCollectionsForRender.includes(col.name) ? 'var(--accent)' : 'var(--soft)',
+                color: selectedCollectionsForRender.includes(col.name) ? '#fff' : 'var(--fg)',
+                cursor: 'pointer', transition: 'all 0.1s',
+              }}
+            >
+              {col.name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Schema panel for selected collections */}
+      {selectedCollectionsForRender.length > 0 && (
+        <div id="tutorial-collection-panel" style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {collectionInfoError && (
+            <div style={{ background: 'color-mix(in oklch, var(--status-err) 10%, var(--bg))', border: '1px solid color-mix(in oklch, var(--status-err) 30%, var(--border))', color: 'var(--status-err)', padding: '8px 12px', borderRadius: 'var(--radius-sm)', fontSize: 12 }}>
+              {collectionInfoError}
+            </div>
+          )}
+
+          {/* Multi-collection schema relationships */}
+          {selectedCollectionsForRender.length > 1 && (
+            <div className="animate-fade-in" style={{ background: 'var(--soft)', borderRadius: 'var(--radius-md)', padding: 14, border: '1px solid var(--border)' }}>
+              <div style={{ display: 'flex', alignItems: 'center', marginBottom: 10 }}>
+                <span style={{ fontSize: 13, fontWeight: 500 }}>Schema Connections</span>
+              </div>
+              {(isAnalyzingRelationships || !relationships) && !relationshipError && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'var(--muted)', fontSize: 12, padding: '8px 0' }}>
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-500"></div>
+                  Searching for connections…
+                </div>
+              )}
+              {relationshipError && (
+                <div style={{ color: 'var(--status-err)', fontSize: 12 }}>{relationshipError}</div>
+              )}
+              {relationships && !isAnalyzingRelationships && (
+                <div className="animate-fade-in" style={{ display: 'flex', justifyContent: 'center' }}>
+                  <SchemaRelationshipGraph relationships={relationships} selectedCollections={selectedCollections} />
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Per-collection schema accordion */}
+          {selectedCollectionsForRender.map(colName => {
+            const info = collectionDetailsMapForRender[colName];
+            const isColLoading = loadingCollections[colName];
+            const isExpanded = expandedCollectionSchemas[colName] ?? (selectedCollectionsForRender.length === 1);
+            return (
+              <div key={colName} style={{ background: 'var(--bg)', borderRadius: 'var(--radius-md)', border: '1px solid var(--border)', overflow: 'hidden' }}>
+                <button
+                  onClick={() => setExpandedCollectionSchemas(prev => ({ ...prev, [colName]: !isExpanded }))}
+                  style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '9px 14px', background: 'none', border: 'none', cursor: 'pointer', color: 'var(--fg)', fontFamily: 'var(--font-body)' }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+                    <ChevronDownIcon className={`w-4 h-4 transition-transform`} style={{ color: 'var(--muted)', transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)' }} />
+                    <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, fontWeight: 500 }}>{colName}</span>
+                    {isColLoading && <SpinnerIcon className="w-3 h-3 animate-spin text-blue-500" />}
+                  </div>
+                  {info && <span style={{ fontSize: 11, color: 'var(--muted)' }}>{info.documentCount.toLocaleString()} docs</span>}
+                </button>
+                {isExpanded && (
+                  <div style={{ borderTop: '1px solid var(--border)', background: 'var(--panel)' }}>
+                    {isColLoading ? (
+                      <div style={{ padding: '12px 14px', fontSize: 12, color: 'var(--muted)' }}>Loading schema…</div>
+                    ) : info ? (
+                      <CollectionActionPanel info={info} onClose={() => setSelectedCollections(prev => prev.filter(c => c !== colName))} />
+                    ) : (
+                      <div style={{ padding: '12px 14px', fontSize: 12, color: 'var(--status-err)' }}>Failed to load schema.</div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Query Generator section */}
+      <div
+        id="tutorial-prompt-section"
+        style={{ opacity: isQuerySectionDisabled ? 0.4 : 1, pointerEvents: isQuerySectionDisabled ? 'none' : 'auto', transition: 'opacity 0.3s', display: 'flex', flexDirection: 'column', gap: 12 }}
+      >
+        {/* Context banner */}
+        {showContextBanner && contextForRender && (
+          <div id="tutorial-context-banner" className="animate-fade-in" style={{ position: 'relative', background: 'var(--accent-soft)', border: '1px solid color-mix(in oklch, var(--accent) 25%, var(--border))', borderRadius: 'var(--radius-md)', padding: 14 }}>
+            <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <PinIcon className="w-5 h-5" style={{ color: 'var(--accent)', flexShrink: 0 }} />
+                <div>
+                  <div style={{ fontWeight: 600, fontSize: 13, color: 'var(--accent)' }}>Query Context Active</div>
+                  <div style={{ fontSize: 12, color: 'var(--fg)', marginTop: 2 }}>
+                    Using results from <strong style={{ fontFamily: 'var(--font-mono)' }}>{contextForRender.source}</strong> ({Array.isArray(contextForRender.data) ? contextForRender.data.length : 1} items)
+                  </div>
+                  <button onClick={() => setIsContextViewerOpen(true)} style={{ fontSize: 12, color: 'var(--accent)', background: 'none', border: 'none', cursor: 'pointer', padding: 0, marginTop: 2 }}>View data →</button>
+                </div>
+              </div>
+              <button onClick={() => setIntermediateContext(null)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--accent)', padding: 4 }}>
+                <XIcon className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Prompt input card */}
+        <div className="qa-card" style={{ padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 11, color: 'var(--muted)' }}>
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4"><path d="M3 8l3 3 7-7"/></svg>
+            Ask in plain English · Gemini
+            {selectedCollectionsForRender.length > 0 && (
+              <span className="qa-chip" style={{ marginLeft: 'auto' }}>{selectedCollectionsForRender.join(', ')}</span>
+            )}
+          </div>
+          <textarea
+            id="userInput"
+            value={userInput}
+            onChange={(e) => setUserInput(e.target.value)}
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === 'g') {
+                e.preventDefault();
+                if (!isLoading && userInput.trim() && !isQuerySectionDisabled && !isPromptUnchanged) handleGenerateQueryClick();
+              }
+            }}
+            placeholder={isQuerySectionDisabled ? 'Select a collection to begin…' : selectedCollections.length > 0 ? `Querying '${selectedCollections.join(', ')}'… e.g. 'Find all documents from last 30 days'` : "e.g. 'Find all users from Canada and sort by name'"}
+            style={{ width: '100%', minHeight: 80, padding: 10, background: 'transparent', border: 'none', outline: 'none', resize: 'none', fontFamily: 'var(--font-body)', fontSize: 14, color: 'var(--fg)', lineHeight: 1.55, boxSizing: 'border-box' }}
+            disabled={isLoading || isQuerySectionDisabled}
+          />
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <button
+              onClick={handleGenerateQueryClick}
+              disabled={isLoading || !userInput.trim() || isQuerySectionDisabled || isPromptUnchanged}
+              className="qa-btn primary"
+              style={{ fontSize: 13 }}
+            >
+              {isLoading ? 'Generating…' : isPromptUnchanged ? 'Generated ✓' : 'Generate query'}
+            </button>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>Iterations:</span>
+              <input
+                id="max-iterations-slider"
+                type="range" min={1} max={10} step={1}
+                value={maxIterations}
+                onChange={(e) => setMaxIterations(Number(e.target.value))}
+                disabled={isLoading || isQuerySectionDisabled}
+                className="accent-blue-600 disabled:opacity-40 cursor-pointer"
+                style={{ width: 72, accentColor: 'var(--accent)' }}
+              />
+              <span style={{ fontSize: 11.5, color: 'var(--accent)', fontFamily: 'var(--font-mono)', minWidth: 14 }}>{maxIterations}</span>
+            </div>
+            <span className="qa-chip" style={{ marginLeft: 'auto', fontSize: 10.5, cursor: 'pointer' }}
+              onClick={() => setIsShortcutCheatsheetOpen(true)} title="Keyboard shortcuts">⌘/</span>
+          </div>
+        </div>
+
+        {/* Loading */}
+        {isLoading && !isDemoModeForDebugStep && !isDemoModeForResultsStep && !isDemoModeForRunStep && (
+          <Loader message="Generating query…" />
+        )}
+
+        {/* Error */}
+        {error && !isDemoModeForDebugStep && !isDemoModeForResultsStep && !isDemoModeForRunStep && (
+          <div style={{ background: 'color-mix(in oklch, var(--status-err) 10%, var(--bg))', border: '1px solid color-mix(in oklch, var(--status-err) 30%, var(--border))', color: 'var(--status-err)', padding: '10px 14px', borderRadius: 'var(--radius-md)', fontSize: 13 }}>
+            <strong>Error: </strong>{error}
+          </div>
+        )}
+
+        {/* Results area */}
+        <div id="tutorial-results-area">
+          {/* Tutorial demo modes */}
+          {(isDemoModeForRunStep || isDemoModeForSaveStep) && (
+            <div className="animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <QueryDisplay code={mockFindUsersQuery.generated_code} onCodeChange={() => {}} onRunQuery={() => {}} onSaveQuery={() => {}} isExecuting={false} historyCount={1} historyIndex={0} onNavigateHistory={() => {}} />
+            </div>
+          )}
+          {(isDemoModeForResultsStep || isDemoModeForContextActiveStep) && (
+            <div className="animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <QueryDisplay code={mockFindUsersQuery.generated_code} onCodeChange={() => {}} onRunQuery={() => {}} onSaveQuery={() => {}} isExecuting={false} historyCount={1} historyIndex={0} onNavigateHistory={() => {}} />
+              <QueryResult isExecuting={false} executionError={null} executionResult={mockUserFindResult} onDebug={() => {}} isDebugging={false} debuggingResult={null} debugError={null} sourceCollection={'users'} onSetIntermediateContext={() => {}} intermediateContext={null} onAnalyze={() => {}} isAnalyzing={false} analysisResult={null} analysisError={null} onEvaluateWrite={() => {}} isEvaluatingWrite={false} writeEvaluationResult={null} writeEvaluationError={null} isTutorialActive={isTutorialActive} tutorialStepIndex={tutorialStepIndex} />
+            </div>
+          )}
+          {isDemoModeForDebugStep && (
+            <div className="animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <QueryDisplay code={"db['users'].find({}).sor([('name', 1)])"} onCodeChange={() => {}} onRunQuery={() => {}} onSaveQuery={() => {}} isExecuting={false} historyCount={1} historyIndex={0} onNavigateHistory={() => {}} />
+              <QueryResult isExecuting={false} executionError={"MongoDB query error: unknown operator: $sor (MongoServerError)"} executionResult={null} onDebug={() => {}} isDebugging={false} debuggingResult={null} debugError={null} sourceCollection={'users'} onSetIntermediateContext={() => {}} intermediateContext={null} onAnalyze={() => {}} isAnalyzing={false} analysisResult={null} analysisError={null} onEvaluateWrite={() => {}} isEvaluatingWrite={false} writeEvaluationResult={null} writeEvaluationError={null} isTutorialActive={isTutorialActive} tutorialStepIndex={tutorialStepIndex} />
+            </div>
+          )}
+
+          {/* Real results */}
+          {(!isLoading && !error && !isDemoModeForResultsStep && !isDemoModeForDebugStep && !isDemoModeForContextActiveStep && !isDemoModeForRunStep && !isDemoModeForSaveStep) && (
+            editableCode ? (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                <QueryDisplay code={editableCode} onCodeChange={setEditableCode} onRunQuery={handleRunQuery} onSaveQuery={handleOpenSaveDialog} isExecuting={isExecuting} historyCount={codeHistory.length} historyIndex={historyIndex} onNavigateHistory={handleNavigateHistory} />
+                <QueryResult isExecuting={isExecuting} executionError={executionError} executionResult={executionResult} onDebug={handleDebugQuery} isDebugging={isDebugging} debuggingResult={debuggingResult} debugError={debugError} sourceCollection={querySourceCollection} onSetIntermediateContext={handleSetIntermediateContext} intermediateContext={intermediateContext} onAnalyze={handleAnalyzeQuery} isAnalyzing={isAnalyzing} analysisResult={analysisResult} analysisError={analysisError} onEvaluateWrite={handleEvaluateWrite} isEvaluatingWrite={isEvaluatingWrite} writeEvaluationResult={writeEvaluationResult} writeEvaluationError={writeEvaluationError} />
+              </div>
+            ) : (
+              <div style={{ textAlign: 'center', color: 'var(--muted)', padding: '32px 0', border: '1.5px dashed var(--border)', borderRadius: 'var(--radius-md)', fontSize: 13 }}>
+                Your generated query will appear here.
+              </div>
+            )
+          )}
+        </div>
+      </div>
     </div>
-  ) : (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-800 dark:text-slate-200 font-sans p-4 sm:p-6 lg:p-8">
-      {innerContent}
-    </div>
+  );
+
+  return (
+    <>
+      <div style={{ display: 'flex', height: '100%', overflow: 'hidden', fontFamily: 'var(--font-body)', color: 'var(--fg)', background: 'var(--bg)' }}>
+        {queryColumn}
+        {insightsRail}
+      </div>
+      {sharedTail}
+    </>
   );
 };
 

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -329,10 +329,11 @@ export interface QueryGeneratorPageProps {
   email?: string;
   onLogout: () => void;
   onNavigateToExplorer: (connection: { resource: SelectedResource; dbInfo: DbInfo; accountName: string; availableDbs: DbInfo[], availableAccounts: CosmosDBAccount[] }) => void;
+  embedded?: boolean;
 }
 
 // --- Main Page Component ---
-const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, onLogout, onNavigateToExplorer }) => {
+const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, onLogout, onNavigateToExplorer, embedded = false }) => {
   const [userInput, setUserInput] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -1261,21 +1262,23 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
   );
 
 
-  return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-800 dark:text-slate-200 font-sans p-4 sm:p-6 lg:p-8">
+  const innerContent = (
+    <>
       <div className="max-w-4xl mx-auto">
 
-        <HeaderUI
-          name={name}
-          onLogout={onLogout}
-          onClearCache={handleClearCache}
-          isClearingCache={isClearingCache}
-          cacheClearStatus={cacheClearStatus}
-          onStartTutorial={() => setIsTutorialActive(true)}
-          onShowSavedQueries={() => setIsSavedQueriesPanelOpen(true)}
-          onShowShortcuts={() => setIsShortcutCheatsheetOpen(true)}
-          isUserMenuForcedOpen={isUserMenuOpenForTutorial}
-        />
+        {!embedded && (
+          <HeaderUI
+            name={name}
+            onLogout={onLogout}
+            onClearCache={handleClearCache}
+            isClearingCache={isClearingCache}
+            cacheClearStatus={cacheClearStatus}
+            onStartTutorial={() => setIsTutorialActive(true)}
+            onShowSavedQueries={() => setIsSavedQueriesPanelOpen(true)}
+            onShowShortcuts={() => setIsShortcutCheatsheetOpen(true)}
+            isUserMenuForcedOpen={isUserMenuOpenForTutorial}
+          />
+        )}
 
         <main className="space-y-8">
           {/* Connection Manager */}
@@ -1823,6 +1826,16 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
             animation: slide-in-drawer 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;
           }
        `}</style>
+    </>
+  );
+
+  return embedded ? (
+    <div style={{ fontFamily: 'var(--font-body)', color: 'var(--fg)', padding: '16px 24px', minHeight: '100%' }}>
+      {innerContent}
+    </div>
+  ) : (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-800 dark:text-slate-200 font-sans p-4 sm:p-6 lg:p-8">
+      {innerContent}
     </div>
   );
 };

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -830,8 +830,8 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     handleGenerateQuery(userInput, primaryContext);
   }, [userInput, intermediateContext, selectedCollections, collectionDetailsMap, handleGenerateQuery]);
 
-  const handleRunQuery = useCallback(async () => {
-    if (!editableCode.trim() || !connectedDbInfo || !connectedResource) {
+  const executeCode = useCallback(async (code: string) => {
+    if (!code.trim() || !connectedDbInfo || !connectedResource) {
       setExecutionError("Cannot run a query without a database connection.");
       return;
     }
@@ -846,7 +846,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     setWriteEvaluationError(null);
 
     try {
-      const result = await runMongoQuery(connectedResource.accountId, editableCode, connectedResource);
+      const result = await runMongoQuery(connectedResource.accountId, code, connectedResource);
       setExecutionResult(result);
 
       // --- Add step to notebook ---
@@ -855,12 +855,12 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
         id: new Date().toISOString() + Math.random(),
         type: 'query',
         prompt: lastSuccessfulPrompt || 'Query executed without a new prompt.',
-        query: editableCode,
+        query: code,
         resultSample: resultSample,
         contextSource: currentQueryContextSource ?? undefined,
       };
       setNotebookSteps(prev => [...prev, newStep]);
-      setCurrentQueryContextSource(null); // Reset after use
+      setCurrentQueryContextSource(null);
 
     } catch (e) {
       if (e instanceof Error) {
@@ -875,7 +875,9 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     } finally {
       setIsExecuting(false);
     }
-  }, [editableCode, connectedDbInfo, connectedResource, lastSuccessfulPrompt, currentQueryContextSource]);
+  }, [connectedDbInfo, connectedResource, lastSuccessfulPrompt, currentQueryContextSource]);
+
+  const handleRunQuery = useCallback(() => executeCode(editableCode), [executeCode, editableCode]);
 
   const handleDebugQuery = useCallback(async () => {
     if (!editableCode || !executionError) return;
@@ -1130,16 +1132,24 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
   }, [savedQueries]);
 
   const handleLoadSavedQuery = (query: SavedQuery) => {
-    clearQueryState(); // Clear all results and errors
+    clearQueryState();
     setUserInput(query.prompt);
     setLastSuccessfulPrompt(query.prompt);
     setEditableCode(query.code);
-
-    // Set code history for the loaded query
     setCodeHistory([query.code]);
     setHistoryIndex(0);
+    setIsSavedQueriesPanelOpen(false);
+  };
 
-    setIsSavedQueriesPanelOpen(false); // Close panel after loading
+  const handleLoadAndRunSavedQuery = (query: SavedQuery) => {
+    clearQueryState();
+    setUserInput(query.prompt);
+    setLastSuccessfulPrompt(query.prompt);
+    setEditableCode(query.code);
+    setCodeHistory([query.code]);
+    setHistoryIndex(0);
+    setIsSavedQueriesPanelOpen(false);
+    executeCode(query.code);
   };
 
   // --- Sharing Handlers ---
@@ -1346,15 +1356,18 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
   ) : null;
 
   const showSavedQueriesPanel = isSavedQueriesPanelOpen || isDemoModeForSavedQueriesPanelStep;
+  const dbReady = !isLoadingAccounts && !isLoadingDatabases && !isConnectingToDb && !!connectedResource;
   const savedQueriesPanelDrawer = showSavedQueriesPanel ? createPortal(
     <SavedQueriesPanel
       onClose={() => setIsSavedQueriesPanelOpen(false)}
       queries={isDemoModeForSavedQueriesPanelStep ? mockSavedQueries : savedQueries}
       onLoad={handleLoadSavedQuery}
+      onLoadAndRun={handleLoadAndRunSavedQuery}
       onEdit={handleEditSavedQuery}
       onDelete={handleDeleteSavedQuery}
       onShare={handleOpenShareDialog}
       isLoading={isDemoModeForSavedQueriesPanelStep ? false : isLoadingSavedQueries}
+      dbReady={isDemoModeForSavedQueriesPanelStep ? true : dbReady}
       currentUserEmail={email || 'dev.user@example.com'}
     />,
     document.body

--- a/frontend/pages/QueryGeneratorPageWrapper.tsx
+++ b/frontend/pages/QueryGeneratorPageWrapper.tsx
@@ -5,7 +5,16 @@ import { useAuth } from '../contexts/AuthContext';
 import { USE_MSAL_AUTH } from '../app.config';
 import QueryGeneratorPage from './QueryGeneratorPage';
 import AppLayout from '../components/AppLayout';
-import { SelectedResource, DbInfo, CosmosDBAccount } from '../types';
+import { SelectedResource, DbInfo, CosmosDBAccount, CollectionSummary } from '../types';
+
+type ConnectionState = { accountId: string; databaseName: string; accountName?: string; collections?: CollectionSummary[]; availableAccounts?: CosmosDBAccount[]; availableDbs?: DbInfo[] };
+
+const readSessionConnection = (): ConnectionState | null => {
+  try {
+    const saved = sessionStorage.getItem('qp_connection');
+    return saved ? JSON.parse(saved) : null;
+  } catch { return null; }
+};
 
 interface HubNavState {
   preselectedAccountId?: string;
@@ -18,35 +27,50 @@ const MsalQueryGeneratorPageWrapper: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const hubState = (location.state as HubNavState) ?? {};
+  const [connection, setConnection] = React.useState<ConnectionState | null>(() =>
+    hubState.preselectedAccountId ? null : readSessionConnection()
+  );
 
   const name = accounts[0]?.name;
   const email = accounts[0]?.username;
   const onLogout = () => instance.logoutRedirect({ postLogoutRedirectUri: "/" });
 
-  const onNavigateToExplorer = (connection: {
+  const onNavigateToExplorer = (conn: {
     resource: SelectedResource;
     dbInfo: DbInfo;
     accountName: string;
     availableDbs: DbInfo[];
     availableAccounts: CosmosDBAccount[]
   }) => {
-    navigate(`/data-explorer/${encodeURIComponent(connection.resource.accountId)}/${encodeURIComponent(connection.resource.databaseName)}`, {
+    navigate(`/data-explorer/${encodeURIComponent(conn.resource.accountId)}/${encodeURIComponent(conn.resource.databaseName)}`, {
       state: {
-        dbInfo: connection.dbInfo,
-        accountName: connection.accountName,
-        availableDbs: connection.availableDbs,
-        availableAccounts: connection.availableAccounts
+        dbInfo: conn.dbInfo,
+        accountName: conn.accountName,
+        availableDbs: conn.availableDbs,
+        availableAccounts: conn.availableAccounts
       }
     });
   };
 
   return (
-    <AppLayout>
+    <AppLayout
+      accountId={connection?.accountId}
+      databaseName={connection?.databaseName}
+      accountName={connection?.accountName}
+      collections={connection?.collections}
+      availableAccounts={connection?.availableAccounts}
+      availableDbs={connection?.availableDbs}
+      onSwitchAccount={(acc) => navigate('/query-generator', { state: { preselectedAccountId: acc.id } })}
+      onSwitchDatabase={(db) => connection && navigate(`/data-explorer/${encodeURIComponent(connection.accountId)}/${encodeURIComponent(db.name)}`)}
+    >
       <QueryGeneratorPage
         name={name}
         email={email}
         onLogout={onLogout}
         onNavigateToExplorer={onNavigateToExplorer}
+        onConnectionChange={(accountId, databaseName, accountName, collections, availableAccounts, availableDbs) =>
+          setConnection(accountId && databaseName ? { accountId, databaseName, accountName: accountName ?? undefined, collections, availableAccounts, availableDbs } : null)
+        }
         preselectedAccountId={hubState.preselectedAccountId}
         embedded
       />
@@ -60,34 +84,49 @@ const BypassQueryGeneratorPageWrapper: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const hubState = (location.state as HubNavState) ?? {};
+  const [connection, setConnection] = React.useState<ConnectionState | null>(() =>
+    hubState.preselectedAccountId ? null : readSessionConnection()
+  );
 
   const name = user?.name;
   const email = user?.email;
 
-  const onNavigateToExplorer = (connection: {
+  const onNavigateToExplorer = (conn: {
     resource: SelectedResource;
     dbInfo: DbInfo;
     accountName: string;
     availableDbs: DbInfo[];
     availableAccounts: CosmosDBAccount[]
   }) => {
-    navigate(`/data-explorer/${encodeURIComponent(connection.resource.accountId)}/${encodeURIComponent(connection.resource.databaseName)}`, {
+    navigate(`/data-explorer/${encodeURIComponent(conn.resource.accountId)}/${encodeURIComponent(conn.resource.databaseName)}`, {
       state: {
-        dbInfo: connection.dbInfo,
-        accountName: connection.accountName,
-        availableDbs: connection.availableDbs,
-        availableAccounts: connection.availableAccounts
+        dbInfo: conn.dbInfo,
+        accountName: conn.accountName,
+        availableDbs: conn.availableDbs,
+        availableAccounts: conn.availableAccounts
       }
     });
   };
 
   return (
-    <AppLayout>
+    <AppLayout
+      accountId={connection?.accountId}
+      databaseName={connection?.databaseName}
+      accountName={connection?.accountName}
+      collections={connection?.collections}
+      availableAccounts={connection?.availableAccounts}
+      availableDbs={connection?.availableDbs}
+      onSwitchAccount={(acc) => navigate('/query-generator', { state: { preselectedAccountId: acc.id } })}
+      onSwitchDatabase={(db) => connection && navigate(`/data-explorer/${encodeURIComponent(connection.accountId)}/${encodeURIComponent(db.name)}`)}
+    >
       <QueryGeneratorPage
         name={name}
         email={email}
         onLogout={logout}
         onNavigateToExplorer={onNavigateToExplorer}
+        onConnectionChange={(accountId, databaseName, accountName, collections, availableAccounts, availableDbs) =>
+          setConnection(accountId && databaseName ? { accountId, databaseName, accountName: accountName ?? undefined, collections, availableAccounts, availableDbs } : null)
+        }
         preselectedAccountId={hubState.preselectedAccountId}
         embedded
       />

--- a/frontend/pages/QueryGeneratorPageWrapper.tsx
+++ b/frontend/pages/QueryGeneratorPageWrapper.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useMsal } from "@azure/msal-react";
 import { useAuth } from '../contexts/AuthContext';
 import { USE_MSAL_AUTH } from '../app.config';
@@ -7,10 +7,17 @@ import QueryGeneratorPage from './QueryGeneratorPage';
 import AppLayout from '../components/AppLayout';
 import { SelectedResource, DbInfo, CosmosDBAccount } from '../types';
 
+interface HubNavState {
+  preselectedAccountId?: string;
+  preselectedAccountName?: string;
+}
+
 // Component for the real MSAL authentication flow
 const MsalQueryGeneratorPageWrapper: React.FC = () => {
   const { instance, accounts } = useMsal();
   const navigate = useNavigate();
+  const location = useLocation();
+  const hubState = (location.state as HubNavState) ?? {};
 
   const name = accounts[0]?.name;
   const email = accounts[0]?.username;
@@ -40,6 +47,7 @@ const MsalQueryGeneratorPageWrapper: React.FC = () => {
         email={email}
         onLogout={onLogout}
         onNavigateToExplorer={onNavigateToExplorer}
+        preselectedAccountId={hubState.preselectedAccountId}
         embedded
       />
     </AppLayout>
@@ -50,6 +58,8 @@ const MsalQueryGeneratorPageWrapper: React.FC = () => {
 const BypassQueryGeneratorPageWrapper: React.FC = () => {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
+  const hubState = (location.state as HubNavState) ?? {};
 
   const name = user?.name;
   const email = user?.email;
@@ -78,6 +88,7 @@ const BypassQueryGeneratorPageWrapper: React.FC = () => {
         email={email}
         onLogout={logout}
         onNavigateToExplorer={onNavigateToExplorer}
+        preselectedAccountId={hubState.preselectedAccountId}
         embedded
       />
     </AppLayout>

--- a/frontend/pages/QueryGeneratorPageWrapper.tsx
+++ b/frontend/pages/QueryGeneratorPageWrapper.tsx
@@ -4,25 +4,25 @@ import { useMsal } from "@azure/msal-react";
 import { useAuth } from '../contexts/AuthContext';
 import { USE_MSAL_AUTH } from '../app.config';
 import QueryGeneratorPage from './QueryGeneratorPage';
+import AppLayout from '../components/AppLayout';
 import { SelectedResource, DbInfo, CosmosDBAccount } from '../types';
 
 // Component for the real MSAL authentication flow
 const MsalQueryGeneratorPageWrapper: React.FC = () => {
   const { instance, accounts } = useMsal();
   const navigate = useNavigate();
-  
+
   const name = accounts[0]?.name;
   const email = accounts[0]?.username;
   const onLogout = () => instance.logoutRedirect({ postLogoutRedirectUri: "/" });
 
-  const onNavigateToExplorer = (connection: { 
-    resource: SelectedResource; 
-    dbInfo: DbInfo; 
-    accountName: string; 
-    availableDbs: DbInfo[]; 
-    availableAccounts: CosmosDBAccount[] 
+  const onNavigateToExplorer = (connection: {
+    resource: SelectedResource;
+    dbInfo: DbInfo;
+    accountName: string;
+    availableDbs: DbInfo[];
+    availableAccounts: CosmosDBAccount[]
   }) => {
-    // Navigate to data explorer with URL parameters
     navigate(`/data-explorer/${encodeURIComponent(connection.resource.accountId)}/${encodeURIComponent(connection.resource.databaseName)}`, {
       state: {
         dbInfo: connection.dbInfo,
@@ -34,12 +34,15 @@ const MsalQueryGeneratorPageWrapper: React.FC = () => {
   };
 
   return (
-    <QueryGeneratorPage 
-      name={name} 
-      email={email} 
-      onLogout={onLogout} 
-      onNavigateToExplorer={onNavigateToExplorer}
-    />
+    <AppLayout>
+      <QueryGeneratorPage
+        name={name}
+        email={email}
+        onLogout={onLogout}
+        onNavigateToExplorer={onNavigateToExplorer}
+        embedded
+      />
+    </AppLayout>
   );
 };
 
@@ -47,18 +50,17 @@ const MsalQueryGeneratorPageWrapper: React.FC = () => {
 const BypassQueryGeneratorPageWrapper: React.FC = () => {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
-  
+
   const name = user?.name;
   const email = user?.email;
 
-  const onNavigateToExplorer = (connection: { 
-    resource: SelectedResource; 
-    dbInfo: DbInfo; 
-    accountName: string; 
-    availableDbs: DbInfo[]; 
-    availableAccounts: CosmosDBAccount[] 
+  const onNavigateToExplorer = (connection: {
+    resource: SelectedResource;
+    dbInfo: DbInfo;
+    accountName: string;
+    availableDbs: DbInfo[];
+    availableAccounts: CosmosDBAccount[]
   }) => {
-    // Navigate to data explorer with URL parameters
     navigate(`/data-explorer/${encodeURIComponent(connection.resource.accountId)}/${encodeURIComponent(connection.resource.databaseName)}`, {
       state: {
         dbInfo: connection.dbInfo,
@@ -70,12 +72,15 @@ const BypassQueryGeneratorPageWrapper: React.FC = () => {
   };
 
   return (
-    <QueryGeneratorPage 
-      name={name} 
-      email={email} 
-      onLogout={logout} 
-      onNavigateToExplorer={onNavigateToExplorer}
-    />
+    <AppLayout>
+      <QueryGeneratorPage
+        name={name}
+        email={email}
+        onLogout={logout}
+        onNavigateToExplorer={onNavigateToExplorer}
+        embedded
+      />
+    </AppLayout>
   );
 };
 

--- a/frontend/router.tsx
+++ b/frontend/router.tsx
@@ -3,7 +3,7 @@ import LoginPage from './pages/LoginPage';
 import HubPage from './pages/HubPage';
 import QueryGeneratorPageWrapper from './pages/QueryGeneratorPageWrapper';
 import DataExplorerPageWrapper from './pages/DataExplorerPageWrapper';
-import AnalyticsPage from './pages/AnalyticsPage';
+import AnalyticsPageWrapper from './pages/AnalyticsPageWrapper';
 import NotFoundPage from './pages/NotFoundPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import AuditPage from './pages/AuditPage';
@@ -37,7 +37,7 @@ export const router = createBrowserRouter([
     path: "/analytics",
     element: (
       <ProtectedRoute>
-        <AnalyticsPage />
+        <AnalyticsPageWrapper />
       </ProtectedRoute>
     ),
   },

--- a/frontend/router.tsx
+++ b/frontend/router.tsx
@@ -1,7 +1,9 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import LoginPage from './pages/LoginPage';
+import HubPage from './pages/HubPage';
 import QueryGeneratorPageWrapper from './pages/QueryGeneratorPageWrapper';
 import DataExplorerPageWrapper from './pages/DataExplorerPageWrapper';
+import AnalyticsPage from './pages/AnalyticsPage';
 import NotFoundPage from './pages/NotFoundPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import AuditPage from './pages/AuditPage';
@@ -9,17 +11,33 @@ import AuditPage from './pages/AuditPage';
 export const router = createBrowserRouter([
   {
     path: "/",
-    element: <Navigate to="/query-generator" replace />,
+    element: <Navigate to="/hub" replace />,
   },
   {
     path: "/login",
     element: <LoginPage />,
   },
   {
+    path: "/hub",
+    element: (
+      <ProtectedRoute>
+        <HubPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
     path: "/audit",
     element: (
       <ProtectedRoute>
         <AuditPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: "/analytics",
+    element: (
+      <ProtectedRoute>
+        <AnalyticsPage />
       </ProtectedRoute>
     ),
   },

--- a/frontend/services/dbService.ts
+++ b/frontend/services/dbService.ts
@@ -53,6 +53,20 @@ import {
   mockUpdateDocument
 } from './mockData';
 
+const _cache = new Map<string, { data: unknown; expiry: number }>();
+const CACHE_TTL = 5 * 60 * 1000;
+function _getCached<T>(key: string): T | null {
+  const entry = _cache.get(key);
+  if (!entry || Date.now() > entry.expiry) return null;
+  return entry.data as T;
+}
+function _setCached(key: string, data: unknown): void {
+  _cache.set(key, { data, expiry: Date.now() + CACHE_TTL });
+}
+export function invalidateDbCache(): void {
+  _cache.clear();
+}
+
 /**
  * Helper function to get access token with proper error handling
  */
@@ -100,6 +114,9 @@ export const getAzureCosmosAccounts = async (): Promise<CosmosDBAccount[]> => {
   }
   // --- END DEVELOPMENT MOCK ---
 
+  const cached = _getCached<CosmosDBAccount[]>('accounts');
+  if (cached) return cached;
+
   const accessToken = await getAuthenticatedToken();
 
   console.log("Fetching Azure cosmosdb accounts from backend...");
@@ -119,7 +136,9 @@ export const getAzureCosmosAccounts = async (): Promise<CosmosDBAccount[]> => {
     throw new Error(errorMessage);
   }
 
-  return responseApi.json();
+  const data: CosmosDBAccount[] = await responseApi.json();
+  _setCached('accounts', data);
+  return data;
 };
 
 
@@ -147,9 +166,12 @@ export const getDatabasesForAccount = async (accountId: string): Promise<DbInfo[
   }
   // --- END DEVELOPMENT MOCK ---
 
+  const cacheKey = `dbs:${accountId}`;
+  const cached = _getCached<DbInfo[]>(cacheKey);
+  if (cached) return cached;
+
   console.log(`Fetching databases for account ID ${accountId} from backend...`);
 
-  // Use helper function to get authenticated token with proper error handling
   const accessToken = await getAuthenticatedToken();
 
   const response = await fetch(`${API_BASE_URL}/azure/account_details`, {
@@ -167,7 +189,9 @@ export const getDatabasesForAccount = async (accountId: string): Promise<DbInfo[
     throw new Error(errorMessage);
   }
 
-  return response.json();
+  const data: DbInfo[] = await response.json();
+  _setCached(cacheKey, data);
+  return data;
 };
 
 
@@ -296,6 +320,7 @@ export const clearSystemCache = async (): Promise<{ message: string }> => {
     throw new Error(errorMessage);
   }
 
+  invalidateDbCache();
   return response.json();
 };
 

--- a/frontend/src/design-tokens.css
+++ b/frontend/src/design-tokens.css
@@ -1,0 +1,161 @@
+/* QueryPal — Refined Minimal design tokens */
+
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500&family=Instrument+Sans:ital,wght@0,400;0,500;0,600;1,400;1,500&display=swap');
+
+:root {
+  --bg:          #fbfaf7;
+  --panel:       #ffffff;
+  --fg:          #1a1916;
+  --muted:       #6c6760;
+  --soft:        #f3f0eb;
+  --border:      #e9e4dc;
+  --accent:      #3a8c5f;
+  --accent-soft: color-mix(in oklch, #3a8c5f 14%, #fbfaf7);
+
+  --status-ok:   #3a8c5f;
+  --status-err:  #c94250;
+  --status-warn: #c98d42;
+
+  --font-display: 'Instrument Sans', system-ui, sans-serif;
+  --font-body:    'Geist', system-ui, sans-serif;
+  --font-mono:    'Geist Mono', ui-monospace, monospace;
+
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+}
+
+html.dark {
+  --bg:          #0f0e0d;
+  --panel:       #1a1916;
+  --fg:          #f0ede8;
+  --muted:       #7a7470;
+  --soft:        #242220;
+  --border:      #2e2b27;
+  --accent:      #4aab73;
+  --accent-soft: color-mix(in oklch, #4aab73 14%, #0f0e0d);
+}
+
+/* ── Utility atoms ─────────────────────────────────────────── */
+
+.qa-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--panel);
+  color: var(--fg);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+  white-space: nowrap;
+}
+.qa-btn:hover { background: var(--soft); }
+.qa-btn.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.qa-btn.primary:hover { opacity: 0.9; }
+
+.qa-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 99px;
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted);
+  background: var(--soft);
+}
+.qa-chip.accent {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: transparent;
+}
+.qa-chip.ok {
+  background: color-mix(in oklch, var(--status-ok) 14%, var(--bg));
+  color: var(--status-ok);
+  border-color: transparent;
+}
+.qa-chip.err {
+  background: color-mix(in oklch, var(--status-err) 14%, var(--bg));
+  color: var(--status-err);
+  border-color: transparent;
+}
+
+.qa-avatar {
+  width: 26px;
+  height: 26px;
+  border-radius: 99px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--font-body);
+  flex-shrink: 0;
+}
+
+.qa-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+}
+
+/* ── App shell ─────────────────────────────────────────────── */
+
+.qp-app {
+  display: flex;
+  height: 100vh;
+  background: var(--bg);
+  font-family: var(--font-body);
+  color: var(--fg);
+  overflow: hidden;
+}
+
+.qp-sidebar {
+  width: 220px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--panel);
+  border-right: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.qp-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.qp-topbar {
+  height: 52px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel);
+  gap: 12px;
+}
+
+.qp-content {
+  flex: 1;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}

--- a/frontend/src/design-tokens.css
+++ b/frontend/src/design-tokens.css
@@ -159,3 +159,26 @@ html.dark {
   flex-direction: column;
   min-height: 0;
 }
+
+/* ── Status dots ────────────────────────────────────────────── */
+
+.qa-dot {
+  width: 6px; height: 6px;
+  border-radius: 99px;
+  background: var(--muted);
+  display: inline-block;
+  flex-shrink: 0;
+}
+.qa-dot.ok   { background: var(--status-ok); }
+.qa-dot.warn { background: var(--status-warn); }
+.qa-dot.err  { background: var(--status-err); }
+
+/* ── Drawer slide-in animation ──────────────────────────────── */
+
+@keyframes qp-slide-in-right {
+  from { transform: translateX(100%); opacity: 0; }
+  to   { transform: translateX(0);    opacity: 1; }
+}
+.qp-drawer {
+  animation: qp-slide-in-right 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+}

--- a/frontend/utils/queryHandover.ts
+++ b/frontend/utils/queryHandover.ts
@@ -1,0 +1,134 @@
+export interface FilterState {
+  id: string;
+  key: string;
+  value: string;
+  isCustom: boolean;
+  operator?: string;
+  type?: 'string' | 'number' | 'boolean' | 'date';
+}
+
+export interface HandoverResult {
+  collection: string;
+  filters: FilterState[];
+}
+
+// MongoDB operator → Explorer operator
+const MONGO_OP_MAP: Record<string, string> = {
+  '$eq':    'equals',
+  '$ne':    'not_equals',
+  '$gt':    'greater_than',
+  '$gte':   'greater_than',
+  '$lt':    'less_than',
+  '$lte':   'less_than',
+  '$regex': 'contains',
+};
+
+function inferType(v: unknown): FilterState['type'] {
+  if (typeof v === 'number') return 'number';
+  if (typeof v === 'boolean') return 'boolean';
+  return 'string';
+}
+
+function makeid(): string {
+  return Math.random().toString(36).substring(7);
+}
+
+export function parseQueryForHandover(code: string): HandoverResult | null {
+  const collMatch =
+    code.match(/db\[['"](.+?)['"]\]\.find\s*\(/) ||
+    code.match(/db\.(\w+)\.find\s*\(/);
+  if (!collMatch) return null;
+  const collection = collMatch[1];
+
+  const findIdx = code.indexOf('.find(');
+  if (findIdx === -1) return null;
+
+  let depth = 0;
+  let start = -1;
+  let end = -1;
+  for (let i = findIdx + 6; i < code.length; i++) {
+    if (code[i] === '{') {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (code[i] === '}') {
+      depth--;
+      if (depth === 0) { end = i; break; }
+    }
+  }
+
+  if (start === -1 || end === -1) return { collection, filters: [] };
+
+  const raw = code.slice(start, end + 1);
+
+  // Normalize Python dict syntax → JSON
+  const jsonStr = raw
+    .replace(/\bTrue\b/g, 'true')
+    .replace(/\bFalse\b/g, 'false')
+    .replace(/\bNone\b/g, 'null')
+    .replace(/'/g, '"');
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { collection, filters: [] };
+  }
+
+  const filters: FilterState[] = [];
+
+  for (const [key, value] of Object.entries(parsed)) {
+    if (key.startsWith('$')) continue;
+
+    // Primitive value → equals
+    if (typeof value !== 'object' || value === null) {
+      filters.push({
+        id: makeid(), key,
+        value: String(value),
+        operator: 'equals',
+        isCustom: false,
+        type: inferType(value),
+      });
+      continue;
+    }
+
+    // Operator object: {"$ne": "x"}, {"$gt": 5}, {"$exists": true}, etc.
+    const obj = value as Record<string, unknown>;
+    const ops = Object.keys(obj);
+
+    if (ops.length === 1) {
+      const op = ops[0];
+
+      if (op === '$exists') {
+        filters.push({
+          id: makeid(), key,
+          value: '',
+          operator: obj[op] ? 'exists' : 'not_exists',
+          isCustom: false,
+          type: 'string',
+        });
+        continue;
+      }
+
+      const explorerOp = MONGO_OP_MAP[op];
+      if (explorerOp && (typeof obj[op] !== 'object' || obj[op] === null)) {
+        const v = obj[op];
+        filters.push({
+          id: makeid(), key,
+          value: String(v),
+          operator: explorerOp,
+          isCustom: false,
+          type: inferType(v),
+        });
+        continue;
+      }
+    }
+
+    // Complex operator or multiple ops — skip (can't represent cleanly)
+  }
+
+  return { collection, filters };
+}

--- a/frontend/utils/queryHandover.ts
+++ b/frontend/utils/queryHandover.ts
@@ -96,12 +96,11 @@ export function parseQueryForHandover(code: string): HandoverResult | null {
     }
 
     // Operator object: {"$ne": "x"}, {"$gt": 5}, {"$exists": true}, etc.
+    // Multiple operators on the same field become multiple filter rows.
     const obj = value as Record<string, unknown>;
-    const ops = Object.keys(obj);
+    let handled = false;
 
-    if (ops.length === 1) {
-      const op = ops[0];
-
+    for (const op of Object.keys(obj)) {
       if (op === '$exists') {
         filters.push({
           id: makeid(), key,
@@ -110,12 +109,14 @@ export function parseQueryForHandover(code: string): HandoverResult | null {
           isCustom: false,
           type: 'string',
         });
+        handled = true;
         continue;
       }
 
       const explorerOp = MONGO_OP_MAP[op];
-      if (explorerOp && (typeof obj[op] !== 'object' || obj[op] === null)) {
-        const v = obj[op];
+      const v = obj[op];
+      // Skip null values for comparison operators — they can't be represented as a string filter
+      if (explorerOp && v !== null && v !== undefined && typeof v !== 'object') {
         filters.push({
           id: makeid(), key,
           value: String(v),
@@ -123,11 +124,12 @@ export function parseQueryForHandover(code: string): HandoverResult | null {
           isCustom: false,
           type: inferType(v),
         });
-        continue;
+        handled = true;
       }
     }
 
-    // Complex operator or multiple ops — skip (can't represent cleanly)
+    if (handled) continue;
+    // Complex operator — skip (can't represent cleanly)
   }
 
   return { collection, filters };


### PR DESCRIPTION
## Summary

- **Hub page** — new landing page after login with DB engine cards; unavailable engines show correct badges
- **App shell** — `AppLayout`, `AppSidebar`, `AppTopBar` extracted as shared components across all authenticated routes; sidebar connection chip always rendered (placeholder prevents layout shift during loading)
- **Command palette** (`⌘K`) — fuzzy search across navigate, actions, switch DB/account, and jump-to-collection commands; global keyboard shortcuts wired (`⌘⇧1-4`, `⌘N`, `⌘⇧S`)
- **Login page** — fully redesigned with design tokens, inline SVG icons, no Tailwind/MUI
- **AI analysis result** — redesigned with design tokens; two-column insight + Chart.js panel
- **Workspace persistence** — `userInput`, `editableCode`, `querySourceCollection`, `executionResult`, and `_queryResult` saved to `sessionStorage['qp_workspace']` scoped to active connection; survives sidebar tab switches without clearing on auto-reconnect
- **Query handover to Explorer** — "Open in Explorer" button in `QueryDisplay` (disabled with tooltip for non-`find()` queries); `parseQueryForHandover()` extracts collection + filters from generated code, mapping MongoDB operators (`$ne`, `$gt`, `$lt`, `$exists`, `$regex`, multi-op objects) to Explorer filter rows
- **Explorer filter handover** — `initialFilters` threaded through `DataExplorerPageWrapper` → `DataExplorerPage`; applied once via ref-guarded `useEffect` after collection selection; fast-path (session cache hit) now also forwards `initialFilters`
- **Analytics page** — new `AnalyticsPage` + `AnalyticsPageWrapper` added to routing
- **HubPage tweaks** — removed "Don't see yours?" link; PostgreSQL/Snowflake/BigQuery/ClickHouse all marked Unavailable

## Test plan

- [ ] Login → Hub → connect to Cosmos DB → Query Generator
- [ ] Generate a `find()` query, run it, click "Open in Explorer" — collection selected, filters pre-applied, result list matches workspace
- [ ] Generate an `aggregate` query — "Open in Explorer" button is visible but disabled with tooltip
- [ ] Switch sidebar tabs (Analytics → Workspace) — prompt, generated code, and result all restored
- [ ] Switch account via connection chip — sidebar chip and collections remain stable (no flash/vanish)
- [ ] `⌘K` opens palette; arrow keys + Enter navigate; Esc closes; jump-to-collection works
- [ ] `npm run test:run` — 67/67 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)