### PR TITLE
fix: align Terraform DB config and reorganize docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,532 +1,66 @@
 # QueryPal
 ### AI-Powered Database Assistant for Azure Cosmos DB
 
-QueryPal is a highly scalable, intelligent database exploration and management platform designed for developers, analysts, and data professionals working with **Azure Cosmos DB (MongoDB API)**. It combines the power of **Google Gemini AI** with a secure, user-friendly interface to transform how you interact with your NoSQL databases.
+QueryPal lets you query, explore, and manage **Azure Cosmos DB (MongoDB API)** using natural language. Type a question, get an optimized MongoDB query and AI-generated analysis back.
 
-**Key Capabilities:**
-- 🧠 **Natural Language Queries**: Convert plain English to MongoDB queries using AI
-- 📊 **AI-Powered Data Analysis**: Automatic insights and visualizations from query results
-- 🔍 **Smart Data Explorer**: Paginated browsing with advanced filtering and search
-- 💾 **Query Management**: Save, share, and collaborate on queries with team members
-- 🔒 **Enterprise Security**: Microsoft Entra ID authentication with On-Behalf-Of (OBO) flow
-- 📝 **Document Management**: Full CRUD operations with audit trails and history
-- 🎯 **Schema Discovery**: Intelligent schema inference and documentation
+**Key capabilities:**
+- Natural language → MongoDB query via Google Gemini + LangGraph ReAct agent
+- Paginated data explorer with filtering, multi-select, and document editing
+- Saved queries, audit trails, and schema relationship graph
+- Enterprise auth: Microsoft Entra ID with On-Behalf-Of (OBO) flow
+- Private backend: frontend nginx proxies all API calls internally — backend is unreachable from the internet
 
 ---
 
-## 🚀 Why QueryPal?
+## Tech Stack
 
-Azure Cosmos DB's portal interface can be limiting for real-world data exploration and analysis. QueryPal addresses these pain points by providing:
-
-- **🎯 Intuitive Data Discovery**: Browse collections, analyze schemas, and understand your data structure without complex queries
-- **🧠 AI-Powered Query Generation**: Ask questions in natural language and get optimized MongoDB queries instantly
-- **📊 Intelligent Analytics**: Automatic data analysis with AI-generated insights and Chart.js visualizations
-- **👥 Team Collaboration**: Share queries, insights, and findings with your team through built-in collaboration features
-- **🛡️ Enterprise-Grade Security**: Zero-trust architecture with Microsoft Entra ID and secure token management
-- **📋 Data Management**: Complete document lifecycle management with audit trails and version history
-- **🔍 Advanced Search**: Powerful filtering and search capabilities across collections and documents
-
----
-
-## ✨ Features
-## 🎯 Key Features Deep Dive
-
-### 🧠 AI-Powered Natural Language Queries
-- **Smart Query Generation**: Convert plain English to optimized MongoDB queries
-- **Context Awareness**: Uses database schema and collection metadata for better results
-- **Query Optimization**: AI suggests performance improvements and best practices
-- **Multi-step Queries**: Handle complex queries requiring multiple steps
-
-### 📊 Intelligent Data Analysis
-- **Automatic Insights**: AI analyzes query results and provides meaningful insights
-- **Dynamic Visualizations**: Chart.js integration with 8+ chart types
-- **Theme-Aware Charts**: Automatic dark/light mode adaptation
-- **Export Capabilities**: Save query output for external analysis
-
-### 💾 Team Collaboration & Query Management
-- **Save & Share Queries**: Build a knowledge base of useful queries
-- **Team Collaboration**: Share queries with specific team members
-- **Version History**: Track query modifications and usage
-- **Quick Access**: Organize and categorize saved queries
-
-### 🔍 Advanced Data Explorer
-- **Paginated Browsing**: Handle large collections efficiently
-- **Smart Filtering**: Filter by any field with intelligent search
-- **Document Linking**: Automatic cross-reference detection and navigation
-
-### 📝 Document Management
-- **Full CRUD Operations**: Create, read, update, delete documents
-- **Audit Trails**: Complete history of document changes
-- **Field-Level Editing**: Modify specific fields without affecting the whole document
-- **Data Validation**: Ensure data integrity with schema validation
-
-### 🎓 User Experience
-- **Interactive Tutorial**: Guided onboarding for new users
-- **Contextual Help**: In-app assistance and tooltips
-- **Responsive Design**: Works seamlessly on desktop and mobile
-- **Accessibility**: WCAG 2.1 compliant interface
-
----
-
-## 🧱 Technology Stack
-
-| Component           | Technology                                                                   |
-|--------------------|-----------------------------------------------------------------------------|
-| **Frontend**       | React 18, TypeScript, Vite, Tailwind CSS, Material-UI                     |
-| **AI & Analytics** | Google Gemini Pro, Chart.js, React Chart.js 2                             |
-| **Authentication** | Microsoft Entra ID, MSAL (Browser & Python), On-Behalf-Of Flow             |
-| **Backend API**    | FastAPI (Python 3.12), Uvicorn, Pydantic V2                               |
-| **Database**       | Azure Cosmos DB (MongoDB API), PostgreSQL (User Data)                      |
-| **Cloud Platform** | Google Cloud Run, Azure Resource Manager (ARM)                             |
-| **Infrastructure** | Terraform, GCP Secret Manager, Serverless VPC Access, Cloud SQL            |
-| **DevOps & CI/CD** | GitHub Actions, Docker, Google Container Registry                          |
-| **Testing**        | Vitest, React Testing Library, Pytest, Coverage.py                        |
-| **Code Quality**   | ESLint, Black, Flake8, MyPy, TypeScript Strict Mode                       |
-| **Monitoring**     | Application Insights, Cloud SQL Proxy, Logging                             |
-
----
-
-## 🏗️ Architecture Overview
-
-QueryPal follows a secure **Backend-for-Frontend (BFF)** pattern with enterprise-grade security:
-
-```
-┌─────────────────────┐     Auth       ┌─────────────────────┐
-│    React Frontend   ├───────────────►│  Microsoft Entra    │
-│   (SPA + MSAL.js)   │◄───────────────┤   Identity Platform │
-└─────────────────────┘   Access Token └─────────────────────┘
-           │
-           ▼ Bearer Token
-┌─────────────────────┐
-│   FastAPI Backend   │
-│  • Token Validation │
-│  • OBO Exchange     │◄──────────┐
-│  • Query Processing │           │
-│  • AI Integration   │           │
-│  • Document CRUD    │           │
-└─────────────────────┘           │
-           │                      │
-           ▼                      │
-┌─────────────────────┐           │
-│  Google Gemini API  │           │
-│  • NL2Query         │           │
-│  • Data Analysis    │           │
-│  • Insights Gen     │           │
-└─────────────────────┘           │
-                                  │
-┌─────────────────────┐           │
-│   PostgreSQL DB     │           │
-│  • User Queries     │           │
-│  • Audit Logs       │           │
-│  • Query History    │           │
-└─────────────────────┘           │
-                                  │
-┌─────────────────────┐           │
-│  Azure Cosmos DB    │◄──────────┘
-│  • Document Storage │
-│  • MongoDB API      │
-│  • ARM Management   │
-└─────────────────────┘
-```
-
-### Autonomous Query Generation with ReAct Agent
-
-QueryPal employs a powerful LangGraph-based ReAct (Reasoning and Acting) agent to autonomously generate, sandbox-test, and evaluate MongoDB queries. This ensures unparalleled accuracy while maintaining strict safety boundaries for write operations.
-
-```mermaid
-graph TD
-    A[User Intent] -->|Natural Language| B(Generate Query)
-    B --> C{Write Operation?}
-    C -- Yes --> D[Return Query to User]
-    D --> E((Manual Review & Run))
-    E --> F[Execute Write]
-    F --> G[Log to Audit Database]
-    F --> H[Evaluate with AI]
-    
-    C -- No (Read Only) --> I(Sandbox Execution)
-    I --> J{Evaluate Result}
-    J -- Success --> K[Return Final Query & Data]
-    J -- Failure/Error --> B
-    
-    subgraph LangGraph Agent Loop
-        B
-        C
-        I
-        J
-    end
-```
-
-**Security Features:**
-- ✅ **Zero-Trust Architecture**: No secrets stored in frontend
-- 🔐 **Token-Based Authentication**: MSAL with automatic token refresh
-- 🛡️ **On-Behalf-Of Flow**: Secure Azure resource access
-- 🛡️ **Input Validation**: Comprehensive request/response validation
-- 📝 **Audit Logging**: Complete audit trail for all operations
-
----
-
+| Layer | Technology |
+|---|---|
+| Frontend | React 18, TypeScript, Vite |
+| Backend | FastAPI (Python 3.12), Pydantic V2 |
+| AI | Google Gemini (`gemini-2.5-flash`), LangGraph |
+| Auth | Microsoft Entra ID, MSAL, OBO flow |
+| Databases | Azure Cosmos DB (MongoDB API), PostgreSQL (Cloud SQL) |
+| Infrastructure | Google Cloud Run, Terraform, GCP Secret Manager, Serverless VPC Access |
+| CI/CD | GitHub Actions, Docker, Google Container Registry |
 
 ---
 
 ## Quick Start
 
-### Option 1: Docker Compose (Recommended)
-
-The fastest way to get QueryPal running locally:
-
 ```bash
-# Clone the repository
-git clone https://github.com/ChingEnLin/QueryPal
-cd QueryPal
-
-# Configure environment variables
 cp backend/.env.example backend/.env
-# Edit backend/.env with your API keys and Azure credentials
-
-# Start both frontend and backend
+# Fill in backend/.env — see docs/DEVELOPMENT.md for all variables
 docker-compose up --build
-
-# Access the application
-# Frontend: http://localhost:5173
-# Backend API: http://localhost:8000
-# API Documentation: http://localhost:8000/docs
 ```
 
-### Option 2: Development Setup
+- Frontend: http://localhost:5173
+- Backend API: http://localhost:8000
+- API docs: http://localhost:8000/docs
 
-For development with hot reload:
-
-```bash
-# Backend setup
-cd backend
-python -m venv venv
-source venv/bin/activate  # or venv\Scripts\activate on Windows
-pip install -r requirements.txt
-cp .env.example .env  # Configure your environment variables
-uvicorn main:app --reload
-
-# Frontend setup (new terminal)
-cd frontend
-npm install
-npm run dev
-```
-
-### Environment Configuration
-
-Create a `backend/.env` file with:
-
-```env
-# Google Gemini API
-GEMINI_API_KEY=your_gemini_api_key_here
-
-# Azure Entra ID Configuration
-AZURE_TENANT_ID=your_tenant_id
-AZURE_CLIENT_ID=your_backend_app_id
-AZURE_CLIENT_SECRET=your_client_secret
-ARM_SCOPE=https://management.azure.com/.default
-
-# PostgreSQL Database (for user data)
-DB_USER=querypal_user
-DB_PASS=your_db_password
-DB_NAME=querypal
-DB_HOST=localhost
-DB_PORT=5432
-
-# Optional: For production
-DB_UNIX_SOCKET=/cloudsql/project:region:instance
-```
+For dev without Azure, set `USE_MSAL_AUTH = false` in `frontend/app.config.ts` to use mock data.
 
 ---
 
-## 🧪 Testing & Quality Assurance
+## Documentation
 
-QueryPal maintains high code quality with comprehensive testing:
-
-### Backend Testing
-```bash
-cd backend
-
-# Run all tests with coverage
-./run_tests.sh
-
-# Individual commands
-pytest --cov=. --cov-report=html    # Tests with coverage
-flake8 . --statistics                # Code linting
-black --check .                      # Code formatting
-mypy .                               # Type checking
-```
-
-### Frontend Testing
-```bash
-cd frontend
-
-# Run all tests
-npm test
-
-# Run with coverage
-npm run test:coverage
-
-# Run tests once
-npm run test:run
-
-# Interactive UI testing
-npm run test:ui
-```
-
-### Test Coverage
-- **Backend**: 85%+ code coverage with pytest
-- **Frontend**: 80%+ code coverage with Vitest
-- **Integration Tests**: E2E testing of critical user flows
-- **Static Analysis**: Type checking, linting, and formatting
-
-### CI/CD Pipeline
-- ✅ **Automated Testing**: All PRs trigger comprehensive test suites
-- 🚀 **Deployment**: Automatic deployment to Google Cloud Run on production branch
-- 📊 **Code Coverage**: Coverage reports uploaded to Codecov
-- 🔍 **Code Quality**: ESLint, Black, MyPy, and TypeScript strict mode
-
----
-
-## ☁️ Infrastructure & Deployment
-
-### Production Architecture
-
-QueryPal runs on Google Cloud Run with a private backend topology. The frontend nginx container is the only public entry point — the backend service is network-isolated and unreachable from the internet.
-
-```mermaid
-graph TB
-    Browser(["👤 Browser"])
-
-    subgraph gcp["☁️ Google Cloud Platform &mdash; europe-west1"]
-        subgraph cloudrun["Cloud Run"]
-            direction TB
-            Frontend["<b>querypal-frontend</b><br/>──────────────<br/>ingress: public<br/>nginx · serves SPA<br/>proxies /api/* → backend"]
-            Backend["<b>querypal-backend</b><br/>──────────────<br/>ingress: internal only<br/>FastAPI · Uvicorn<br/>❌ not reachable from internet"]
-        end
-
-        subgraph vpc["VPC Network"]
-            Connector["Serverless VPC<br/>Access Connector<br/><i>10.8.0.0/28</i>"]
-        end
-
-        SM[("🔑 Secret Manager<br/>6 secrets")]
-        SQL[("🗄️ Cloud SQL<br/>PostgreSQL")]
-        GCR["📦 Container Registry"]
-        SA["🪪 Cloud Run SA<br/><i>least-privilege</i>"]
-    end
-
-    subgraph azure["☁️ Microsoft Azure"]
-        Entra["🔐 Entra ID<br/><i>MSAL · OBO flow</i>"]
-        Cosmos[("🌍 Cosmos DB<br/>MongoDB API")]
-    end
-
-    Gemini["🤖 Google Gemini Pro"]
-
-    Browser -- "HTTPS" --> Frontend
-    Frontend -. "vpc-egress: all-traffic" .-> Connector
-    Connector -- "internal ingress\n✅ VPC source allowed" --> Backend
-    Backend -- "Cloud SQL Proxy\nunix socket" --> SQL
-    Backend -- "HTTPS" --> Entra
-    Backend -- "HTTPS" --> Cosmos
-    Backend -- "HTTPS" --> Gemini
-    SM -- "mounted at startup\nvia --set-secrets" --> Backend
-    SA -. "identity" .-> Frontend
-    SA -. "identity" .-> Backend
-    GCR -- "image" --> Frontend
-    GCR -- "image" --> Backend
-```
-
-### Network Security Model
-
-| | Frontend | Backend |
-|---|---|---|
-| **Cloud Run ingress** | `all` (public) | `internal` (VPC only) |
-| **VPC egress** | `all-traffic` (proxy to backend) | `private-ranges-only` |
-| **Internet accessible** | ✅ Yes | ❌ No — 403 from GFE |
-| **Who can call it** | Anyone | Frontend nginx via VPC connector |
-
-All API calls from the browser go to `/api/*` on the frontend's own origin. Nginx strips the `/api` prefix and proxies the request to the backend's internal Cloud Run URL through the VPC connector. The backend URL is never exposed to the browser.
-
-### Secret Management
-
-All sensitive configuration is stored in **GCP Secret Manager** and mounted into the backend container at startup via Cloud Run's native `--set-secrets` integration. Secrets are never passed as plain environment variables and never appear in deployment logs or `gcloud run describe` output.
-
-| Secret | Description |
+| Doc | Contents |
 |---|---|
-| `querypal-azure-tenant-id` | Microsoft Entra ID tenant |
-| `querypal-azure-client-id` | Backend app registration client ID |
-| `querypal-azure-client-secret` | Backend app registration client secret |
-| `querypal-gemini-api-key` | Google Gemini API key |
-| `querypal-db-user` | Cloud SQL PostgreSQL username |
-| `querypal-db-pass` | Cloud SQL PostgreSQL password |
-
-### Infrastructure as Code
-
-Cloud infrastructure is managed by **Terraform** in the `terraform/` directory. The CI pipeline owns image builds and Cloud Run deployments; Terraform owns everything underneath.
-
-| Resource | Managed by |
-|---|---|
-| VPC connector | Terraform |
-| Secret Manager secrets | Terraform |
-| Cloud Run service account + IAM | Terraform |
-| Cloud SQL instance & database | Terraform (import existing) |
-| Cloud Run services | CI pipeline (GitHub Actions) |
-| Docker images | CI pipeline (GitHub Actions) |
-
-```bash
-cd terraform
-cp terraform.tfvars.example terraform.tfvars
-terraform init
-./import.sh      # import existing Cloud SQL — no data migration needed
-terraform apply
-```
-
-> See the PR migration guide for the full step-by-step checklist, including how to populate Secret Manager values and what to verify before the first production deploy.
-
-### CI/CD Pipeline
-
-Pushes to the `production` branch trigger the deploy workflow (`.github/workflows/google-cloudrun-docker.yml`).
-
-```mermaid
-flowchart LR
-    Push(["push to\nproduction"]) --> Auth
-
-    subgraph gha["GitHub Actions"]
-        Auth["Authenticate\nWorkload Identity\nFederation"]
-        Auth --> BuildBE["Build &amp; push\nbackend image"]
-        Auth --> BuildFE["Build &amp; push\nfrontend image"]
-        BuildBE --> DeployBE["Deploy backend\n--ingress=internal\n--set-secrets\n--vpc-connector"]
-        BuildFE --> DeployFE
-        DeployBE -- "backend URL" --> DeployFE["Deploy frontend\nBACKEND_URL=internal URL\n--vpc-connector"]
-    end
-
-    DeployBE --> SM
-    DeployFE --> Done(["✅ Live"])
-
-    subgraph gcp["GCP"]
-        SM[("Secret Manager\nfetch at startup")]
-    end
-```
-
-Workload Identity Federation is used for keyless authentication — no long-lived service account keys are stored in GitHub. The dedicated Cloud Run service account (`querypal-cloudrun-sa`) holds only the permissions it needs: `secretmanager.secretAccessor`, `cloudsql.client`, and `vpcaccess.user`.
+| [Architecture](docs/ARCHITECTURE.md) | BFF pattern, auth flow, ReAct agent loop, security model |
+| [Infrastructure](docs/INFRASTRUCTURE.md) | Cloud topology, network security, Secret Manager, Terraform setup, CI/CD pipeline |
+| [Azure Setup](docs/AZURE_SETUP.md) | Entra ID app registrations, Cosmos DB permissions, frontend auth config |
+| [Development](docs/DEVELOPMENT.md) | Local setup, testing commands, code style |
+| [Design Handbook](DESIGN_HANDBOOK.md) | CSS tokens, utility classes, component conventions |
+| [Versioning](docs/SEMANTIC_VERSIONING.md) | Semantic versioning and conventional commits |
 
 ---
 
-## 🔧 Development Setup
+## Links
 
-### Prerequisites
-- **Node.js** 20+ and npm
-- **Python** 3.12+
-- **Docker** and Docker Compose
-- **Google Cloud SDK** (for deployment)
-- **Azure CLI** (optional, for Azure resources)
-
-### IDE Recommendations
-- **VS Code** with extensions:
-  - Python
-  - TypeScript
-  - Pylance
-  - Prettier
-  - ESLint
-  - Docker
+- **Live**: https://querypal.virtonomy.io
+- **Issues**: https://github.com/ChingEnLin/QueryPal/issues
+- **License**: [MIT](LICENSE)
 
 ---
 
-## ⚙️ Azure Setup & Configuration
-
-### 1. Microsoft Entra ID Application Registration
-
-**Frontend Application (SPA):**
-1. Go to [Azure Portal → App Registrations](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps)
-2. Create new registration:
-   - **Name**: `QueryPal Frontend`
-   - **Platform**: Single-page application (SPA)
-   - **Redirect URI**: `http://localhost:5173` (development) / your production URL
-3. Note the **Application (client) ID** and **Directory (tenant) ID**
-
-**Backend Application (Confidential Client):**
-1. Create another registration:
-   - **Name**: `QueryPal Backend`
-   - **Client type**: Confidential client
-2. Add a **client secret** (Certificates & secrets)
-3. **Expose an API**:
-   - Add scope: `api://[backend-client-id]/access_as_user`
-   - Add the frontend app as an authorized client
-
-**API Permissions:**
-- Add permissions for both apps:
-  - `Microsoft Graph` → `User.Read`
-  - `Azure Service Management` → `user_impersonation`
-- **Grant admin consent** for your organization
-
-### 2. Azure Cosmos DB Permissions
-
-Grant the backend application appropriate access:
-1. Go to your **Cosmos DB account** → **Access control (IAM)**
-2. Add role assignment:
-   - **Role**: `Cosmos DB Account Reader Role`
-   - **Assign access to**: Service principal
-   - **Select**: Your backend application
-
-### 3. Frontend Configuration
-
-Update `frontend/authConfig.ts`:
-
-```typescript
-export const msalConfig = {
-  auth: {
-    clientId: "your-frontend-client-id",
-    authority: "https://login.microsoftonline.com/your-tenant-id",
-    redirectUri: "http://localhost:5173" // or your production URL
-  },
-};
-
-export const loginRequest = {
-  scopes: ["User.Read", "api://your-backend-client-id/access_as_user"]
-};
-```
-
----
-
-## 🏷️ Versioning
-
-This project uses [Semantic Versioning](https://semver.org/) with automated releases based on [Conventional Commits](https://www.conventionalcommits.org/).
-
-- **Version format**: `vMAJOR.MINOR.PATCH` (e.g., `v2.1.0`)
-- **Automated releases**: Triggered when pushing to the `production` branch
-- **Release notes**: Auto-generated and published to GitHub Releases and project wiki
-
-For detailed information about our versioning process and commit message conventions, see [docs/SEMANTIC_VERSIONING.md](docs/SEMANTIC_VERSIONING.md).
-
----
-
-## 📚 API Documentation
-
-QueryPal provides comprehensive REST APIs. When running locally, access:
-- **Interactive Docs**: http://localhost:8000/docs
-- **OpenAPI Spec**: http://localhost:8000/openapi.json
-
----
-
-## 📄 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
----
-
-## 👨‍💻 Author & Acknowledgments
-
-**Built by [Ching-En Lin](https://github.com/ChingEnLin)**
-
-**Powered by:**
-- 🤖 Google Gemini Pro AI
-- ☁️ Microsoft Azure & Google Cloud
-- ⚡ Modern web technologies
-
----
-
-## 🔗 Links
-
-- **Live Demo**: [QueryPal Production](https://querypal.virtonomy.io)
-- **GitHub Repository**: [QueryPal Source](https://github.com/ChingEnLin/QueryPal)
-- **Issues & Feedback**: [GitHub Issues](https://github.com/ChingEnLin/QueryPal/issues)
-
+Built by [Ching-En Lin](https://github.com/ChingEnLin)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,91 @@
+# Architecture
+
+## Backend-for-Frontend (BFF) Pattern
+
+QueryPal uses a BFF architecture where the FastAPI backend is the sole actor that touches Azure and database credentials. The browser only ever holds an MSAL access token.
+
+```
+┌─────────────────────┐     Auth       ┌─────────────────────┐
+│    React Frontend   ├───────────────►│  Microsoft Entra    │
+│   (SPA + MSAL.js)   │◄───────────────┤   Identity Platform │
+└─────────────────────┘   Access Token └─────────────────────┘
+           │
+           ▼ Bearer Token
+┌─────────────────────┐
+│   FastAPI Backend   │
+│  • Token Validation │
+│  • OBO Exchange     │
+│  • Query Processing │
+│  • AI Integration   │
+│  • Document CRUD    │
+└─────────────────────┘
+           │
+           ├──────────────────────────────────────┐
+           ▼                                      ▼
+┌─────────────────────┐              ┌─────────────────────┐
+│  Google Gemini API  │              │   Azure Cosmos DB   │
+│  • NL2Query         │              │  • Document Storage │
+│  • Data Analysis    │              │  • MongoDB API      │
+└─────────────────────┘              └─────────────────────┘
+           │
+           ▼
+┌─────────────────────┐
+│   PostgreSQL DB     │
+│  • User Queries     │
+│  • Audit Logs       │
+└─────────────────────┘
+```
+
+### Authentication Flow
+
+1. Frontend acquires an access token from Microsoft Entra ID via MSAL (`api://<backend-client-id>/access_as_user` scope).
+2. Frontend sends `Authorization: Bearer <token>` to the backend.
+3. Backend performs an On-Behalf-Of (OBO) exchange to get an ARM-scoped token.
+4. Backend uses the ARM token to fetch Cosmos DB accounts and connection strings from Azure Resource Manager.
+
+---
+
+## ReAct Agent Loop
+
+QueryPal uses a LangGraph-based ReAct agent to autonomously generate, sandbox-test, and evaluate MongoDB queries. Write operations are detected via AST (not regex) and returned to the user for manual review rather than executed automatically.
+
+```mermaid
+graph TD
+    A[User Intent] -->|Natural Language| B(Generate Query)
+    B --> C{Write Operation?}
+    C -- Yes --> D[Return Query to User]
+    D --> E((Manual Review & Run))
+    E --> F[Execute Write]
+    F --> G[Log to Audit Database]
+
+    C -- No (Read Only) --> I(Sandbox Execution)
+    I --> J{Evaluate Result}
+    J -- Success --> K[Return Final Query & Data]
+    J -- Failure/Error --> B
+
+    subgraph LangGraph Agent Loop
+        B
+        C
+        I
+        J
+    end
+```
+
+**Agent nodes:** `generate_query → execute_test → evaluate_result → (loop or end)`
+
+- Max iterations enforced server-side via `max_iterations` in `QueryPrompt` (default 3, max 10).
+- Sandbox scope is locked to `{"db": db, "ObjectId": ObjectId}` — no arbitrary code execution.
+- Write operations (`insert_one`, `update_*`, `delete_*`, etc.) are AST-detected and never executed in the sandbox.
+
+---
+
+## Security Model
+
+| Layer | Mechanism |
+|---|---|
+| Browser → Backend | MSAL Bearer token, validated on every request |
+| Backend → Azure | OBO token exchange, never stored |
+| Backend → Cosmos DB | ARM-fetched connection string, scoped per request |
+| Secrets at rest | GCP Secret Manager, mounted at container startup |
+| Backend network | `--ingress=internal` — unreachable from public internet |
+| Frontend → Backend | nginx proxy over VPC connector — backend URL never exposed to browser |

--- a/docs/AZURE_SETUP.md
+++ b/docs/AZURE_SETUP.md
@@ -1,0 +1,71 @@
+# Azure Setup
+
+## 1. Entra ID App Registrations
+
+You need two app registrations: one for the frontend SPA and one for the backend confidential client.
+
+### Frontend (SPA)
+
+1. Go to Azure Portal → App Registrations → New registration
+2. Name: `QueryPal Frontend`, Platform: Single-page application
+3. Redirect URI: `http://localhost:5173` (dev) / your production URL
+4. Note the **Application (client) ID** and **Directory (tenant) ID**
+
+### Backend (Confidential Client)
+
+1. New registration — Name: `QueryPal Backend`, Client type: Confidential client
+2. Add a **client secret** under Certificates & secrets
+3. Expose an API:
+   - Application ID URI: `api://<backend-client-id>`
+   - Add scope: `access_as_user`
+   - Add the frontend app as an authorized client application
+
+### API Permissions (both apps)
+
+- `Microsoft Graph` → `User.Read`
+- `Azure Service Management` → `user_impersonation`
+- Grant admin consent for your organization
+
+---
+
+## 2. Cosmos DB Access
+
+Grant the backend application read access to your Cosmos DB account:
+
+1. Go to your Cosmos DB account → Access control (IAM)
+2. Add role assignment:
+   - Role: `Cosmos DB Account Reader Role`
+   - Assign to: your backend app registration (service principal)
+
+---
+
+## 3. Frontend Configuration
+
+Update `frontend/authConfig.ts`:
+
+```typescript
+export const msalConfig = {
+  auth: {
+    clientId: "your-frontend-client-id",
+    authority: "https://login.microsoftonline.com/your-tenant-id",
+    redirectUri: "http://localhost:5173",
+  },
+};
+
+export const loginRequest = {
+  scopes: ["User.Read", "api://your-backend-client-id/access_as_user"],
+};
+```
+
+---
+
+## 4. Backend Environment Variables
+
+```env
+AZURE_TENANT_ID=your_tenant_id
+AZURE_CLIENT_ID=your_backend_client_id
+AZURE_CLIENT_SECRET=your_client_secret
+ARM_SCOPE=https://management.azure.com/.default
+```
+
+In production these are sourced from GCP Secret Manager — see [INFRASTRUCTURE.md](INFRASTRUCTURE.md#secret-management).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,96 @@
+# Development Guide
+
+## Prerequisites
+
+- Node.js 20+
+- Python 3.12+
+- Docker & Docker Compose
+- Google Cloud SDK (for deployment)
+
+---
+
+## Running Locally
+
+### Docker Compose (recommended)
+
+```bash
+cp backend/.env.example backend/.env
+# Fill in backend/.env with your credentials
+docker-compose up --build
+# Frontend: http://localhost:5173
+# Backend:  http://localhost:8000
+# API docs: http://localhost:8000/docs
+```
+
+### Without Azure (mock mode)
+
+Set `USE_MSAL_AUTH = false` in `frontend/app.config.ts`. All `dbService.ts` calls return mock data without hitting the backend or Azure.
+
+### Manual (hot reload)
+
+```bash
+# Backend
+cd backend
+python -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+uvicorn main:app --reload
+
+# Frontend (separate terminal)
+cd frontend
+npm install
+npm run dev
+```
+
+### Backend `.env`
+
+```env
+GEMINI_API_KEY=
+AZURE_TENANT_ID=
+AZURE_CLIENT_ID=
+AZURE_CLIENT_SECRET=
+ARM_SCOPE=https://management.azure.com/.default
+DB_USER=
+DB_PASS=
+DB_NAME=querypal
+DB_HOST=localhost
+DB_PORT=5432
+# DB_UNIX_SOCKET=/cloudsql/project:region:instance  # Cloud SQL only
+```
+
+---
+
+## Testing
+
+### Backend
+
+```bash
+cd backend
+pytest --cov=. --cov-report=term-missing   # with coverage
+PYTHONPATH=. pytest tests/test_query_routes.py -v  # single file
+make lint        # flake8
+make format      # black --check
+make format-fix  # black (auto-fix)
+make typecheck   # mypy
+make all         # install + lint + format + test
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm test              # watch mode
+npm run test:run      # CI mode (run once)
+npm run test:coverage # with coverage report
+npm run test:ui       # interactive Vitest UI
+```
+
+---
+
+## Code Style
+
+- **Python**: Black (formatting), Flake8 (linting), MyPy (permissive type checking)
+- **TypeScript**: ESLint, TypeScript strict mode
+- **CSS**: No Tailwind — use CSS tokens from `frontend/src/design-tokens.css` and inline `style` props. See [DESIGN_HANDBOOK.md](../DESIGN_HANDBOOK.md).
+- **Icons**: Inline SVGs only (`stroke="currentColor"`), no icon libraries.
+- **Comments**: Only when the *why* is non-obvious. No docstrings or block comments explaining what the code does.

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -1,0 +1,133 @@
+# Infrastructure & Deployment
+
+## Production Topology
+
+The frontend nginx container is the only public entry point. The backend is network-isolated and unreachable from the internet — all browser traffic goes to `/api/*` on the frontend's origin, which nginx proxies internally through the VPC connector.
+
+```mermaid
+graph TB
+    Browser(["👤 Browser"])
+
+    subgraph gcp["☁️ Google Cloud Platform — europe-west1"]
+        subgraph cloudrun["Cloud Run"]
+            direction TB
+            Frontend["querypal-frontend\ningress: public\nnginx · serves SPA\nproxies /api/* → backend"]
+            Backend["querypal-backend\ningress: internal only\nFastAPI · Uvicorn\n❌ not reachable from internet"]
+        end
+
+        subgraph vpc["VPC Network"]
+            Connector["Serverless VPC\nAccess Connector\n10.8.0.0/28"]
+        end
+
+        SM[("Secret Manager\n6 secrets")]
+        SQL[("Cloud SQL\nPostgreSQL")]
+        GCR["Container Registry"]
+        SA["Cloud Run SA\nleast-privilege"]
+    end
+
+    subgraph azure["☁️ Microsoft Azure"]
+        Entra["Entra ID\nMSAL · OBO flow"]
+        Cosmos[("Cosmos DB\nMongoDB API")]
+    end
+
+    Gemini["Google Gemini"]
+
+    Browser -- "HTTPS" --> Frontend
+    Frontend -. "vpc-egress: all-traffic" .-> Connector
+    Connector -- "internal ingress" --> Backend
+    Backend -- "Cloud SQL Proxy / unix socket" --> SQL
+    Backend -- "HTTPS" --> Entra
+    Backend -- "HTTPS" --> Cosmos
+    Backend -- "HTTPS" --> Gemini
+    SM -- "mounted at startup via --set-secrets" --> Backend
+    SA -. "identity" .-> Frontend
+    SA -. "identity" .-> Backend
+```
+
+## Network Security
+
+| | Frontend | Backend |
+|---|---|---|
+| Cloud Run ingress | `all` (public) | `internal` (VPC only) |
+| VPC egress | `all-traffic` | `private-ranges-only` |
+| Internet accessible | Yes | No — 403 from GFE |
+| Who can call it | Anyone | Frontend nginx via VPC connector |
+
+---
+
+## Secret Management
+
+All sensitive configuration lives in **GCP Secret Manager** and is mounted into the backend container at startup via `--set-secrets`. Secrets are never passed as plain environment variables and never appear in `gcloud run describe` output.
+
+| Secret ID | Description |
+|---|---|
+| `querypal-azure-tenant-id` | Microsoft Entra ID tenant |
+| `querypal-azure-client-id` | Backend app registration client ID |
+| `querypal-azure-client-secret` | Backend app registration client secret |
+| `querypal-gemini-api-key` | Google Gemini API key |
+| `querypal-db-user` | Cloud SQL PostgreSQL username |
+| `querypal-db-pass` | Cloud SQL PostgreSQL password |
+
+---
+
+## Terraform
+
+Cloud infrastructure is managed by Terraform in `terraform/`. The CI pipeline owns image builds and Cloud Run deployments; Terraform owns everything underneath.
+
+| Resource | Owner |
+|---|---|
+| VPC connector | Terraform |
+| Secret Manager secrets | Terraform |
+| Cloud Run service account + IAM | Terraform |
+| Cloud SQL instance & database | Terraform (imported existing) |
+| Cloud Run services | CI pipeline |
+| Docker images | CI pipeline |
+
+### First-time setup
+
+```bash
+cd terraform
+cp terraform.tfvars.example terraform.tfvars
+terraform init
+./import.sh      # import existing Cloud SQL — no data migration needed
+terraform apply
+```
+
+After apply, populate Secret Manager before triggering any deployment:
+
+```bash
+for SECRET_ID in querypal-azure-tenant-id querypal-azure-client-id querypal-azure-client-secret querypal-gemini-api-key querypal-db-user querypal-db-pass; do
+  echo -n "Enter value for ${SECRET_ID}: "
+  read -rs VALUE && echo
+  echo -n "${VALUE}" | gcloud secrets versions add "${SECRET_ID}" --data-file=-
+done
+```
+
+---
+
+## CI/CD Pipeline
+
+Pushes to the `production` branch (or manual `workflow_dispatch`) trigger `.github/workflows/google-cloudrun-docker.yml`.
+
+```mermaid
+flowchart LR
+    Push(["push to production"]) --> Auth
+
+    subgraph gha["GitHub Actions"]
+        Auth["Authenticate\nWorkload Identity Federation"]
+        Auth --> BuildBE["Build & push\nbackend image"]
+        Auth --> BuildFE["Build & push\nfrontend image"]
+        BuildBE --> DeployBE["Deploy backend\n--ingress=internal\n--set-secrets\n--vpc-connector"]
+        BuildFE --> DeployFE
+        DeployBE -- "backend URL" --> DeployFE["Deploy frontend\nBACKEND_URL=internal URL\n--vpc-connector"]
+    end
+
+    subgraph gcp["GCP"]
+        SM[("Secret Manager\nfetch at startup")]
+    end
+
+    DeployBE --> SM
+    DeployFE --> Done(["✅ Live"])
+```
+
+Authentication uses Workload Identity Federation — no long-lived service account keys are stored in GitHub. The `querypal-cloudrun-sa` service account holds only the permissions it needs: `secretmanager.secretAccessor`, `cloudsql.client`, and `vpcaccess.user`.

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -10,9 +10,9 @@ resource "google_sql_database_instance" "querypal_db" {
     tier = "db-f1-micro"
 
     backup_configuration {
-      enabled                        = true
-      start_time                     = "02:00"
-      point_in_time_recovery_enabled = true
+      enabled                        = false
+      start_time                     = "03:00"
+      point_in_time_recovery_enabled = false
       transaction_log_retention_days = 7
     }
 


### PR DESCRIPTION
## Summary

- Aligns `terraform/database.tf` backup configuration with the actual Cloud SQL instance state (backup was disabled in prod; the config had it enabled, which would cause a spurious diff on every plan)
- Splits the README into focused `docs/` files to reduce length and improve navigability

## Changes

**`terraform/database.tf`** — backup config corrected to match real instance:
- `enabled: true → false`
- `start_time: "02:00" → "03:00"`
- `point_in_time_recovery_enabled: true → false`

**`docs/`** — new files extracted from README:
- `ARCHITECTURE.md` — BFF pattern, auth flow, ReAct agent loop, security model
- `INFRASTRUCTURE.md` — Cloud topology, network security, Secret Manager, Terraform setup, CI/CD
- `AZURE_SETUP.md` — Entra ID app registrations, Cosmos DB permissions, frontend auth config
- `DEVELOPMENT.md` — local setup, testing commands, code style

**`README.md`** — trimmed to a lean landing page (~60 lines) with a docs reference table.

## Test plan

- [ ] `terraform plan` shows no changes on Cloud SQL (backup config aligned)
- [ ] README links resolve correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)