### PR TITLE
feat: QueryArgus data-quality integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
       env:
         GEMINI_API_KEY: "dummy-key-for-tests"
       run: |
-        PYTHONPATH=. pytest --cov=. --cov-report=term-missing --cov-report=xml --verbose
+        # Skip queryargus submodule tests: they need extras (azure-*, typer)
+        # that we deliberately don't install via `pip install --no-deps`.
+        PYTHONPATH=. pytest --ignore=queryargus --cov=. --cov-report=term-missing --cov-report=xml --verbose
         
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+      with:
+        submodules: recursive
+
     - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
@@ -34,6 +36,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        # queryargus (submodule) installed with --no-deps; its google-genai<1 pin
+        # conflicts with langchain-google-genai. 1.x API is compatible.
+        pip install --no-deps -e ./queryargus
         
     - name: Lint with flake8
       working-directory: ./backend
@@ -70,7 +75,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+      with:
+        submodules: recursive
+
     - name: Set up Node.js 20
       uses: actions/setup-node@v4
       with:
@@ -103,7 +110,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+      with:
+        submodules: recursive
+
     - name: Set up Node.js 20
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/google-cloudrun-docker.yml
+++ b/.github/workflows/google-cloudrun-docker.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # actions/checkout@v4
+        with:
+          submodules: recursive
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ DESIGN_HANDBOOK.md
 
 # virtual environment
 .venv/
+
+# HITL experiment artifacts (lives on experiment/hitl-* branches)
+results/
+backend/experiments/

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ CLAUDE.md
 .claude/settings.local.json
 HANDOFF.md
 DESIGN_HANDBOOK.md
+
+# virtual environment
+.venv/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "backend/queryargus"]
+	path = backend/queryargus
+	url = https://github.com/ChingEnLin/QueryArgus
+	branch = dev

--- a/backend/.flake8
+++ b/backend/.flake8
@@ -7,6 +7,7 @@ exclude =
     .pytest_cache,
     htmlcov,
     venv,
-    .venv
+    .venv,
+    queryargus
 per-file-ignores = 
     __init__.py:F401

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,8 +4,10 @@ FROM python:3.12-slim
 WORKDIR /app/backend
 
 COPY requirements.txt .
+COPY queryargus ./queryargus
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir --no-deps -e ./queryargus
 
 COPY . .
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Backend Dockerfile
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /app/backend
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,21 @@
 import os
+from contextlib import asynccontextmanager
+
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from routes import query, azure, system, user_queries, data_documents, audit, argus
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    from services.argus_store import get_report_store
+
+    get_report_store()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 # Configure CORS origins based on environment
 # Check for production indicators

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,7 @@ import os
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routes import query, azure, system, user_queries, data_documents, audit
+from routes import query, azure, system, user_queries, data_documents, audit, argus
 
 app = FastAPI()
 
@@ -56,6 +56,7 @@ app.include_router(system.router, prefix="/system", tags=["System"])
 app.include_router(user_queries.router, prefix="/user", tags=["User Queries"])
 app.include_router(data_documents.router, prefix="/data", tags=["Data Documents"])
 app.include_router(audit.router, prefix="/audit", tags=["Audit"])
+app.include_router(argus.router, prefix="/argus", tags=["Argus"])
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,5 +10,6 @@ exclude = '''
   | htmlcov
   | venv
   | \.venv
+  | queryargus
 )/
 '''

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -3,7 +3,7 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = 
+addopts =
     --strict-markers
     --strict-config
     --verbose
@@ -12,6 +12,7 @@ addopts =
     --cov-report=html
     --cov-exclude=tests/*
     --cov-exclude=queryargus/*
+    --ignore=queryargus
 markers =
     unit: Unit tests
     integration: Integration tests

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -11,6 +11,7 @@ addopts =
     --cov-report=term-missing
     --cov-report=html
     --cov-exclude=tests/*
+    --cov-exclude=queryargus/*
 markers =
     unit: Unit tests
     integration: Integration tests

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,10 @@
+# Note: the queryargus submodule (backend/queryargus) is installed separately
+# via `pip install --no-deps -e ./queryargus`. Its pyproject pins google-genai<1,
+# which conflicts with langchain-google-genai (needs >=1.65). The 1.x client API
+# is compatible — we install --no-deps so the bound is ignored.
 cachetools
 fastapi
-google-genai
+google-genai>=1.65.0,<2
 uvicorn
 pydantic
 python-dotenv

--- a/backend/routes/argus.py
+++ b/backend/routes/argus.py
@@ -360,6 +360,12 @@ async def _execute_job(
         report.duration_seconds,
     )
 
+    # Apply diff against prior run before persisting so raw_report carries
+    # previous_run_id/new_findings/resolved_findings. Upstream's CLI does this
+    # in cli/main.py; the agent itself does not.
+    if previous is not None:
+        report = report.diff_against(previous)
+
     if store is not None:
         try:
             await run_in_threadpool(store.save, report)
@@ -473,28 +479,46 @@ async def get_report(report_id: str, authorization: str = Header(...)):
     except ValueError:
         raise HTTPException(status_code=404, detail="Report not found")
 
-    report = await run_in_threadpool(store.get, report_uuid)
+    async def _resolve_access() -> list[str]:
+        try:
+            access_token = await run_in_threadpool(exchange_token_obo, user_token)
+        except Exception as exc:
+            logger.exception("argus get_report auth failed")
+            raise HTTPException(status_code=502, detail=f"Azure auth failed: {exc}")
+        return await run_in_threadpool(_accessible_account_ids, access_token)
+
+    # Fan out the independent I/O: report lookup, created_by lookup, and the
+    # auth + ARM resource list all run concurrently. Previous-report lookup
+    # depends on `report` so it kicks off as soon as that returns.
+    report_task = asyncio.create_task(run_in_threadpool(store.get, report_uuid))
+    created_by_task = asyncio.create_task(
+        run_in_threadpool(fetch_report_created_by, str(report_uuid))
+    )
+    accessible_task = asyncio.create_task(_resolve_access())
+
+    report = await report_task
     if report is None:
+        created_by_task.cancel()
+        accessible_task.cancel()
         raise HTTPException(status_code=404, detail="Report not found")
 
-    try:
-        access_token = await run_in_threadpool(exchange_token_obo, user_token)
-    except Exception as exc:
-        logger.exception("argus get_report auth failed")
-        raise HTTPException(status_code=502, detail=f"Azure auth failed: {exc}")
+    previous_task = asyncio.create_task(
+        run_in_threadpool(
+            store.get_previous,
+            collection=report.collection,
+            database=report.database,
+            before=report.run_at,
+        )
+    )
 
-    accessible = await run_in_threadpool(_accessible_account_ids, access_token)
+    accessible = await accessible_task
     if report.cosmos_account not in accessible:
+        previous_task.cancel()
+        created_by_task.cancel()
         # 404, not 403 — don't leak existence of reports the caller cannot see
         raise HTTPException(status_code=404, detail="Report not found")
 
-    previous = await run_in_threadpool(
-        store.get_previous,
-        collection=report.collection,
-        database=report.database,
-        before=report.run_at,
-    )
-    created_by = await run_in_threadpool(fetch_report_created_by, str(report.id))
+    previous, created_by = await asyncio.gather(previous_task, created_by_task)
     # Resolved profile/model are not persisted yet — fall back to the report's
     # own model field and an unknown profile marker until Phase 2 lands.
     return JSONResponse(

--- a/backend/routes/argus.py
+++ b/backend/routes/argus.py
@@ -48,10 +48,17 @@ router = APIRouter()
 Profile = Literal["fast", "balanced", "thorough"]
 JobStatus = Literal["queued", "running", "done", "error"]
 
+# Upstream PROFILE_THOROUGH ships with judge_provider="openai"/judge_model="gpt-4o".
+# Only Gemini is wired up end-to-end in our deployment, so swap the default to
+# gemini-2.5-pro. Inline config_overrides from the UI still take precedence.
+_PROFILE_THOROUGH_GEMINI = PROFILE_THOROUGH.model_copy(
+    update={"judge_provider": "gemini", "judge_model": "gemini-2.5-pro"},
+)
+
 _PROFILES = {
     "fast": PROFILE_FAST,
     "balanced": PROFILE_BALANCED,
-    "thorough": PROFILE_THOROUGH,
+    "thorough": _PROFILE_THOROUGH_GEMINI,
 }
 
 _SEVERITY_UI = {
@@ -201,6 +208,15 @@ def _serialize_report(
         if report.overall_quality_score is not None
         else None
     )
+    run_eval = None
+    if report.run_evaluation is not None:
+        run_eval = {
+            "verdict": str(report.run_evaluation.verdict),
+            "score": report.run_evaluation.score,
+            "reason": report.run_evaluation.reason,
+            "critique": report.run_evaluation.critique,
+            "evaluated_by": report.run_evaluation.evaluated_by,
+        }
     return {
         "report_id": str(report.id),
         "collection": report.collection,
@@ -215,6 +231,7 @@ def _serialize_report(
         "model": model,
         "profile": profile,
         "quality_score": quality,
+        "run_evaluation": run_eval,
         "counts": counts,
         "diff": diff_counts,
         "findings": findings,
@@ -316,7 +333,33 @@ async def _execute_job(
             job["finished_at"] = datetime.now(timezone.utc).isoformat()
             return
         llm = GeminiClient(model=config.llm_model)
-        agent = ArgusAgent.from_config(config=config, llm=llm)
+        # Build a judge client when the evaluator config asks for a judge or
+        # composite gate. Only Gemini is wired up end-to-end in our deployment;
+        # `judge_provider` is validated by Pydantic but we ignore non-gemini
+        # values here and fall through to GeminiClient.
+        judge_llm = None
+        judge_model_name = None
+        eval_cfg = config.evaluation
+        needs_judge = any(
+            getattr(eval_cfg, gate) in ("judge", "composite")
+            for gate in ("action_evaluator", "finding_evaluator", "run_evaluator")
+        )
+        if needs_judge:
+            # Always route the judge through Gemini in our deployment. If the
+            # config carries a non-gemini model (e.g. upstream's gpt-4o default
+            # leaking through a stale saved profile), force a sane gemini model.
+            jm = eval_cfg.judge_model or ""
+            if not jm or "gemini" not in jm.lower():
+                judge_model_name = "gemini-2.5-pro"
+            else:
+                judge_model_name = jm
+            judge_llm = GeminiClient(model=judge_model_name)
+        agent = ArgusAgent.from_config(
+            config=config,
+            llm=llm,
+            judge_llm=judge_llm,
+            judge_model_name=judge_model_name,
+        )
 
         history = None
         previous: Optional[AuditReport] = None

--- a/backend/routes/argus.py
+++ b/backend/routes/argus.py
@@ -162,8 +162,14 @@ async def run_audit(req: AuditRequest, authorization: str = Header(...)):
         raise HTTPException(status_code=401, detail="Invalid token format")
 
     user_token = authorization.replace("Bearer ", "")
-    access_token = exchange_token_obo(user_token)
-    connection_string = get_connection_string(req.account_id, access_token)
+    try:
+        access_token = exchange_token_obo(user_token)
+        connection_string = get_connection_string(req.account_id, access_token)
+    except Exception as exc:
+        logger.exception(
+            "argus auth/connection-string failed account=%s", req.account_id
+        )
+        raise HTTPException(status_code=502, detail=f"Azure auth failed: {exc}")
 
     connection = CosmosConnection.from_connection_string(
         connection_string=connection_string,

--- a/backend/routes/argus.py
+++ b/backend/routes/argus.py
@@ -251,6 +251,14 @@ def _evict_old_jobs() -> None:
         _JOBS.pop(jid, None)
 
 
+def _queue_has_capacity() -> bool:
+    """True when a new job can be accepted after eviction. Protects against a
+    stuck queue where every slot is held by a running job and no terminal jobs
+    can be evicted."""
+    _evict_old_jobs()
+    return len(_JOBS) < _MAX_JOBS
+
+
 def _accessible_account_ids(access_token: str) -> list[str]:
     """Cosmos accounts (full ARM resource IDs) visible to the caller."""
     try:
@@ -439,8 +447,13 @@ async def run_audit(req: AuditRequest, authorization: str = Header(...)):
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid token format")
 
-    user_token = authorization.replace("Bearer ", "")
+    user_token = authorization[7:]
     caller_email = extract_email_from_token(user_token)
+    if not _queue_has_capacity():
+        raise HTTPException(
+            status_code=429,
+            detail="Audit queue is full; please retry shortly.",
+        )
     job_id = uuid.uuid4().hex
     _JOBS[job_id] = {
         "status": "queued",
@@ -453,7 +466,6 @@ async def run_audit(req: AuditRequest, authorization: str = Header(...)):
         "profile": req.profile,
         "created_by": caller_email,
     }
-    _evict_old_jobs()
     asyncio.create_task(_execute_job(job_id, req, user_token, caller_email))
     return JSONResponse(
         status_code=202,
@@ -462,9 +474,16 @@ async def run_audit(req: AuditRequest, authorization: str = Header(...)):
 
 
 @router.get("/runs/{job_id}")
-async def get_run(job_id: str):
+async def get_run(job_id: str, authorization: str = Header(...)):
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid token format")
+    caller_email = extract_email_from_token(authorization[7:])
     job = _JOBS.get(job_id)
     if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    # Scope job-status reads to the caller who created the job. Returning 404
+    # (not 403) avoids leaking job existence to other tenants.
+    if job.get("created_by") and job["created_by"] != caller_email:
         raise HTTPException(status_code=404, detail="Job not found")
     return JSONResponse(
         content={
@@ -491,7 +510,7 @@ async def list_runs(
 ):
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid token format")
-    user_token = authorization.replace("Bearer ", "")
+    user_token = authorization[7:]
     try:
         access_token = await run_in_threadpool(exchange_token_obo, user_token)
     except Exception as exc:
@@ -517,7 +536,7 @@ async def list_runs(
 async def get_report(report_id: str, authorization: str = Header(...)):
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid token format")
-    user_token = authorization.replace("Bearer ", "")
+    user_token = authorization[7:]
     store = get_report_store()
     if store is None:
         raise HTTPException(status_code=404, detail="Report not found")
@@ -594,7 +613,7 @@ class ProfileCreate(BaseModel):
 def _require_caller_email(authorization: str) -> str:
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid token format")
-    email = extract_email_from_token(authorization.replace("Bearer ", ""))
+    email = extract_email_from_token(authorization[7:])
     if not email:
         raise HTTPException(status_code=401, detail="Caller identity missing")
     return email
@@ -668,7 +687,7 @@ async def rate_finding(
     ``GET /argus/reports/{id}`` reflects it without an extra join.
     """
     email = _require_caller_email(authorization)
-    user_token = authorization.replace("Bearer ", "")
+    user_token = authorization[7:]
     store = get_report_store()
     if store is None:
         raise HTTPException(status_code=404, detail="Report not found")

--- a/backend/routes/argus.py
+++ b/backend/routes/argus.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from fastapi import APIRouter, Header, HTTPException
+from fastapi.concurrency import run_in_threadpool
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from queryargus.agent.loop import ArgusAgent
+from queryargus.llm.gemini import GeminiClient
+from queryargus.models.config import (
+    PROFILE_BALANCED,
+    PROFILE_FAST,
+    PROFILE_THOROUGH,
+    ArgusConfig,
+)
+from queryargus.models.connection import CosmosConnection
+from queryargus.models.finding import Finding
+from queryargus.models.report import AuditReport
+from services.azure_auth import exchange_token_obo
+from services.azure_cosmos_resources import get_connection_string
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+Profile = Literal["fast", "balanced", "thorough"]
+
+_PROFILES = {
+    "fast": PROFILE_FAST,
+    "balanced": PROFILE_BALANCED,
+    "thorough": PROFILE_THOROUGH,
+}
+
+# Maps QueryArgus's 4-level severity to the design's 3-level UI bucket.
+_SEVERITY_UI = {
+    "critical": "critical",
+    "high": "warning",
+    "medium": "info",
+    "low": "info",
+}
+
+
+class AuditRequest(BaseModel):
+    account_id: str
+    database: str
+    collection: str
+    max_iterations: int = 20
+    profile: Profile = "fast"
+
+
+def _summary(description: str) -> str:
+    first = description.strip().split("\n", 1)[0]
+    period = first.find(". ")
+    return first[: period + 1] if period != -1 else first
+
+
+def _finding_trace(report: AuditReport, finding: Finding) -> str:
+    """Slice run_trace down to actions that touched this finding's field.
+
+    Heuristic: include any action whose action_input mentions the field path,
+    plus the write_finding action that produced this finding (if present).
+    Lines are formatted as ``iter N · action`` followed by the reasoning.
+    """
+    field = finding.field
+    lines: list[str] = []
+    for i, action in enumerate(report.run_trace, start=1):
+        inp_repr = repr(action.action_input)
+        is_write = action.action == "write_finding" and field in inp_repr
+        if field not in inp_repr and not is_write:
+            continue
+        lines.append(f"iter {i} · {action.action}")
+        lines.append(f"reason: {action.reasoning}")
+        if is_write:
+            lines.append("finding gate: PASS")
+    return "\n".join(lines)
+
+
+def _serialize_finding(
+    finding: Finding,
+    report: AuditReport,
+    new_keys: set[tuple[str, str]],
+    regressed: set[str],
+) -> dict[str, Any]:
+    severity_ui = _SEVERITY_UI.get(finding.severity.value, "info")
+    diff: str
+    if (finding.field, finding.category) in new_keys:
+        diff = "new"
+    elif finding.field in regressed:
+        diff = "regressed"
+    else:
+        diff = "existing"
+    total = report.collection_size or report.documents_sampled or finding.affected_count
+    return {
+        "id": str(finding.id),
+        "severity": severity_ui,
+        "field": finding.field,
+        "category": finding.category,
+        "summary": _summary(finding.description),
+        "description": finding.description,
+        "evidence": finding.evidence_query,
+        "affected": finding.affected_count,
+        "total": total,
+        "affected_pct": round(finding.affected_pct * 100, 1),
+        "diff": diff,
+        "trace": _finding_trace(report, finding),
+    }
+
+
+def _serialize_report(
+    report: AuditReport,
+    *,
+    model: str,
+    profile: Profile,
+) -> dict[str, Any]:
+    new_keys = {(f.field, f.category) for f in report.new_findings}
+    regressed = set(report.regressed_fields)
+
+    findings = [
+        _serialize_finding(f, report, new_keys, regressed) for f in report.findings
+    ]
+    counts = {
+        "critical": sum(1 for f in findings if f["severity"] == "critical"),
+        "warning": sum(1 for f in findings if f["severity"] == "warning"),
+        "info": sum(1 for f in findings if f["severity"] == "info"),
+        "dismissed": len(report.dismissed_findings),
+    }
+    quality = (
+        round(report.overall_quality_score * 100)
+        if report.overall_quality_score is not None
+        else None
+    )
+    return {
+        "report_id": str(report.id),
+        "collection": report.collection,
+        "database": report.database,
+        "cosmos_account": report.cosmos_account,
+        "run_at": report.run_at.isoformat(),
+        "duration_seconds": report.duration_seconds,
+        "documents_sampled": report.documents_sampled,
+        "collection_size": report.collection_size,
+        "iterations": len(report.run_trace),
+        "total_tokens": report.total_input_tokens + report.total_output_tokens,
+        "model": model,
+        "profile": profile,
+        "quality_score": quality,
+        "counts": counts,
+        "diff": {
+            "new": len(report.new_findings),
+            "resolved": len(report.resolved_findings),
+            "regressed": len(report.regressed_fields),
+        },
+        "findings": findings,
+        "history": None,  # populated once ReportStore is wired
+    }
+
+
+@router.post("/run")
+async def run_audit(req: AuditRequest, authorization: str = Header(...)):
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid token format")
+
+    user_token = authorization.replace("Bearer ", "")
+    access_token = exchange_token_obo(user_token)
+    connection_string = get_connection_string(req.account_id, access_token)
+
+    connection = CosmosConnection.from_connection_string(
+        connection_string=connection_string,
+        cosmos_account=req.account_id,
+        database=req.database,
+    )
+    config = ArgusConfig(
+        max_iterations=req.max_iterations,
+        evaluation=_PROFILES[req.profile],
+    )
+    llm = GeminiClient(model=config.llm_model)
+    agent = ArgusAgent.with_defaults(config=config, llm=llm)
+
+    logger.info(
+        "argus run start collection=%s database=%s profile=%s",
+        req.collection,
+        req.database,
+        req.profile,
+    )
+    try:
+        report = await run_in_threadpool(agent.run, connection, req.collection)
+    except Exception as exc:
+        logger.exception("argus run failed collection=%s", req.collection)
+        return JSONResponse(status_code=500, content={"detail": str(exc)})
+
+    logger.info(
+        "argus run done collection=%s findings=%d duration=%.2fs",
+        req.collection,
+        len(report.findings),
+        report.duration_seconds,
+    )
+    return JSONResponse(
+        content=_serialize_report(report, model=config.llm_model, profile=req.profile)
+    )

--- a/backend/routes/argus.py
+++ b/backend/routes/argus.py
@@ -22,6 +22,13 @@ from queryargus.models.config import (
 from queryargus.models.connection import CosmosConnection
 from queryargus.models.finding import Finding
 from queryargus.models.report import AuditReport
+from services.argus_profiles_service import (
+    ProfileNameConflict,
+    create_profile,
+    delete_profile,
+    get_profile_for_user,
+    list_profiles,
+)
 from services.argus_store import (
     fetch_report_created_by,
     fetch_run_summaries,
@@ -63,6 +70,16 @@ class AuditRequest(BaseModel):
     collection: str
     max_iterations: int = 20
     profile: Profile = "fast"
+    # Tier 2 overrides — merged onto ArgusConfig before the run.
+    # Unknown keys raise 400 via Pydantic's extra="forbid" on ArgusConfig.
+    argus_overrides: Optional[dict[str, Any]] = None
+    # Tier 3 — merged onto EvaluatorConfig. Wired here so the request
+    # contract is stable across phases even before the UI exposes it.
+    config_overrides: Optional[dict[str, Any]] = None
+    # Tier 4 — saved profile id. When set, the profile's overrides are
+    # resolved server-side; inline overrides above take precedence so the
+    # user can tweak a saved profile for a one-off run.
+    saved_profile_id: Optional[str] = None
 
 
 def _summary(description: str) -> str:
@@ -243,16 +260,57 @@ async def _execute_job(
         return
 
     store = get_report_store()
+
+    # Resolve saved profile (Tier 4): inline overrides win, so a user can tweak
+    # a saved profile for a single run without mutating the stored profile.
+    saved_evaluator: dict[str, Any] = {}
+    saved_argus: dict[str, Any] = {}
+    if req.saved_profile_id and caller_email:
+        profile_row = await run_in_threadpool(
+            get_profile_for_user,
+            profile_id=req.saved_profile_id,
+            user_email=caller_email,
+        )
+        if profile_row is None:
+            job["status"] = "error"
+            job["error"] = "Saved profile not found"
+            job["finished_at"] = datetime.now(timezone.utc).isoformat()
+            return
+        saved_evaluator = profile_row.get("evaluator_overrides") or {}
+        saved_argus = profile_row.get("argus_overrides") or {}
+
     try:
         connection = CosmosConnection.from_connection_string(
             connection_string=connection_string,
             cosmos_account=req.account_id,
             database=req.database,
         )
-        config = ArgusConfig(
-            max_iterations=req.max_iterations,
-            evaluation=_PROFILES[req.profile],
-        )
+        evaluation = _PROFILES[req.profile]
+        merged_eval = {**saved_evaluator, **(req.config_overrides or {})}
+        merged_argus = {**saved_argus, **(req.argus_overrides or {})}
+        if merged_eval:
+            try:
+                evaluation = evaluation.model_copy(update=merged_eval)
+                # Re-validate so threshold ranges + Literal fields are enforced.
+                evaluation = evaluation.__class__(**evaluation.model_dump())
+            except Exception as exc:
+                job["status"] = "error"
+                job["error"] = f"Invalid evaluator override: {exc}"
+                job["finished_at"] = datetime.now(timezone.utc).isoformat()
+                return
+        argus_kwargs: dict[str, Any] = {
+            "max_iterations": req.max_iterations,
+            "evaluation": evaluation,
+        }
+        if merged_argus:
+            argus_kwargs.update(merged_argus)
+        try:
+            config = ArgusConfig(**argus_kwargs)
+        except Exception as exc:
+            job["status"] = "error"
+            job["error"] = f"Invalid argus override: {exc}"
+            job["finished_at"] = datetime.now(timezone.utc).isoformat()
+            return
         llm = GeminiClient(model=config.llm_model)
         agent = ArgusAgent.from_config(config=config, llm=llm)
 
@@ -448,3 +506,68 @@ async def get_report(report_id: str, authorization: str = Header(...)):
             created_by=created_by,
         )
     )
+
+
+# ---------------------------------------------------------------------------
+# Tier 4 — saved custom profiles
+# ---------------------------------------------------------------------------
+
+
+class ProfileCreate(BaseModel):
+    name: str
+    base_profile: Profile
+    evaluator_overrides: dict[str, Any] = {}
+    argus_overrides: dict[str, Any] = {}
+
+
+def _require_caller_email(authorization: str) -> str:
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid token format")
+    email = extract_email_from_token(authorization.replace("Bearer ", ""))
+    if not email:
+        raise HTTPException(status_code=401, detail="Caller identity missing")
+    return email
+
+
+@router.get("/profiles")
+async def list_saved_profiles(authorization: str = Header(...)):
+    email = _require_caller_email(authorization)
+    rows = await run_in_threadpool(list_profiles, email)
+    return JSONResponse(content={"profiles": rows})
+
+
+@router.post("/profiles")
+async def create_saved_profile(
+    payload: ProfileCreate, authorization: str = Header(...)
+):
+    email = _require_caller_email(authorization)
+    name = payload.name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="Name is required")
+    try:
+        row = await run_in_threadpool(
+            create_profile,
+            user_email=email,
+            name=name,
+            base_profile=payload.base_profile,
+            evaluator_overrides=payload.evaluator_overrides,
+            argus_overrides=payload.argus_overrides,
+        )
+    except ProfileNameConflict:
+        raise HTTPException(
+            status_code=409, detail="A profile with that name already exists"
+        )
+    if row is None:
+        raise HTTPException(status_code=500, detail="Failed to create profile")
+    return JSONResponse(status_code=201, content=row)
+
+
+@router.delete("/profiles/{profile_id}")
+async def delete_saved_profile(profile_id: str, authorization: str = Header(...)):
+    email = _require_caller_email(authorization)
+    ok = await run_in_threadpool(
+        delete_profile, profile_id=profile_id, user_email=email
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return JSONResponse(content={"deleted": True})

--- a/backend/routes/argus.py
+++ b/backend/routes/argus.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Any, Literal
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Literal, Optional
 
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Header, HTTPException, Query
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
@@ -19,13 +22,23 @@ from queryargus.models.config import (
 from queryargus.models.connection import CosmosConnection
 from queryargus.models.finding import Finding
 from queryargus.models.report import AuditReport
-from services.azure_auth import exchange_token_obo
-from services.azure_cosmos_resources import get_connection_string
+from services.argus_store import (
+    fetch_report_created_by,
+    fetch_run_summaries,
+    get_report_store,
+    set_report_created_by,
+)
+from services.azure_auth import exchange_token_obo, extract_email_from_token
+from services.azure_cosmos_resources import (
+    get_connection_string,
+    list_cosmos_resources,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
 Profile = Literal["fast", "balanced", "thorough"]
+JobStatus = Literal["queued", "running", "done", "error"]
 
 _PROFILES = {
     "fast": PROFILE_FAST,
@@ -33,13 +46,15 @@ _PROFILES = {
     "thorough": PROFILE_THOROUGH,
 }
 
-# Maps QueryArgus's 4-level severity to the design's 3-level UI bucket.
 _SEVERITY_UI = {
     "critical": "critical",
     "high": "warning",
     "medium": "info",
     "low": "info",
 }
+
+_JOBS: dict[str, dict[str, Any]] = {}
+_MAX_JOBS = 50
 
 
 class AuditRequest(BaseModel):
@@ -57,12 +72,6 @@ def _summary(description: str) -> str:
 
 
 def _finding_trace(report: AuditReport, finding: Finding) -> str:
-    """Slice run_trace down to actions that touched this finding's field.
-
-    Heuristic: include any action whose action_input mentions the field path,
-    plus the write_finding action that produced this finding (if present).
-    Lines are formatted as ``iter N · action`` followed by the reasoning.
-    """
     field = finding.field
     lines: list[str] = []
     for i, action in enumerate(report.run_trace, start=1):
@@ -75,6 +84,46 @@ def _finding_trace(report: AuditReport, finding: Finding) -> str:
         if is_write:
             lines.append("finding gate: PASS")
     return "\n".join(lines)
+
+
+def _compute_diff(
+    current: AuditReport, previous: Optional[AuditReport]
+) -> tuple[set[tuple[str, str]], set[str], dict[str, int]]:
+    """Return (new_keys, regressed_fields, counts) by comparing against ``previous``.
+
+    When ``previous`` is None we fall back to the report's own diff fields (zero
+    when no prior run existed at agent runtime).
+    """
+    if previous is None:
+        new_keys = {(f.field, f.category) for f in current.new_findings}
+        regressed = set(current.regressed_fields)
+        counts = {
+            "new": len(current.new_findings),
+            "resolved": len(current.resolved_findings),
+            "regressed": len(current.regressed_fields),
+        }
+        return new_keys, regressed, counts
+
+    severity_order = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+    prev_by_key = {(f.field, f.category): f for f in previous.findings}
+    curr_by_key = {(f.field, f.category): f for f in current.findings}
+    new_keys = set(curr_by_key) - set(prev_by_key)
+    resolved = set(prev_by_key) - set(curr_by_key)
+    regressed: set[str] = set()
+    for key, f in curr_by_key.items():
+        prev = prev_by_key.get(key)
+        if prev is None:
+            continue
+        if severity_order.get(f.severity.value, 0) > severity_order.get(
+            prev.severity.value, 0
+        ):
+            regressed.add(f.field)
+    counts = {
+        "new": len(new_keys),
+        "resolved": len(resolved),
+        "regressed": len(regressed),
+    }
+    return new_keys, regressed, counts
 
 
 def _serialize_finding(
@@ -113,10 +162,10 @@ def _serialize_report(
     *,
     model: str,
     profile: Profile,
+    previous: Optional[AuditReport] = None,
+    created_by: Optional[str] = None,
 ) -> dict[str, Any]:
-    new_keys = {(f.field, f.category) for f in report.new_findings}
-    regressed = set(report.regressed_fields)
-
+    new_keys, regressed, diff_counts = _compute_diff(report, previous)
     findings = [
         _serialize_finding(f, report, new_keys, regressed) for f in report.findings
     ]
@@ -146,14 +195,132 @@ def _serialize_report(
         "profile": profile,
         "quality_score": quality,
         "counts": counts,
-        "diff": {
-            "new": len(report.new_findings),
-            "resolved": len(report.resolved_findings),
-            "regressed": len(report.regressed_fields),
-        },
+        "diff": diff_counts,
         "findings": findings,
-        "history": None,  # populated once ReportStore is wired
+        "created_by": created_by,
+        "history": None,
     }
+
+
+def _evict_old_jobs() -> None:
+    if len(_JOBS) <= _MAX_JOBS:
+        return
+    terminal = [
+        (jid, j) for jid, j in _JOBS.items() if j["status"] in ("done", "error")
+    ]
+    terminal.sort(key=lambda kv: kv[1].get("finished_at") or kv[1]["started_at"])
+    for jid, _ in terminal[: len(_JOBS) - _MAX_JOBS]:
+        _JOBS.pop(jid, None)
+
+
+def _accessible_account_ids(access_token: str) -> list[str]:
+    """Cosmos accounts (full ARM resource IDs) visible to the caller."""
+    try:
+        resources = list_cosmos_resources(access_token)
+    except Exception:
+        logger.exception("failed to list cosmos resources for caller")
+        return []
+    return [r["id"] for r in resources if r.get("id")]
+
+
+async def _execute_job(
+    job_id: str, req: AuditRequest, user_token: str, caller_email: Optional[str]
+) -> None:
+    job = _JOBS[job_id]
+    job["status"] = "running"
+    try:
+        access_token = await run_in_threadpool(exchange_token_obo, user_token)
+        connection_string = await run_in_threadpool(
+            get_connection_string, req.account_id, access_token
+        )
+    except Exception as exc:
+        logger.exception(
+            "argus auth/connection-string failed account=%s", req.account_id
+        )
+        job["status"] = "error"
+        job["error"] = f"Azure auth failed: {exc}"
+        job["finished_at"] = datetime.now(timezone.utc).isoformat()
+        return
+
+    store = get_report_store()
+    try:
+        connection = CosmosConnection.from_connection_string(
+            connection_string=connection_string,
+            cosmos_account=req.account_id,
+            database=req.database,
+        )
+        config = ArgusConfig(
+            max_iterations=req.max_iterations,
+            evaluation=_PROFILES[req.profile],
+        )
+        llm = GeminiClient(model=config.llm_model)
+        agent = ArgusAgent.from_config(config=config, llm=llm)
+
+        history = None
+        previous: Optional[AuditReport] = None
+        if store is not None:
+            try:
+                history = await run_in_threadpool(
+                    store.load_history,
+                    collection=req.collection,
+                    database=req.database,
+                    limit=5,
+                )
+                previous = await run_in_threadpool(
+                    store.get_previous,
+                    collection=req.collection,
+                    database=req.database,
+                )
+            except Exception:
+                logger.exception(
+                    "failed to load history for collection=%s", req.collection
+                )
+
+        logger.info(
+            "argus run start job=%s collection=%s profile=%s",
+            job_id,
+            req.collection,
+            req.profile,
+        )
+        report = await run_in_threadpool(
+            agent.run, connection, req.collection, history=history
+        )
+    except Exception as exc:
+        logger.exception(
+            "argus run failed job=%s collection=%s", job_id, req.collection
+        )
+        job["status"] = "error"
+        job["error"] = str(exc)
+        job["finished_at"] = datetime.now(timezone.utc).isoformat()
+        return
+
+    logger.info(
+        "argus run done job=%s collection=%s findings=%d duration=%.2fs",
+        job_id,
+        req.collection,
+        len(report.findings),
+        report.duration_seconds,
+    )
+
+    if store is not None:
+        try:
+            await run_in_threadpool(store.save, report)
+            if caller_email:
+                await run_in_threadpool(
+                    set_report_created_by, str(report.id), caller_email
+                )
+        except Exception:
+            logger.exception("failed to persist argus report id=%s", report.id)
+
+    job["status"] = "done"
+    job["report"] = _serialize_report(
+        report,
+        model=config.llm_model,
+        profile=req.profile,
+        previous=previous,
+        created_by=caller_email,
+    )
+    job["finished_at"] = datetime.now(timezone.utc).isoformat()
 
 
 @router.post("/run")
@@ -162,45 +329,122 @@ async def run_audit(req: AuditRequest, authorization: str = Header(...)):
         raise HTTPException(status_code=401, detail="Invalid token format")
 
     user_token = authorization.replace("Bearer ", "")
+    caller_email = extract_email_from_token(user_token)
+    job_id = uuid.uuid4().hex
+    _JOBS[job_id] = {
+        "status": "queued",
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "finished_at": None,
+        "report": None,
+        "error": None,
+        "collection": req.collection,
+        "database": req.database,
+        "profile": req.profile,
+        "created_by": caller_email,
+    }
+    _evict_old_jobs()
+    asyncio.create_task(_execute_job(job_id, req, user_token, caller_email))
+    return JSONResponse(
+        status_code=202,
+        content={"job_id": job_id, "status": "queued"},
+    )
+
+
+@router.get("/runs/{job_id}")
+async def get_run(job_id: str):
+    job = _JOBS.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return JSONResponse(
+        content={
+            "job_id": job_id,
+            "status": job["status"],
+            "started_at": job["started_at"],
+            "finished_at": job["finished_at"],
+            "collection": job["collection"],
+            "database": job["database"],
+            "profile": job["profile"],
+            "report": job["report"],
+            "error": job["error"],
+        }
+    )
+
+
+@router.get("/runs")
+async def list_runs(
+    authorization: str = Header(...),
+    account_id: Optional[str] = Query(default=None),
+    database: Optional[str] = Query(default=None),
+    collection: Optional[str] = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+):
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid token format")
+    user_token = authorization.replace("Bearer ", "")
     try:
-        access_token = exchange_token_obo(user_token)
-        connection_string = get_connection_string(req.account_id, access_token)
+        access_token = await run_in_threadpool(exchange_token_obo, user_token)
     except Exception as exc:
-        logger.exception(
-            "argus auth/connection-string failed account=%s", req.account_id
-        )
+        logger.exception("argus list_runs auth failed")
         raise HTTPException(status_code=502, detail=f"Azure auth failed: {exc}")
 
-    connection = CosmosConnection.from_connection_string(
-        connection_string=connection_string,
-        cosmos_account=req.account_id,
-        database=req.database,
+    accessible = await run_in_threadpool(_accessible_account_ids, access_token)
+    if account_id is not None:
+        accessible = [a for a in accessible if a == account_id]
+    if not accessible:
+        return JSONResponse(content={"runs": []})
+    rows = await run_in_threadpool(
+        fetch_run_summaries,
+        cosmos_accounts=accessible,
+        database=database,
+        collection=collection,
+        limit=limit,
     )
-    config = ArgusConfig(
-        max_iterations=req.max_iterations,
-        evaluation=_PROFILES[req.profile],
-    )
-    llm = GeminiClient(model=config.llm_model)
-    agent = ArgusAgent.with_defaults(config=config, llm=llm)
+    return JSONResponse(content={"runs": rows})
 
-    logger.info(
-        "argus run start collection=%s database=%s profile=%s",
-        req.collection,
-        req.database,
-        req.profile,
-    )
+
+@router.get("/reports/{report_id}")
+async def get_report(report_id: str, authorization: str = Header(...)):
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid token format")
+    user_token = authorization.replace("Bearer ", "")
+    store = get_report_store()
+    if store is None:
+        raise HTTPException(status_code=404, detail="Report not found")
     try:
-        report = await run_in_threadpool(agent.run, connection, req.collection)
-    except Exception as exc:
-        logger.exception("argus run failed collection=%s", req.collection)
-        return JSONResponse(status_code=500, content={"detail": str(exc)})
+        report_uuid = uuid.UUID(report_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Report not found")
 
-    logger.info(
-        "argus run done collection=%s findings=%d duration=%.2fs",
-        req.collection,
-        len(report.findings),
-        report.duration_seconds,
+    report = await run_in_threadpool(store.get, report_uuid)
+    if report is None:
+        raise HTTPException(status_code=404, detail="Report not found")
+
+    try:
+        access_token = await run_in_threadpool(exchange_token_obo, user_token)
+    except Exception as exc:
+        logger.exception("argus get_report auth failed")
+        raise HTTPException(status_code=502, detail=f"Azure auth failed: {exc}")
+
+    accessible = await run_in_threadpool(_accessible_account_ids, access_token)
+    if report.cosmos_account not in accessible:
+        # 404, not 403 — don't leak existence of reports the caller cannot see
+        raise HTTPException(status_code=404, detail="Report not found")
+
+    previous = await run_in_threadpool(
+        store.get_previous,
+        collection=report.collection,
+        database=report.database,
+        before=report.run_at,
     )
+    created_by = await run_in_threadpool(fetch_report_created_by, str(report.id))
+    # Resolved profile/model are not persisted yet — fall back to the report's
+    # own model field and an unknown profile marker until Phase 2 lands.
     return JSONResponse(
-        content=_serialize_report(report, model=config.llm_model, profile=req.profile)
+        content=_serialize_report(
+            report,
+            model="gemini-2.5-flash",
+            profile="balanced",
+            previous=previous,
+            created_by=created_by,
+        )
     )

--- a/backend/routes/argus.py
+++ b/backend/routes/argus.py
@@ -33,6 +33,7 @@ from services.argus_store import (
     fetch_report_created_by,
     fetch_run_summaries,
     get_report_store,
+    set_finding_rating,
     set_report_created_by,
 )
 from services.azure_auth import exchange_token_obo, extract_email_from_token
@@ -171,6 +172,9 @@ def _serialize_finding(
         "affected_pct": round(finding.affected_pct * 100, 1),
         "diff": diff,
         "trace": _finding_trace(report, finding),
+        # Arm A — surface the current verdict so the UI can render the
+        # rating buttons in the correct state. None when unrated.
+        "user_label": finding.user_label,
     }
 
 
@@ -595,3 +599,79 @@ async def delete_saved_profile(profile_id: str, authorization: str = Header(...)
     if not ok:
         raise HTTPException(status_code=404, detail="Profile not found")
     return JSONResponse(content={"deleted": True})
+
+
+# ---------------------------------------------------------------------------
+# Arm A — post-hoc finding rating
+# ---------------------------------------------------------------------------
+
+
+class FindingRating(BaseModel):
+    label: Literal["tp", "fp"]
+
+
+@router.post("/findings/{report_id}/{finding_id}/rate")
+async def rate_finding(
+    report_id: str,
+    finding_id: str,
+    payload: FindingRating,
+    authorization: str = Header(...),
+):
+    """Record a human verdict (TP / FP) on a single persisted finding.
+
+    The verdict is scoped by the caller's Cosmos-account access (same OBO check
+    as ``get_report``); cross-tenant attempts return 404 to avoid leaking
+    existence. The label is also written into ``raw_report`` JSONB so the next
+    ``GET /argus/reports/{id}`` reflects it without an extra join.
+    """
+    email = _require_caller_email(authorization)
+    user_token = authorization.replace("Bearer ", "")
+    store = get_report_store()
+    if store is None:
+        raise HTTPException(status_code=404, detail="Report not found")
+    try:
+        report_uuid = uuid.UUID(report_id)
+        finding_uuid = uuid.UUID(finding_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Report not found")
+
+    # Fan out report fetch and access-check; need both before touching storage.
+    report_task = asyncio.create_task(run_in_threadpool(store.get, report_uuid))
+
+    async def _resolve_access() -> list[str]:
+        try:
+            access_token = await run_in_threadpool(exchange_token_obo, user_token)
+        except Exception as exc:
+            logger.exception("argus rate_finding auth failed")
+            raise HTTPException(status_code=502, detail=f"Azure auth failed: {exc}")
+        return await run_in_threadpool(_accessible_account_ids, access_token)
+
+    accessible_task = asyncio.create_task(_resolve_access())
+
+    report = await report_task
+    if report is None:
+        accessible_task.cancel()
+        raise HTTPException(status_code=404, detail="Report not found")
+
+    accessible = await accessible_task
+    if report.cosmos_account not in accessible:
+        # 404, not 403 — symmetric with get_report's existence-leak guard.
+        raise HTTPException(status_code=404, detail="Report not found")
+
+    ok = await run_in_threadpool(
+        set_finding_rating,
+        report_id=str(report_uuid),
+        finding_id=str(finding_uuid),
+        label=payload.label,
+        rated_by=email,
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Finding not found")
+    return JSONResponse(
+        content={
+            "report_id": str(report_uuid),
+            "finding_id": str(finding_uuid),
+            "user_label": payload.label,
+            "rated_by": email,
+        }
+    )

--- a/backend/routes/query.py
+++ b/backend/routes/query.py
@@ -273,9 +273,7 @@ def list_models():
     try:
         client = genai.Client()
         available = {
-            m.name.replace("models/", "")
-            for m in client.models.list()
-            if m.name
+            m.name.replace("models/", "") for m in client.models.list() if m.name
         }
         filtered = [m for m in SUPPORTED_MODELS if m in available]
         # Fall back to the allowlist if the API listing is empty or filtered

--- a/backend/routes/query.py
+++ b/backend/routes/query.py
@@ -249,31 +249,38 @@ def evaluate_write(
     )
 
 
+# Curated allowlist of models we know work with our prompts, response_schema
+# usage, and tool-calling paths. Keep this short — every model here has been
+# manually verified against /nl2query, /analyze, /evaluate-write, and the
+# QueryArgus run path. Pro models route through thinking_config_for() so they
+# don't trip the "thinking_budget=0 invalid" error.
+SUPPORTED_MODELS = [
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+    "gemini-2.5-pro",
+    "gemini-2.0-flash",
+]
+
+
 @router.get("/models", response_model=List[str])
 def list_models():
     """
-    Returns available Gemini model IDs filtered to generative models.
-    Intentionally unauthenticated — model names are non-sensitive and
-    this endpoint is called on page load before auth completes.
+    Returns the intersection of our supported-model allowlist and the
+    models actually available to the configured API key. Intentionally
+    unauthenticated — model names are non-sensitive and this endpoint is
+    called on page load before auth completes.
     """
     try:
         client = genai.Client()
-        models = list(client.models.list())
-        model_ids = [
+        available = {
             m.name.replace("models/", "")
-            for m in models
+            for m in client.models.list()
             if m.name
-            and "gemini" in m.name.lower()
-            and hasattr(m, "supported_actions")
-            and "generateContent" in (m.supported_actions or [])
-        ]
-        if not model_ids:
-            # Fallback: return all gemini models if supported_actions is absent
-            model_ids = [
-                m.name.replace("models/", "")
-                for m in models
-                if m.name and "gemini" in m.name.lower()
-            ]
-        return sorted(set(model_ids))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to list models: {str(e)}")
+        }
+        filtered = [m for m in SUPPORTED_MODELS if m in available]
+        # Fall back to the allowlist if the API listing is empty or filtered
+        # nothing through (e.g. unexpected naming): better to show known-good
+        # options than an empty dropdown.
+        return filtered or SUPPORTED_MODELS
+    except Exception:
+        return SUPPORTED_MODELS

--- a/backend/services/analyze_service.py
+++ b/backend/services/analyze_service.py
@@ -2,6 +2,7 @@ import json
 from google import genai
 from google.genai import types
 from models.analyze import AnalyzeResponse
+from services.gemini_service import thinking_config_for
 
 
 def analyze_query_result(
@@ -23,7 +24,7 @@ Respond in JSON with keys: insight, chartType, chartData, chartOptions.
         model=model,
         contents=prompt,
         config=types.GenerateContentConfig(
-            thinking_config=types.ThinkingConfig(thinking_budget=0)
+            thinking_config=thinking_config_for(model)
         ),
     )
     # Try to extract JSON from the response

--- a/backend/services/analyze_service.py
+++ b/backend/services/analyze_service.py
@@ -23,9 +23,7 @@ Respond in JSON with keys: insight, chartType, chartData, chartOptions.
     response = client.models.generate_content(
         model=model,
         contents=prompt,
-        config=types.GenerateContentConfig(
-            thinking_config=thinking_config_for(model)
-        ),
+        config=types.GenerateContentConfig(thinking_config=thinking_config_for(model)),
     )
     # Try to extract JSON from the response
     try:

--- a/backend/services/argus_profiles_service.py
+++ b/backend/services/argus_profiles_service.py
@@ -1,0 +1,155 @@
+"""CRUD for per-user QueryArgus run profiles (Tier 4 — saved custom profiles)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any, Literal, Optional
+
+import psycopg2
+from psycopg2.errors import UniqueViolation
+
+from services.argus_store import _build_dsn
+
+logger = logging.getLogger(__name__)
+
+BaseProfile = Literal["fast", "balanced", "thorough"]
+
+
+def list_profiles(user_email: str) -> list[dict[str, Any]]:
+    dsn = _build_dsn()
+    if dsn is None:
+        return []
+    try:
+        with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, name, base_profile, evaluator_overrides, argus_overrides, created_at
+                FROM argus_profiles
+                WHERE user_email = %s
+                ORDER BY created_at DESC
+                """,
+                (user_email,),
+            )
+            rows = cur.fetchall()
+    except Exception:
+        logger.exception("failed to list profiles for %s", user_email)
+        return []
+    return [
+        {
+            "id": str(r[0]),
+            "name": r[1],
+            "base_profile": r[2],
+            "evaluator_overrides": r[3] or {},
+            "argus_overrides": r[4] or {},
+            "created_at": r[5].isoformat() if r[5] else None,
+        }
+        for r in rows
+    ]
+
+
+class ProfileNameConflict(Exception):
+    """Raised when (user_email, name) already exists."""
+
+
+def create_profile(
+    *,
+    user_email: str,
+    name: str,
+    base_profile: BaseProfile,
+    evaluator_overrides: dict[str, Any],
+    argus_overrides: dict[str, Any],
+) -> Optional[dict[str, Any]]:
+    dsn = _build_dsn()
+    if dsn is None:
+        return None
+    try:
+        with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO argus_profiles
+                    (user_email, name, base_profile, evaluator_overrides, argus_overrides)
+                VALUES (%s, %s, %s, %s::jsonb, %s::jsonb)
+                RETURNING id, created_at
+                """,
+                (
+                    user_email,
+                    name,
+                    base_profile,
+                    json.dumps(evaluator_overrides),
+                    json.dumps(argus_overrides),
+                ),
+            )
+            row = cur.fetchone()
+    except UniqueViolation as exc:
+        raise ProfileNameConflict(name) from exc
+    except Exception:
+        logger.exception("failed to create profile %s for %s", name, user_email)
+        return None
+    if row is None:
+        return None
+    return {
+        "id": str(row[0]),
+        "name": name,
+        "base_profile": base_profile,
+        "evaluator_overrides": evaluator_overrides,
+        "argus_overrides": argus_overrides,
+        "created_at": row[1].isoformat() if row[1] else None,
+    }
+
+
+def delete_profile(*, profile_id: str, user_email: str) -> bool:
+    dsn = _build_dsn()
+    if dsn is None:
+        return False
+    try:
+        profile_uuid = uuid.UUID(profile_id)
+    except ValueError:
+        return False
+    try:
+        with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM argus_profiles WHERE id = %s AND user_email = %s",
+                (profile_uuid, user_email),
+            )
+            return cur.rowcount > 0
+    except Exception:
+        logger.exception("failed to delete profile %s for %s", profile_id, user_email)
+        return False
+
+
+def get_profile_for_user(
+    *, profile_id: str, user_email: str
+) -> Optional[dict[str, Any]]:
+    """Fetch a profile only if it belongs to the caller. Returns None otherwise."""
+    dsn = _build_dsn()
+    if dsn is None:
+        return None
+    try:
+        profile_uuid = uuid.UUID(profile_id)
+    except ValueError:
+        return None
+    try:
+        with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, name, base_profile, evaluator_overrides, argus_overrides
+                FROM argus_profiles
+                WHERE id = %s AND user_email = %s
+                """,
+                (profile_uuid, user_email),
+            )
+            row = cur.fetchone()
+    except Exception:
+        logger.exception("failed to fetch profile %s for %s", profile_id, user_email)
+        return None
+    if row is None:
+        return None
+    return {
+        "id": str(row[0]),
+        "name": row[1],
+        "base_profile": row[2],
+        "evaluator_overrides": row[3] or {},
+        "argus_overrides": row[4] or {},
+    }

--- a/backend/services/argus_store.py
+++ b/backend/services/argus_store.py
@@ -57,6 +57,17 @@ def _apply_querypal_columns(dsn: str) -> None:
         cur.execute(
             "ALTER TABLE argus_reports " "ADD COLUMN IF NOT EXISTS created_by TEXT"
         )
+        # Arm A (post-hoc rating) audit trail — who labelled a finding and when.
+        # The label itself lives in upstream argus_findings.user_label; these two
+        # columns are QueryPal-specific so we don't fork upstream schema.sql.
+        cur.execute(
+            "ALTER TABLE argus_findings "
+            "ADD COLUMN IF NOT EXISTS rated_by TEXT"
+        )
+        cur.execute(
+            "ALTER TABLE argus_findings "
+            "ADD COLUMN IF NOT EXISTS rated_at TIMESTAMPTZ"
+        )
         # Per-user saved custom profiles (Tier 4). Per-user scoping only — no
         # team sharing in v1. Reference to argus_reports is intentionally absent;
         # deleting a profile must not break reproducibility of past reports.
@@ -109,6 +120,59 @@ def set_report_created_by(report_id: str, email: str) -> None:
             )
     except Exception:
         logger.exception("failed to set created_by on report %s", report_id)
+
+
+def set_finding_rating(
+    *,
+    report_id: str,
+    finding_id: str,
+    label: str,
+    rated_by: str,
+) -> bool:
+    """Persist a human reviewer's verdict on a finding (Arm A — post-hoc rating).
+
+    Writes both the upstream ``argus_findings.user_label`` column (via the
+    store, which also patches ``raw_report`` JSONB) and the QueryPal-only
+    ``rated_by`` / ``rated_at`` audit columns. Returns ``True`` when the
+    finding was found and updated, ``False`` when no such finding exists
+    under that report (e.g. typo, deleted, or wrong report).
+    """
+    if label not in ("tp", "fp"):
+        raise ValueError(f"invalid label {label!r}; expected 'tp' or 'fp'")
+    store = get_report_store()
+    if store is None:
+        return False
+    from uuid import UUID
+
+    ok = store.update_user_label(
+        report_id=UUID(report_id),
+        finding_id=UUID(finding_id),
+        label=label,  # type: ignore[arg-type]
+    )
+    if not ok:
+        return False
+    dsn = _build_dsn()
+    if dsn is None:
+        # update_user_label succeeded, but we have no separate DSN to record
+        # the audit trail — surface as success since the verdict is stored.
+        return True
+    try:
+        with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE argus_findings
+                SET rated_by = %s, rated_at = NOW()
+                WHERE id = %s AND report_id = %s
+                """,
+                (rated_by, finding_id, report_id),
+            )
+    except Exception:
+        logger.exception(
+            "failed to record rating audit trail for finding %s on report %s",
+            finding_id,
+            report_id,
+        )
+    return True
 
 
 def fetch_report_created_by(report_id: str) -> Optional[str]:

--- a/backend/services/argus_store.py
+++ b/backend/services/argus_store.py
@@ -1,0 +1,174 @@
+"""Process-wide accessor for QueryArgus's ReportStore.
+
+Builds a libpq DSN from the same DB_* env vars QueryPal already uses
+(``services.pg_connection``). Returns ``None`` when DB vars are absent so local
+dev without Postgres keeps working — matches QueryArgus's "storage is optional"
+contract.
+
+The first call applies the upstream schema (idempotent ``CREATE TABLE IF NOT
+EXISTS``) and then runs additive ALTERs for QueryPal-specific columns we don't
+want to fork into the upstream ``schema.sql``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import psycopg2
+
+from queryargus.storage.postgres import ReportStore
+from services.pg_connection import (
+    DB_HOST,
+    DB_NAME,
+    DB_PASS,
+    DB_PORT,
+    DB_UNIX_SOCKET,
+    DB_USER,
+)
+
+logger = logging.getLogger(__name__)
+
+_store: Optional[ReportStore] = None
+_initialised = False
+
+
+def _build_dsn() -> Optional[str]:
+    if not DB_NAME or not DB_USER:
+        return None
+    host = DB_UNIX_SOCKET or DB_HOST
+    if not host:
+        return None
+    parts = [
+        f"dbname={DB_NAME}",
+        f"user={DB_USER}",
+        f"password={DB_PASS}",
+        f"host={host}",
+    ]
+    # Unix socket connections must not pass port=
+    if not DB_UNIX_SOCKET and DB_PORT:
+        parts.append(f"port={DB_PORT}")
+    return " ".join(parts)
+
+
+def _apply_querypal_columns(dsn: str) -> None:
+    """Additive ALTERs for QueryPal-specific columns on upstream tables."""
+    with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute(
+            "ALTER TABLE argus_reports " "ADD COLUMN IF NOT EXISTS created_by TEXT"
+        )
+
+
+def get_report_store() -> Optional[ReportStore]:
+    """Return a shared ReportStore, or None when PG is not configured."""
+    global _store, _initialised
+    if _initialised:
+        return _store
+    _initialised = True
+    dsn = _build_dsn()
+    if dsn is None:
+        logger.info("argus report store disabled (DB env vars missing)")
+        return None
+    try:
+        store = ReportStore(dsn)
+        store.init_schema()
+        _apply_querypal_columns(dsn)
+        _store = store
+        logger.info("argus schema applied")
+    except Exception:
+        logger.exception("argus report store init failed")
+        _store = None
+    return _store
+
+
+def set_report_created_by(report_id: str, email: str) -> None:
+    """Record who triggered a run. Best-effort — logs on failure."""
+    dsn = _build_dsn()
+    if dsn is None:
+        return
+    try:
+        with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                "UPDATE argus_reports SET created_by = %s WHERE id = %s",
+                (email, report_id),
+            )
+    except Exception:
+        logger.exception("failed to set created_by on report %s", report_id)
+
+
+def fetch_report_created_by(report_id: str) -> Optional[str]:
+    dsn = _build_dsn()
+    if dsn is None:
+        return None
+    try:
+        with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT created_by FROM argus_reports WHERE id = %s",
+                (report_id,),
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
+    except Exception:
+        logger.exception("failed to fetch created_by for report %s", report_id)
+        return None
+
+
+def fetch_run_summaries(
+    *,
+    cosmos_accounts: list[str],
+    database: Optional[str],
+    collection: Optional[str],
+    limit: int,
+) -> list[dict]:
+    """List recent runs scoped to the caller's accessible Cosmos accounts.
+
+    Returns a list of dicts already shaped for the HTTP response. Empty list when
+    PG is not configured or when ``cosmos_accounts`` is empty.
+    """
+    if not cosmos_accounts:
+        return []
+    dsn = _build_dsn()
+    if dsn is None:
+        return []
+    clauses = ["r.cosmos_account = ANY(%s)"]
+    args: list = [cosmos_accounts]
+    if database:
+        clauses.append("r.database = %s")
+        args.append(database)
+    if collection:
+        clauses.append("r.collection = %s")
+        args.append(collection)
+    where = " AND ".join(clauses)
+    sql = f"""
+        SELECT r.id, r.collection, r.database, r.cosmos_account, r.run_at,
+               r.overall_quality_score, r.run_eval_verdict,
+               r.total_input_tokens, r.total_output_tokens, r.created_by,
+               (SELECT COUNT(*) FROM argus_findings f WHERE f.report_id = r.id) AS findings_count
+        FROM argus_reports r
+        WHERE {where}
+        ORDER BY r.run_at DESC
+        LIMIT %s
+    """
+    args.append(limit)
+    try:
+        with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute(sql, args)
+            rows = cur.fetchall()
+    except Exception:
+        logger.exception("failed to list argus runs")
+        return []
+    return [
+        {
+            "report_id": str(row[0]),
+            "collection": row[1],
+            "database": row[2],
+            "cosmos_account": row[3],
+            "run_at": row[4].isoformat() if row[4] else None,
+            "quality_score": (round(row[5] * 100) if row[5] is not None else None),
+            "run_eval_verdict": row[6],
+            "total_tokens": int(row[7] or 0) + int(row[8] or 0),
+            "created_by": row[9],
+            "findings_count": int(row[10] or 0),
+        }
+        for row in rows
+    ]

--- a/backend/services/argus_store.py
+++ b/backend/services/argus_store.py
@@ -52,11 +52,26 @@ def _build_dsn() -> Optional[str]:
 
 
 def _apply_querypal_columns(dsn: str) -> None:
-    """Additive ALTERs for QueryPal-specific columns on upstream tables."""
+    """Additive ALTERs + QueryPal-only tables that don't belong in upstream DDL."""
     with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
         cur.execute(
             "ALTER TABLE argus_reports " "ADD COLUMN IF NOT EXISTS created_by TEXT"
         )
+        # Per-user saved custom profiles (Tier 4). Per-user scoping only — no
+        # team sharing in v1. Reference to argus_reports is intentionally absent;
+        # deleting a profile must not break reproducibility of past reports.
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS argus_profiles (
+                id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                user_email          TEXT NOT NULL,
+                name                TEXT NOT NULL,
+                base_profile        TEXT NOT NULL,
+                evaluator_overrides JSONB NOT NULL DEFAULT '{}'::jsonb,
+                argus_overrides     JSONB NOT NULL DEFAULT '{}'::jsonb,
+                created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                UNIQUE (user_email, name)
+            )
+            """)
 
 
 def get_report_store() -> Optional[ReportStore]:

--- a/backend/services/argus_store.py
+++ b/backend/services/argus_store.py
@@ -154,12 +154,26 @@ def fetch_run_summaries(
         clauses.append("r.collection = %s")
         args.append(collection)
     where = " AND ".join(clauses)
+    # Severity buckets follow the same mapping as routes/argus.py _SEVERITY_UI:
+    # critical -> critical, high -> warning, medium|low -> info.
     sql = f"""
         SELECT r.id, r.collection, r.database, r.cosmos_account, r.run_at,
                r.overall_quality_score, r.run_eval_verdict,
                r.total_input_tokens, r.total_output_tokens, r.created_by,
-               (SELECT COUNT(*) FROM argus_findings f WHERE f.report_id = r.id) AS findings_count
+               COALESCE(fc.total, 0)    AS findings_count,
+               COALESCE(fc.critical, 0) AS critical_count,
+               COALESCE(fc.warning, 0)  AS warning_count,
+               COALESCE(fc.info, 0)     AS info_count
         FROM argus_reports r
+        LEFT JOIN (
+            SELECT report_id,
+                   COUNT(*) AS total,
+                   COUNT(*) FILTER (WHERE severity = 'critical') AS critical,
+                   COUNT(*) FILTER (WHERE severity = 'high')     AS warning,
+                   COUNT(*) FILTER (WHERE severity IN ('medium','low')) AS info
+            FROM argus_findings
+            GROUP BY report_id
+        ) fc ON fc.report_id = r.id
         WHERE {where}
         ORDER BY r.run_at DESC
         LIMIT %s
@@ -184,6 +198,11 @@ def fetch_run_summaries(
             "total_tokens": int(row[7] or 0) + int(row[8] or 0),
             "created_by": row[9],
             "findings_count": int(row[10] or 0),
+            "counts": {
+                "critical": int(row[11] or 0),
+                "warning": int(row[12] or 0),
+                "info": int(row[13] or 0),
+            },
         }
         for row in rows
     ]

--- a/backend/services/argus_store.py
+++ b/backend/services/argus_store.py
@@ -61,8 +61,7 @@ def _apply_querypal_columns(dsn: str) -> None:
         # The label itself lives in upstream argus_findings.user_label; these two
         # columns are QueryPal-specific so we don't fork upstream schema.sql.
         cur.execute(
-            "ALTER TABLE argus_findings "
-            "ADD COLUMN IF NOT EXISTS rated_by TEXT"
+            "ALTER TABLE argus_findings " "ADD COLUMN IF NOT EXISTS rated_by TEXT"
         )
         cur.execute(
             "ALTER TABLE argus_findings "

--- a/backend/services/azure_auth.py
+++ b/backend/services/azure_auth.py
@@ -1,3 +1,5 @@
+import base64
+import json
 from os import environ as env
 import msal
 from typing import Optional
@@ -33,3 +35,26 @@ def exchange_token_obo(user_token: str) -> str:
     if "access_token" not in result:
         raise Exception(f"OBO token exchange failed: {result}")
     return result["access_token"]
+
+
+def extract_email_from_token(jwt: str) -> Optional[str]:
+    """Decode the JWT payload to pull the caller's email.
+
+    No signature check — Azure already validated this token during the OBO
+    exchange the caller just performed. We only need to read claims.
+    """
+    try:
+        parts = jwt.split(".")
+        if len(parts) < 2:
+            return None
+        payload_b64 = parts[1]
+        # JWT base64url, no padding
+        padding = "=" * (-len(payload_b64) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64 + padding))
+        for key in ("preferred_username", "email", "upn", "unique_name"):
+            value = payload.get(key)
+            if value:
+                return str(value)
+    except Exception:
+        return None
+    return None

--- a/backend/services/evaluate_write_service.py
+++ b/backend/services/evaluate_write_service.py
@@ -3,6 +3,7 @@ from google.genai import types
 from models.schemas import EvaluateWriteResponse
 from services.mongo_service import execute_mongo_query, transform_mongo_result
 from services.react_agent_service import is_write_operation
+from services.gemini_service import thinking_config_for
 
 
 def evaluate_write_result(
@@ -67,7 +68,7 @@ Respond with plain text only in your final answer.
         model=model,
         contents=prompt,
         config=types.GenerateContentConfig(
-            tools=tools, thinking_config=types.ThinkingConfig(thinking_budget=0)
+            tools=tools, thinking_config=thinking_config_for(model)
         ),
     )
 
@@ -95,7 +96,7 @@ Respond with plain text only in your final answer.
                     ],
                     config=types.GenerateContentConfig(
                         tools=tools,
-                        thinking_config=types.ThinkingConfig(thinking_budget=0),
+                        thinking_config=thinking_config_for(model),
                     ),
                 )
 

--- a/backend/services/gemini_service.py
+++ b/backend/services/gemini_service.py
@@ -10,6 +10,18 @@ from pydantic import BaseModel, Field
 from typing import Optional, List
 
 
+def thinking_config_for(model: str) -> Optional[types.ThinkingConfig]:
+    """Return a ThinkingConfig appropriate for the model.
+
+    gemini-2.5-pro requires thinking mode (rejects thinking_budget=0), so we
+    return None to let the API use its default. Flash variants get an explicit
+    budget=0 to keep latency and cost down.
+    """
+    if model and "pro" in model.lower():
+        return None
+    return types.ThinkingConfig(thinking_budget=0)
+
+
 class VisualizationConfig(BaseModel):
     available: bool = Field(description="Whether a chart is recommended for this data")
     type: Optional[str] = Field(
@@ -140,7 +152,7 @@ def generate_query_from_prompt(
         model=model,
         contents=full_prompt,
         config=types.GenerateContentConfig(
-            thinking_config=types.ThinkingConfig(thinking_budget=0)  # Disables thinking
+            thinking_config=thinking_config_for(model),
         ),
     )
     code = extract_python_code(response.text)
@@ -159,7 +171,7 @@ def generate_suggestion_from_query_error(
         model=model,
         contents=full_prompt,
         config=types.GenerateContentConfig(
-            thinking_config=types.ThinkingConfig(thinking_budget=0)  # Disables thinking
+            thinking_config=thinking_config_for(model),
         ),
     )
     suggestion = (
@@ -212,7 +224,7 @@ def generate_audit_sql(user_input: str, model: str = "gemini-2.5-flash") -> str:
         model=model,
         contents=full_prompt,
         config=types.GenerateContentConfig(
-            thinking_config=types.ThinkingConfig(thinking_budget=0)
+            thinking_config=thinking_config_for(model),
         ),
     )
     sql = extract_python_code(response.text)
@@ -237,7 +249,7 @@ def summarize_audit_results(
         config=types.GenerateContentConfig(
             response_mime_type="application/json",
             response_schema=AuditSummaryResponse,
-            thinking_config=types.ThinkingConfig(thinking_budget=0),
+            thinking_config=thinking_config_for(model),
         ),
     )
 
@@ -297,7 +309,7 @@ def generate_schema_relationships(
         config=types.GenerateContentConfig(
             response_mime_type="application/json",
             response_schema=SchemaRelationshipsResponse,
-            thinking_config=types.ThinkingConfig(thinking_budget=0),
+            thinking_config=thinking_config_for(model),
         ),
     )
 

--- a/backend/services/react_agent_service.py
+++ b/backend/services/react_agent_service.py
@@ -18,7 +18,7 @@ if not logger.handlers:
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
-from services.gemini_service import extract_python_code
+from services.gemini_service import extract_python_code, thinking_config_for
 from services.mongo_service import execute_mongo_query, transform_mongo_result
 
 WRITE_METHODS = {
@@ -131,7 +131,7 @@ def generate_query_node(state: AgentState):
             model=state.get("model", "gemini-2.5-flash"),
             contents=prompt,
             config=types.GenerateContentConfig(
-                thinking_config=types.ThinkingConfig(thinking_budget=0)
+                thinking_config=thinking_config_for(state.get("model", "gemini-2.5-flash"))
             ),
         )
         code = extract_python_code(response.text)
@@ -215,7 +215,7 @@ def evaluate_node(state: AgentState):
             contents=prompt,
             config=types.GenerateContentConfig(
                 response_mime_type="application/json",
-                thinking_config=types.ThinkingConfig(thinking_budget=0),
+                thinking_config=thinking_config_for(state.get("model", "gemini-2.5-flash")),
             ),
         )
 

--- a/backend/services/react_agent_service.py
+++ b/backend/services/react_agent_service.py
@@ -131,7 +131,9 @@ def generate_query_node(state: AgentState):
             model=state.get("model", "gemini-2.5-flash"),
             contents=prompt,
             config=types.GenerateContentConfig(
-                thinking_config=thinking_config_for(state.get("model", "gemini-2.5-flash"))
+                thinking_config=thinking_config_for(
+                    state.get("model", "gemini-2.5-flash")
+                )
             ),
         )
         code = extract_python_code(response.text)
@@ -215,7 +217,9 @@ def evaluate_node(state: AgentState):
             contents=prompt,
             config=types.GenerateContentConfig(
                 response_mime_type="application/json",
-                thinking_config=thinking_config_for(state.get("model", "gemini-2.5-flash")),
+                thinking_config=thinking_config_for(
+                    state.get("model", "gemini-2.5-flash")
+                ),
             ),
         )
 

--- a/backend/tests/test_argus_rating.py
+++ b/backend/tests/test_argus_rating.py
@@ -1,0 +1,189 @@
+"""Tests for the Arm A finding-rating endpoint (`POST /argus/findings/.../rate`).
+
+These exercise the route's auth + account-scope checks against a faked
+``ReportStore`` so no real Postgres or Azure dependency is needed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+
+@dataclass
+class _FakeReport:
+    cosmos_account: str
+    id: UUID
+
+
+class _FakeStore:
+    def __init__(self, report: _FakeReport | None) -> None:
+        self._report = report
+
+    def get(self, report_id: UUID) -> _FakeReport | None:
+        if self._report is None or self._report.id != report_id:
+            return None
+        return self._report
+
+
+@pytest.fixture
+def auth_header() -> dict[str, str]:
+    return {"authorization": "Bearer fake-token"}
+
+
+def _patch_common(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    email: str | None,
+    accessible: list[str],
+    store: _FakeStore | None,
+    rating_ok: bool = True,
+) -> dict[str, Any]:
+    """Patch out auth + storage so the route test runs without real deps."""
+    calls: dict[str, Any] = {"rate_args": None}
+
+    monkeypatch.setattr(
+        "routes.argus.extract_email_from_token", lambda _t: email
+    )
+    monkeypatch.setattr(
+        "routes.argus.exchange_token_obo", lambda _t: "arm-token"
+    )
+    monkeypatch.setattr(
+        "routes.argus._accessible_account_ids", lambda _t: accessible
+    )
+    monkeypatch.setattr("routes.argus.get_report_store", lambda: store)
+
+    def _rate(**kwargs: Any) -> bool:
+        calls["rate_args"] = kwargs
+        return rating_ok
+
+    monkeypatch.setattr("routes.argus.set_finding_rating", _rate)
+    return calls
+
+
+def test_rate_finding_writes_label_when_caller_has_access(
+    client, auth_header, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    report_id = uuid4()
+    finding_id = uuid4()
+    report = _FakeReport(cosmos_account="/subscriptions/s/acct", id=report_id)
+    calls = _patch_common(
+        monkeypatch,
+        email="alice@example.com",
+        accessible=[report.cosmos_account],
+        store=_FakeStore(report),
+    )
+
+    resp = client.post(
+        f"/argus/findings/{report_id}/{finding_id}/rate",
+        headers=auth_header,
+        json={"label": "fp"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["user_label"] == "fp"
+    assert body["rated_by"] == "alice@example.com"
+    # Verify the rating helper received the right args (preserves report/finding id).
+    assert calls["rate_args"]["report_id"] == str(report_id)
+    assert calls["rate_args"]["finding_id"] == str(finding_id)
+    assert calls["rate_args"]["label"] == "fp"
+    assert calls["rate_args"]["rated_by"] == "alice@example.com"
+
+
+def test_rate_finding_returns_404_for_inaccessible_account(
+    client, auth_header, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    """Cross-tenant attempts get 404, not 403 — same existence-leak guard as get_report."""
+    report_id = uuid4()
+    finding_id = uuid4()
+    report = _FakeReport(cosmos_account="/subscriptions/s/other-acct", id=report_id)
+    _patch_common(
+        monkeypatch,
+        email="bob@example.com",
+        accessible=["/subscriptions/s/MY-acct"],  # caller cannot see 'other-acct'
+        store=_FakeStore(report),
+    )
+
+    resp = client.post(
+        f"/argus/findings/{report_id}/{finding_id}/rate",
+        headers=auth_header,
+        json={"label": "tp"},
+    )
+    assert resp.status_code == 404
+
+
+def test_rate_finding_returns_404_when_report_missing(
+    client, auth_header, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    report_id = uuid4()
+    finding_id = uuid4()
+    _patch_common(
+        monkeypatch,
+        email="alice@example.com",
+        accessible=["/anything"],
+        store=_FakeStore(None),  # store.get returns None
+    )
+
+    resp = client.post(
+        f"/argus/findings/{report_id}/{finding_id}/rate",
+        headers=auth_header,
+        json={"label": "tp"},
+    )
+    assert resp.status_code == 404
+
+
+def test_rate_finding_returns_404_when_finding_missing(
+    client, auth_header, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    report_id = uuid4()
+    finding_id = uuid4()
+    report = _FakeReport(cosmos_account="/subscriptions/s/acct", id=report_id)
+    _patch_common(
+        monkeypatch,
+        email="alice@example.com",
+        accessible=[report.cosmos_account],
+        store=_FakeStore(report),
+        rating_ok=False,  # finding doesn't exist under this report
+    )
+
+    resp = client.post(
+        f"/argus/findings/{report_id}/{finding_id}/rate",
+        headers=auth_header,
+        json={"label": "tp"},
+    )
+    assert resp.status_code == 404
+
+
+def test_rate_finding_rejects_invalid_label(
+    client, auth_header, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    """Pydantic Literal rejects anything other than 'tp' | 'fp' with 422."""
+    report_id = uuid4()
+    finding_id = uuid4()
+    report = _FakeReport(cosmos_account="/subscriptions/s/acct", id=report_id)
+    _patch_common(
+        monkeypatch,
+        email="alice@example.com",
+        accessible=[report.cosmos_account],
+        store=_FakeStore(report),
+    )
+
+    resp = client.post(
+        f"/argus/findings/{report_id}/{finding_id}/rate",
+        headers=auth_header,
+        json={"label": "maybe"},
+    )
+    assert resp.status_code == 422
+
+
+def test_rate_finding_requires_bearer_token(client) -> None:  # type: ignore[no-untyped-def]
+    resp = client.post(
+        f"/argus/findings/{uuid4()}/{uuid4()}/rate",
+        headers={"authorization": "Basic foo"},
+        json={"label": "tp"},
+    )
+    # _require_caller_email rejects non-Bearer formats with 401.
+    assert resp.status_code == 401

--- a/backend/tests/test_argus_rating.py
+++ b/backend/tests/test_argus_rating.py
@@ -45,15 +45,9 @@ def _patch_common(
     """Patch out auth + storage so the route test runs without real deps."""
     calls: dict[str, Any] = {"rate_args": None}
 
-    monkeypatch.setattr(
-        "routes.argus.extract_email_from_token", lambda _t: email
-    )
-    monkeypatch.setattr(
-        "routes.argus.exchange_token_obo", lambda _t: "arm-token"
-    )
-    monkeypatch.setattr(
-        "routes.argus._accessible_account_ids", lambda _t: accessible
-    )
+    monkeypatch.setattr("routes.argus.extract_email_from_token", lambda _t: email)
+    monkeypatch.setattr("routes.argus.exchange_token_obo", lambda _t: "arm-token")
+    monkeypatch.setattr("routes.argus._accessible_account_ids", lambda _t: accessible)
     monkeypatch.setattr("routes.argus.get_report_store", lambda: store)
 
     def _rate(**kwargs: Any) -> bool:

--- a/backend/tests/test_query_routes.py
+++ b/backend/tests/test_query_routes.py
@@ -296,46 +296,19 @@ def test_execute_query_write_logging(client):
         )
 
 
-def test_list_models_with_supported_actions(client):
-    """Test /models returns gemini models filtered by generateContent support."""
+def test_list_models_intersects_allowlist(client):
+    """Test /models returns only allowlisted models the API actually exposes."""
 
     class MockModel:
-        def __init__(self, name, supported_actions=None):
-            self.name = name
-            self.supported_actions = supported_actions
-
-    mock_models = [
-        MockModel("models/gemini-2.5-flash", ["generateContent", "countTokens"]),
-        MockModel("models/gemini-2.0-flash", ["generateContent"]),
-        MockModel("models/gemini-1.0-pro", ["countTokens"]),  # no generateContent
-        MockModel("models/text-embedding-004", ["embedContent"]),  # not gemini
-        MockModel(None),  # name is None
-    ]
-
-    with patch("routes.query.genai") as mock_genai:
-        mock_genai.Client.return_value.models.list.return_value = mock_models
-        response = client.get("/query/models")
-
-    assert response.status_code == 200
-    data = response.json()
-    assert "gemini-2.5-flash" in data
-    assert "gemini-2.0-flash" in data
-    assert "gemini-1.0-pro" not in data
-    assert "text-embedding-004" not in data
-    assert data == sorted(data)
-
-
-def test_list_models_fallback_no_supported_actions(client):
-    """Test /models fallback when supported_actions is absent on all models."""
-
-    class MockModelNoActions:
         def __init__(self, name):
             self.name = name
 
     mock_models = [
-        MockModelNoActions("models/gemini-2.5-flash"),
-        MockModelNoActions("models/gemini-2.0-flash"),
-        MockModelNoActions("models/text-embedding-004"),
+        MockModel("models/gemini-2.5-flash"),
+        MockModel("models/gemini-2.5-pro"),
+        MockModel("models/gemini-1.0-pro"),  # not in allowlist
+        MockModel("models/text-embedding-004"),  # not in allowlist
+        MockModel(None),
     ]
 
     with patch("routes.query.genai") as mock_genai:
@@ -345,5 +318,18 @@ def test_list_models_fallback_no_supported_actions(client):
     assert response.status_code == 200
     data = response.json()
     assert "gemini-2.5-flash" in data
-    assert "gemini-2.0-flash" in data
+    assert "gemini-2.5-pro" in data
+    assert "gemini-1.0-pro" not in data
     assert "text-embedding-004" not in data
+
+
+def test_list_models_falls_back_when_api_errors(client):
+    """Test /models returns the allowlist when the API listing fails."""
+    from routes.query import SUPPORTED_MODELS
+
+    with patch("routes.query.genai") as mock_genai:
+        mock_genai.Client.side_effect = RuntimeError("API down")
+        response = client.get("/query/models")
+
+    assert response.status_code == 200
+    assert response.json() == SUPPORTED_MODELS

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -55,6 +55,23 @@ graph TB
 
 ---
 
+## QueryArgus persistence
+
+Audit reports persist to the same Cloud SQL Postgres instance the rest of QueryPal uses. The schema lives in the QueryArgus submodule (`backend/queryargus/src/queryargus/storage/schema.sql`) and is applied on backend startup via `ReportStore.init_schema()` — `CREATE TABLE IF NOT EXISTS`, idempotent, no migration tool required. A small additive `ALTER TABLE argus_reports ADD COLUMN IF NOT EXISTS created_by TEXT` runs immediately after so we can attribute runs to the caller without forking upstream DDL.
+
+Tables created:
+
+| Table | Purpose |
+|---|---|
+| `argus_reports` | One row per audit run. Full `AuditReport` lives in `raw_report` JSONB; common fields denormalised for indexed queries. `created_by` (QueryPal-added) holds the caller's email. |
+| `argus_findings` | Confirmed findings per report — for indexed filtering and the cross-run history aggregation. |
+| `argus_dismissed_findings` | Findings the evaluator rejected, with critique — feeds the planner's "do not re-propose" memory. |
+| `argus_evaluation_records` | Full audit trail of action/finding/run gate verdicts. |
+
+`GET /argus/runs` and `GET /argus/reports/{id}` scope reads by the caller's Azure-accessible Cosmos accounts (via OBO + `list_cosmos_resources`) — there is no separate ACL table; Azure RBAC is the source of truth. Cross-tenant fetches return 404 (not 403) so the existence of out-of-scope reports is not leaked.
+
+---
+
 ## Secret Management
 
 All sensitive configuration lives in **GCP Secret Manager** and is mounted into the backend container at startup via `--set-secrets`. Secrets are never passed as plain environment variables and never appear in `gcloud run describe` output.

--- a/frontend/components/AppLayout.tsx
+++ b/frontend/components/AppLayout.tsx
@@ -14,7 +14,8 @@ interface AppLayoutProps {
   collectionName?: string;
   collections?: CollectionSummary[];
   activeCollection?: string;
-  onCollectionSelect?: (name: string) => void;
+  onCollectionSelect?: (name: string, ev?: { ctrlKey?: boolean; metaKey?: boolean }) => void;
+  activeCollections?: string[];
   collectionSeverity?: Record<string, 'critical' | 'warning' | 'info' | 'clean'>;
   collectionFindings?: Record<string, number>;
   onNewQuery?: () => void;
@@ -22,6 +23,7 @@ interface AppLayoutProps {
   onSwitchDatabase?: (db: DbInfo) => void;
   availableAccounts?: CosmosDBAccount[];
   onSwitchAccount?: (account: CosmosDBAccount) => void;
+  chipLoading?: boolean;
 }
 
 const AppLayout: React.FC<AppLayoutProps> = ({
@@ -33,6 +35,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({
   collections,
   activeCollection,
   onCollectionSelect,
+  activeCollections,
   collectionSeverity,
   collectionFindings,
   onNewQuery,
@@ -40,6 +43,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({
   onSwitchDatabase,
   availableAccounts,
   onSwitchAccount,
+  chipLoading,
 }) => {
   const navigate = useNavigate();
   const { toggleTheme } = useTheme();
@@ -90,12 +94,14 @@ const AppLayout: React.FC<AppLayoutProps> = ({
         collections={collections}
         activeCollection={activeCollection}
         onCollectionSelect={onCollectionSelect}
+        activeCollections={activeCollections}
         collectionSeverity={collectionSeverity}
         collectionFindings={collectionFindings}
         availableDbs={availableDbs}
         onSwitchDatabase={onSwitchDatabase}
         availableAccounts={availableAccounts}
         onSwitchAccount={onSwitchAccount}
+        chipLoading={chipLoading}
       />
       <div className="qp-main">
         <AppTopBar

--- a/frontend/components/AppLayout.tsx
+++ b/frontend/components/AppLayout.tsx
@@ -15,6 +15,8 @@ interface AppLayoutProps {
   collections?: CollectionSummary[];
   activeCollection?: string;
   onCollectionSelect?: (name: string) => void;
+  collectionSeverity?: Record<string, 'critical' | 'warning' | 'info' | 'clean'>;
+  collectionFindings?: Record<string, number>;
   onNewQuery?: () => void;
   availableDbs?: DbInfo[];
   onSwitchDatabase?: (db: DbInfo) => void;
@@ -31,6 +33,8 @@ const AppLayout: React.FC<AppLayoutProps> = ({
   collections,
   activeCollection,
   onCollectionSelect,
+  collectionSeverity,
+  collectionFindings,
   onNewQuery,
   availableDbs,
   onSwitchDatabase,
@@ -86,6 +90,8 @@ const AppLayout: React.FC<AppLayoutProps> = ({
         collections={collections}
         activeCollection={activeCollection}
         onCollectionSelect={onCollectionSelect}
+        collectionSeverity={collectionSeverity}
+        collectionFindings={collectionFindings}
         availableDbs={availableDbs}
         onSwitchDatabase={onSwitchDatabase}
         availableAccounts={availableAccounts}

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -9,13 +9,15 @@ interface AppSidebarProps {
   databaseName?: string;
   collections?: CollectionSummary[];
   activeCollection?: string;
-  onCollectionSelect?: (name: string) => void;
+  onCollectionSelect?: (name: string, ev?: { ctrlKey?: boolean; metaKey?: boolean }) => void;
+  activeCollections?: string[];
   collectionSeverity?: Record<string, 'critical' | 'warning' | 'info' | 'clean'>;
   collectionFindings?: Record<string, number>;
   availableDbs?: DbInfo[];
   onSwitchDatabase?: (db: DbInfo) => void;
   availableAccounts?: CosmosDBAccount[];
   onSwitchAccount?: (account: CosmosDBAccount) => void;
+  chipLoading?: boolean;
 }
 
 type NavItem =
@@ -70,12 +72,14 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   collections,
   activeCollection,
   onCollectionSelect,
+  activeCollections,
   collectionSeverity,
   collectionFindings,
   availableDbs,
   onSwitchDatabase,
   availableAccounts,
   onSwitchAccount,
+  chipLoading,
 }) => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -138,7 +142,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
         </Link>
 
         {/* Connection chip — always rendered so the brand section never changes height */}
-        <div ref={chipRef} style={{ position: 'relative' }}>
+        <div ref={chipRef} style={{ position: 'relative', filter: chipLoading ? 'blur(3px)' : undefined, pointerEvents: chipLoading ? 'none' : undefined, transition: 'filter 0.18s ease' }}>
           {!accountName ? (
             /* Placeholder keeps the same height as the real chip */
             <div style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '5px 9px', background: 'var(--soft)', borderRadius: 7 }}>
@@ -384,7 +388,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
               if (collectionSort === 'findings_desc') return bf - af || a.name.localeCompare(b.name);
               return af - bf || a.name.localeCompare(b.name);
             })).map((col) => {
-              const active = activeCollection === col.name;
+              const active = activeCollection === col.name || (activeCollections?.includes(col.name) ?? false);
               const status = collectionSeverity?.[col.name];
               const railColor =
                 status === 'critical' ? '#c94250'
@@ -403,7 +407,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
               return (
                 <button
                   key={col.name}
-                  onClick={() => onCollectionSelect?.(col.name)}
+                  onClick={(e) => onCollectionSelect?.(col.name, { ctrlKey: e.ctrlKey, metaKey: e.metaKey })}
                   title={statusLabel}
                   style={{
                     width: '100%', display: 'flex', alignItems: 'center',

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -10,6 +10,8 @@ interface AppSidebarProps {
   collections?: CollectionSummary[];
   activeCollection?: string;
   onCollectionSelect?: (name: string) => void;
+  collectionSeverity?: Record<string, 'critical' | 'warning' | 'info' | 'clean'>;
+  collectionFindings?: Record<string, number>;
   availableDbs?: DbInfo[];
   onSwitchDatabase?: (db: DbInfo) => void;
   availableAccounts?: CosmosDBAccount[];
@@ -68,6 +70,8 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   collections,
   activeCollection,
   onCollectionSelect,
+  collectionSeverity,
+  collectionFindings,
   availableDbs,
   onSwitchDatabase,
   availableAccounts,
@@ -77,7 +81,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   const navigate = useNavigate();
   const [showDbPicker, setShowDbPicker] = useState(false);
   const [latencyMs, setLatencyMs] = useState<number | null>(null);
-  const [collectionSort, setCollectionSort] = useState<'name_asc' | 'name_desc' | 'count_desc' | 'count_asc'>('name_asc');
+  const [collectionSort, setCollectionSort] = useState<'name_asc' | 'name_desc' | 'count_desc' | 'count_asc' | 'findings_desc' | 'findings_asc'>('name_asc');
   const chipRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -309,6 +313,19 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
             );
           }
 
+          if (item.label === 'Analytics' && !databaseName) {
+            return (
+              <span
+                key={item.label}
+                style={{ ...style, opacity: 0.4, cursor: 'not-allowed' }}
+                title="Loading database…"
+              >
+                {iconSpan}
+                {item.label}
+              </span>
+            );
+          }
+
           return (
             <Link
               key={resolvedHref}
@@ -348,6 +365,12 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
               <option value="name_desc">Z → A</option>
               <option value="count_desc">Most docs</option>
               <option value="count_asc">Fewest docs</option>
+              {collectionFindings && (
+                <>
+                  <option value="findings_desc">Most findings</option>
+                  <option value="findings_asc">Fewest findings</option>
+                </>
+              )}
             </select>
           </div>
           <div style={{ flex: 1, overflowY: 'auto', padding: '0 8px' }}>
@@ -355,23 +378,44 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
               if (collectionSort === 'name_asc') return a.name.localeCompare(b.name);
               if (collectionSort === 'name_desc') return b.name.localeCompare(a.name);
               if (collectionSort === 'count_desc') return b.count - a.count;
-              return a.count - b.count;
+              if (collectionSort === 'count_asc') return a.count - b.count;
+              const af = collectionFindings?.[a.name] ?? -1;
+              const bf = collectionFindings?.[b.name] ?? -1;
+              if (collectionSort === 'findings_desc') return bf - af || a.name.localeCompare(b.name);
+              return af - bf || a.name.localeCompare(b.name);
             })).map((col) => {
               const active = activeCollection === col.name;
+              const status = collectionSeverity?.[col.name];
+              const railColor =
+                status === 'critical' ? '#c94250'
+                : status === 'warning' ? '#c98d42'
+                : status === 'info' ? '#6a85a8'
+                : status === 'clean' ? '#5a9a78'
+                : null;
+              const restBg = status === 'critical' ? '#fdf0f1' : 'transparent';
+              const hoverBg = status === 'critical' ? '#fbe5e8' : 'var(--soft)';
+              const statusLabel =
+                status === 'critical' ? 'Critical findings'
+                : status === 'warning' ? 'Warning findings'
+                : status === 'info' ? 'Info findings'
+                : status === 'clean' ? 'Audited — no findings'
+                : undefined;
               return (
                 <button
                   key={col.name}
                   onClick={() => onCollectionSelect?.(col.name)}
+                  title={statusLabel}
                   style={{
                     width: '100%', display: 'flex', alignItems: 'center',
                     padding: '5px 8px', borderRadius: 6, border: 'none', cursor: 'pointer',
-                    background: active ? 'var(--accent-soft)' : 'transparent',
+                    background: active ? 'var(--accent-soft)' : restBg,
                     color: active ? 'var(--fg)' : 'var(--muted)',
                     fontSize: 12.5, fontFamily: 'var(--font-body)', marginBottom: 1,
                     textAlign: 'left', transition: 'background 0.1s',
+                    boxShadow: railColor ? `inset 2px 0 0 ${railColor}` : 'none',
                   }}
-                  onMouseEnter={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
-                  onMouseLeave={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                  onMouseEnter={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = hoverBg; }}
+                  onMouseLeave={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = restBg; }}
                 >
                   <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" style={{ marginRight: 7, flexShrink: 0, color: active ? 'var(--accent)' : 'var(--muted)' }}>
                     <ellipse cx="8" cy="4" rx="6" ry="2"/><path d="M2 4v8c0 1.1 2.7 2 6 2s6-.9 6-2V4M2 8c0 1.1 2.7 2 6 2s6-.9 6-2"/>

--- a/frontend/components/AppTopBar.tsx
+++ b/frontend/components/AppTopBar.tsx
@@ -58,7 +58,9 @@ const AppTopBar: React.FC<AppTopBarProps> = ({
 
   const handleNotifClick = (n: AppNotification) => {
     setShowNotifs(false);
-    if (n.kind === 'argus_done' || n.kind === 'argus_error') navigate('/analytics');
+    if (n.kind === 'argus_done' || n.kind === 'argus_error') {
+      navigate('/analytics', n.reportId ? { state: { reportId: n.reportId } } : undefined);
+    }
   };
 
   const openNotifs = () => {

--- a/frontend/components/AppTopBar.tsx
+++ b/frontend/components/AppTopBar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
 import { useTheme } from '../contexts/ThemeContext';
+import { useNotifications, AppNotification } from '../contexts/NotificationsContext';
 
 interface AppTopBarProps {
   accountName?: string;
@@ -23,7 +24,10 @@ const AppTopBar: React.FC<AppTopBarProps> = ({
   const navigate = useNavigate();
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [showSignOutConfirm, setShowSignOutConfirm] = useState(false);
+  const [showNotifs, setShowNotifs] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const notifsRef = useRef<HTMLDivElement>(null);
+  const { notifications, unreadCount, activeRuns, markAllRead, dismiss, clearAll } = useNotifications();
 
   const initials = user?.name
     ? user.name.split(' ').map((n) => n[0]).join('').slice(0, 2).toUpperCase()
@@ -40,6 +44,42 @@ const AppTopBar: React.FC<AppTopBarProps> = ({
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
   }, [showUserMenu]);
+
+  useEffect(() => {
+    if (!showNotifs) return;
+    const handleClick = (e: MouseEvent) => {
+      if (notifsRef.current && !notifsRef.current.contains(e.target as Node)) {
+        setShowNotifs(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [showNotifs]);
+
+  const handleNotifClick = (n: AppNotification) => {
+    setShowNotifs(false);
+    if (n.kind === 'argus_done' || n.kind === 'argus_error') navigate('/analytics');
+  };
+
+  const openNotifs = () => {
+    setShowNotifs((v) => {
+      const next = !v;
+      if (next && unreadCount > 0) markAllRead();
+      return next;
+    });
+  };
+
+  const formatRelative = (ts: number): string => {
+    const diff = Math.max(0, Date.now() - ts);
+    const s = Math.floor(diff / 1000);
+    if (s < 45) return 'just now';
+    const m = Math.floor(s / 60);
+    if (m < 60) return `${m}m ago`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h ago`;
+    const d = Math.floor(h / 24);
+    return `${d}d ago`;
+  };
 
   const handleAvatarClick = () => {
     setShowUserMenu(v => !v);
@@ -126,18 +166,164 @@ const AppTopBar: React.FC<AppTopBarProps> = ({
       </button>
 
       {/* Notifications */}
-      <button
-        style={{
-          background: 'none', border: 'none', cursor: 'pointer',
-          color: 'var(--muted)', display: 'flex', padding: 5, borderRadius: 6,
-        }}
-        title="Notifications"
-      >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-          <path d="M8 1.5A3.5 3.5 0 0111.5 5v3.5l1 1.5H3.5l1-1.5V5A3.5 3.5 0 018 1.5z"/>
-          <path d="M6.5 13a1.5 1.5 0 003 0"/>
-        </svg>
-      </button>
+      <div ref={notifsRef} style={{ position: 'relative' }}>
+        <button
+          onClick={openNotifs}
+          style={{
+            background: 'none', border: 'none', cursor: 'pointer',
+            color: 'var(--muted)', display: 'flex', padding: 5, borderRadius: 6,
+            position: 'relative',
+          }}
+          title={
+            activeRuns.length > 0
+              ? `Notifications (${activeRuns.length} running)`
+              : 'Notifications'
+          }
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <path d="M8 1.5A3.5 3.5 0 0111.5 5v3.5l1 1.5H3.5l1-1.5V5A3.5 3.5 0 018 1.5z"/>
+            <path d="M6.5 13a1.5 1.5 0 003 0"/>
+          </svg>
+          {unreadCount > 0 && (
+            <span style={{
+              position: 'absolute', top: 1, right: 1,
+              minWidth: 14, height: 14, borderRadius: 7,
+              background: 'var(--status-err)', color: '#fff',
+              fontSize: 9, fontWeight: 700, fontFamily: 'var(--font-body)',
+              display: 'grid', placeItems: 'center', padding: '0 3px',
+              border: '1px solid var(--bg)', lineHeight: 1,
+            }}>{unreadCount > 9 ? '9+' : unreadCount}</span>
+          )}
+          {unreadCount === 0 && activeRuns.length > 0 && (
+            <span style={{
+              position: 'absolute', top: 4, right: 4,
+              width: 6, height: 6, borderRadius: 3,
+              background: 'var(--accent)',
+              border: '1px solid var(--bg)',
+            }} />
+          )}
+        </button>
+
+        {showNotifs && (
+          <div style={{
+            position: 'absolute', top: 'calc(100% + 8px)', right: 0, zIndex: 200,
+            background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 10,
+            boxShadow: '0 8px 24px rgba(0,0,0,0.12)', width: 320, maxHeight: 420,
+            display: 'flex', flexDirection: 'column', overflow: 'hidden',
+          }}>
+            <div style={{
+              padding: '10px 12px 8px', borderBottom: '1px solid var(--border)',
+              display: 'flex', alignItems: 'center', gap: 8,
+            }}>
+              <span style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
+                Notifications
+              </span>
+              <span style={{ fontSize: 11, color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>
+                {activeRuns.length > 0 ? `${activeRuns.length} running` : ''}
+              </span>
+              {notifications.length > 0 && (
+                <button
+                  onClick={clearAll}
+                  style={{
+                    marginLeft: 'auto', background: 'none', border: 'none',
+                    color: 'var(--muted)', fontSize: 11, cursor: 'pointer',
+                    fontFamily: 'var(--font-body)', padding: 0,
+                  }}
+                  title="Clear all"
+                >Clear all</button>
+              )}
+            </div>
+
+            <div style={{ overflowY: 'auto', flex: 1 }}>
+              {activeRuns.length > 0 && (
+                <div style={{
+                  padding: '8px 12px', borderBottom: '1px solid var(--border)',
+                  background: 'var(--soft)',
+                }}>
+                  <div style={{
+                    fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em',
+                    color: 'var(--muted)', marginBottom: 4, fontFamily: 'var(--font-body)',
+                  }}>In progress</div>
+                  {activeRuns.map((r) => (
+                    <div key={r.jobId} style={{
+                      display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0',
+                      fontSize: 12, color: 'var(--fg)', fontFamily: 'var(--font-body)',
+                    }}>
+                      <svg width="11" height="11" viewBox="0 0 16 16" fill="none"
+                           stroke="var(--accent)" strokeWidth="1.5"
+                           style={{ animation: 'qp-spin 0.8s linear infinite', flexShrink: 0 }}>
+                        <circle cx="8" cy="8" r="6" strokeOpacity="0.3" />
+                        <path d="M8 2a6 6 0 0 1 6 6" />
+                      </svg>
+                      <span style={{
+                        fontFamily: 'var(--font-mono)', fontSize: 11.5,
+                        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                      }}>{r.collection}</span>
+                      <span style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--muted)' }}>
+                        {formatRelative(r.startedAt)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {notifications.length === 0 && activeRuns.length === 0 && (
+                <div style={{
+                  padding: '24px 12px', textAlign: 'center', color: 'var(--muted)',
+                  fontSize: 12, fontFamily: 'var(--font-body)',
+                }}>No notifications yet.</div>
+              )}
+
+              {notifications.map((n) => {
+                const isErr = n.kind === 'argus_error';
+                return (
+                  <div key={n.id}
+                    onClick={() => handleNotifClick(n)}
+                    style={{
+                      padding: '10px 12px', borderBottom: '1px solid var(--border)',
+                      cursor: 'pointer', display: 'flex', gap: 9, alignItems: 'flex-start',
+                    }}
+                    onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                    onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                  >
+                    <span style={{
+                      width: 8, height: 8, borderRadius: 4, marginTop: 5, flexShrink: 0,
+                      background: isErr ? 'var(--status-err)' : 'var(--status-ok)',
+                    }} />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{
+                        fontSize: 12.5, color: 'var(--fg)', fontWeight: 500,
+                        fontFamily: 'var(--font-body)', marginBottom: 2,
+                        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                      }}>{n.title}</div>
+                      <div style={{
+                        fontSize: 11.5, color: 'var(--muted)', fontFamily: 'var(--font-body)',
+                        lineHeight: 1.35,
+                      }}>{n.body}</div>
+                      <div style={{
+                        fontSize: 10.5, color: 'var(--muted)', marginTop: 3,
+                        fontFamily: 'var(--font-body)',
+                      }}>{formatRelative(n.createdAt)}</div>
+                    </div>
+                    <button
+                      onClick={(e) => { e.stopPropagation(); dismiss(n.id); }}
+                      title="Dismiss"
+                      style={{
+                        background: 'none', border: 'none', cursor: 'pointer',
+                        color: 'var(--muted)', padding: 2, borderRadius: 4, flexShrink: 0,
+                      }}
+                    >
+                      <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                        <path d="M3 3l10 10M13 3L3 13"/>
+                      </svg>
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
 
       {/* User avatar + dropdown */}
       <div ref={menuRef} style={{ position: 'relative' }}>

--- a/frontend/components/ArgusTrendsPanel.tsx
+++ b/frontend/components/ArgusTrendsPanel.tsx
@@ -1,0 +1,482 @@
+import React, { useMemo, useState, useRef, useEffect } from 'react';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  ReferenceLine,
+} from 'recharts';
+import type { ArgusRunSummary } from '../services/argusService';
+
+interface Props {
+  history: ArgusRunSummary[];
+  currentReportId?: string;
+  onSelectRun?: (reportId: string) => void;
+}
+
+interface ChartRow {
+  idx: number;
+  label: string;
+  fullDate: string;
+  critical: number;
+  warning: number;
+  info: number;
+  findings: number;
+  confidence: number | null;
+  tokens: number;
+  reportId: string;
+  verdict: string | null;
+}
+
+const SEVER = {
+  critical: { color: '#c94250', bg: '#fdf0f1', label: 'Critical' },
+  warning: { color: '#c98d42', bg: '#fdf6ed', label: 'Warning' },
+  info: { color: 'var(--muted)', bg: 'var(--soft)', label: 'Info' },
+} as const;
+
+const formatShortDate = (iso: string | null): string => {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+};
+
+const formatFullDate = (iso: string | null): string => {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleString();
+};
+
+const confidenceColor = (score: number | null): string => {
+  if (score == null) return 'var(--muted)';
+  if (score >= 80) return '#3a8c5f';
+  if (score >= 60) return '#c98d42';
+  return '#c94250';
+};
+
+const InfoDot: React.FC<{ children: React.ReactNode; title: string }> = ({ children, title }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [open]);
+  return (
+    <span ref={ref} style={{ position: 'relative', display: 'inline-flex' }}>
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); setOpen(v => !v); }}
+        aria-label={`About ${title}`}
+        style={{
+          width: 14, height: 14, borderRadius: '50%',
+          border: '1px solid var(--border)', background: 'var(--soft)',
+          color: 'var(--muted)', cursor: 'pointer', padding: 0,
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 9, fontFamily: 'var(--font-body)', lineHeight: 1, fontWeight: 600,
+        }}
+      >?</button>
+      {open && (
+        <div role="dialog" style={{
+          position: 'absolute', top: 'calc(100% + 6px)', left: 0,
+          zIndex: 200, width: 280,
+          background: 'var(--panel)', border: '1px solid var(--border)',
+          borderRadius: 8, boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+          padding: '10px 12px', fontFamily: 'var(--font-body)',
+          textTransform: 'none', letterSpacing: 'normal',
+        }}>
+          <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--fg)', marginBottom: 4 }}>{title}</div>
+          <div style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--muted)' }}>{children}</div>
+        </div>
+      )}
+    </span>
+  );
+};
+
+const SeverityTooltip: React.FC<{
+  active?: boolean;
+  payload?: Array<{ payload: ChartRow }>;
+}> = ({ active, payload }) => {
+  if (!active || !payload || payload.length === 0) return null;
+  const row = payload[0].payload;
+  return (
+    <div style={{
+      background: 'var(--panel)',
+      border: '1px solid var(--border)',
+      borderRadius: 'var(--radius-sm)',
+      padding: '8px 10px',
+      fontFamily: 'var(--font-body)',
+      fontSize: 11.5,
+      color: 'var(--fg)',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+      minWidth: 160,
+    }}>
+      <div style={{ color: 'var(--muted)', marginBottom: 6, fontSize: 11 }}>{row.fullDate}</div>
+      {(['critical', 'warning', 'info'] as const).map((k) => (
+        <div key={k} style={{ display: 'flex', justifyContent: 'space-between', gap: 12, fontFamily: 'var(--font-mono)', fontSize: 11.5 }}>
+          <span style={{ color: SEVER[k].color }}>● {SEVER[k].label}</span>
+          <span>{row[k]}</span>
+        </div>
+      ))}
+      <div style={{ borderTop: '1px solid var(--border)', marginTop: 6, paddingTop: 6, display: 'flex', justifyContent: 'space-between', fontFamily: 'var(--font-mono)', fontSize: 11.5 }}>
+        <span style={{ color: 'var(--muted)' }}>Total</span>
+        <span>{row.findings}</span>
+      </div>
+    </div>
+  );
+};
+
+const ConfidenceTooltip: React.FC<{
+  active?: boolean;
+  payload?: Array<{ payload: ChartRow }>;
+}> = ({ active, payload }) => {
+  if (!active || !payload || payload.length === 0) return null;
+  const row = payload[0].payload;
+  return (
+    <div style={{
+      background: 'var(--panel)',
+      border: '1px solid var(--border)',
+      borderRadius: 'var(--radius-sm)',
+      padding: '8px 10px',
+      fontFamily: 'var(--font-body)',
+      fontSize: 11.5,
+      color: 'var(--fg)',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+    }}>
+      <div style={{ color: 'var(--muted)', marginBottom: 4, fontSize: 11 }}>{row.fullDate}</div>
+      <div style={{ fontFamily: 'var(--font-mono)', fontSize: 13, color: confidenceColor(row.confidence) }}>
+        {row.confidence == null ? '—' : `${row.confidence.toFixed(0)} / 100`}
+      </div>
+      {row.verdict && (
+        <div style={{ color: 'var(--muted)', marginTop: 4, fontSize: 10.5 }}>{row.verdict}</div>
+      )}
+    </div>
+  );
+};
+
+const TokensTooltip: React.FC<{
+  active?: boolean;
+  payload?: Array<{ payload: ChartRow }>;
+}> = ({ active, payload }) => {
+  if (!active || !payload || payload.length === 0) return null;
+  const row = payload[0].payload;
+  return (
+    <div style={{
+      background: 'var(--panel)',
+      border: '1px solid var(--border)',
+      borderRadius: 'var(--radius-sm)',
+      padding: '8px 10px',
+      fontFamily: 'var(--font-body)',
+      fontSize: 11.5,
+      color: 'var(--fg)',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+    }}>
+      <div style={{ color: 'var(--muted)', marginBottom: 4, fontSize: 11 }}>{row.fullDate}</div>
+      <div style={{ fontFamily: 'var(--font-mono)', fontSize: 13 }}>
+        {row.tokens.toLocaleString()} tokens
+      </div>
+    </div>
+  );
+};
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: 10.5,
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  color: 'var(--muted)',
+  fontFamily: 'var(--font-body)',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+};
+
+const cardStyle: React.CSSProperties = {
+  background: 'var(--panel)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-md)',
+  padding: '12px 14px',
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: 220,
+};
+
+const axisProps = {
+  stroke: 'var(--muted)',
+  tick: { fontSize: 10.5, fill: 'var(--muted)', fontFamily: 'var(--font-mono)' as const },
+  tickLine: false,
+  axisLine: { stroke: 'var(--border)' as const },
+};
+
+export const ArgusTrendsPanel: React.FC<Props> = ({ history, currentReportId, onSelectRun }) => {
+  const rows: ChartRow[] = useMemo(() => {
+    return [...history]
+      .filter((r) => r.run_at != null)
+      .sort((a, b) => new Date(a.run_at!).getTime() - new Date(b.run_at!).getTime())
+      .map((r, i) => {
+        // Fall back when older runs don't have per-severity counts cached.
+        const c = r.counts ?? { critical: 0, warning: 0, info: r.findings_count };
+        return {
+          idx: i,
+          label: formatShortDate(r.run_at),
+          fullDate: formatFullDate(r.run_at),
+          critical: c.critical,
+          warning: c.warning,
+          info: c.info,
+          findings: r.findings_count,
+          confidence: r.quality_score,
+          tokens: r.total_tokens,
+          reportId: r.report_id,
+          verdict: r.run_eval_verdict,
+        };
+      });
+  }, [history]);
+
+  if (rows.length === 0) {
+    return (
+      <div style={{
+        flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: 'var(--muted)', fontSize: 12.5, fontFamily: 'var(--font-body)',
+      }}>
+        No runs to plot yet. Trends appear once this collection has at least one persisted run.
+      </div>
+    );
+  }
+
+  if (rows.length === 1) {
+    const r = rows[0];
+    return (
+      <div style={{ flex: 1, padding: 16, fontFamily: 'var(--font-body)', color: 'var(--muted)', fontSize: 12.5 }}>
+        Only one run on record ({r.fullDate}). Trends need at least two runs — kick off another audit to see history develop.
+      </div>
+    );
+  }
+
+  const latest = rows[rows.length - 1];
+  const first = rows[0];
+  const criticalDelta = latest.critical - first.critical;
+  const findingsDelta = latest.findings - first.findings;
+  const tokensTotal = rows.reduce((acc, r) => acc + r.tokens, 0);
+  const confidenceLatest = latest.confidence;
+
+  const handleBarClick = (data: unknown) => {
+    const row = (data as { payload?: ChartRow } | undefined)?.payload;
+    if (row?.reportId && onSelectRun) onSelectRun(row.reportId);
+  };
+
+  const summaryItem = (
+    label: React.ReactNode,
+    value: React.ReactNode,
+    hint?: React.ReactNode,
+  ) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <span style={sectionLabel}>{label}</span>
+      <span style={{ fontFamily: 'var(--font-display)', fontSize: 22, color: 'var(--fg)', lineHeight: 1 }}>{value}</span>
+      {hint && <span style={{ fontSize: 11, color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>{hint}</span>}
+    </div>
+  );
+
+  const fmtDelta = (n: number) => `${n >= 0 ? '+' : ''}${n}`;
+  const deltaColorBad = (n: number) =>
+    n > 0 ? '#c94250' : n < 0 ? '#3a8c5f' : 'var(--muted)';
+
+  return (
+    <div style={{ flex: 1, overflowY: 'auto', padding: 16, display: 'flex', flexDirection: 'column', gap: 14 }}>
+      {/* Summary strip — leads with collection-health metrics, audit confidence is last */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
+        gap: 12,
+      }}>
+        {summaryItem(
+          'Runs',
+          rows.length,
+          `${first.label} → ${latest.label}`,
+        )}
+        {summaryItem(
+          <>Critical now</>,
+          <span style={{ color: latest.critical > 0 ? SEVER.critical.color : 'var(--fg)' }}>
+            {latest.critical}
+          </span>,
+          <span style={{ color: deltaColorBad(criticalDelta) }}>
+            {fmtDelta(criticalDelta)} vs first
+          </span>,
+        )}
+        {summaryItem(
+          'Findings now',
+          latest.findings,
+          <span style={{ color: deltaColorBad(findingsDelta) }}>
+            {fmtDelta(findingsDelta)} vs first
+          </span>,
+        )}
+        {summaryItem(
+          <>
+            Audit confidence
+            <InfoDot title="Audit confidence ≠ data quality">
+              The confidence score grades how reliable each audit was (did it cover enough fields,
+              run enough iterations, etc.) — not how clean your data is. A perfect-confidence run
+              can still surface critical findings, and a noisy audit can miss real ones.
+            </InfoDot>
+          </>,
+          <span style={{ color: confidenceColor(confidenceLatest), fontSize: 18 }}>
+            {confidenceLatest == null ? '—' : `${confidenceLatest.toFixed(0)} / 100`}
+          </span>,
+          'latest run',
+        )}
+        {summaryItem('Tokens used', tokensTotal.toLocaleString(), 'cumulative')}
+      </div>
+
+      {/* PRIMARY — findings by severity over time (the actual data-quality signal) */}
+      <div style={cardStyle}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+          <div style={sectionLabel}>
+            <span>Findings by severity over time</span>
+            <InfoDot title="What this chart shows">
+              Each bar is one persisted audit, stacked by severity (critical / warning / info). Use
+              this to see whether your collection is trending toward more or fewer issues. This is
+              the data-quality trend.
+            </InfoDot>
+          </div>
+          <div style={{ display: 'flex', gap: 10, fontSize: 10.5, fontFamily: 'var(--font-body)', color: 'var(--muted)' }}>
+            {(['critical', 'warning', 'info'] as const).map((k) => (
+              <span key={k} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                <span style={{ width: 8, height: 8, borderRadius: 2, background: SEVER[k].color }} />
+                {SEVER[k].label}
+              </span>
+            ))}
+          </div>
+        </div>
+        <div style={{ flex: 1, minHeight: 200 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={rows} margin={{ top: 8, right: 16, bottom: 4, left: -12 }}>
+              <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="label" {...axisProps} />
+              <YAxis allowDecimals={false} {...axisProps} />
+              <Tooltip content={<SeverityTooltip />} cursor={{ fill: 'var(--accent-soft)' }} />
+              <Bar
+                dataKey="info"
+                stackId="sev"
+                fill={SEVER.info.color === 'var(--muted)' ? '#9aa0a6' : SEVER.info.color}
+                radius={[0, 0, 0, 0]}
+                isAnimationActive={false}
+                onClick={handleBarClick}
+                cursor={onSelectRun ? 'pointer' : 'default'}
+              />
+              <Bar
+                dataKey="warning"
+                stackId="sev"
+                fill={SEVER.warning.color}
+                radius={[0, 0, 0, 0]}
+                isAnimationActive={false}
+                onClick={handleBarClick}
+                cursor={onSelectRun ? 'pointer' : 'default'}
+              />
+              <Bar
+                dataKey="critical"
+                stackId="sev"
+                fill={SEVER.critical.color}
+                radius={[3, 3, 0, 0]}
+                isAnimationActive={false}
+                onClick={handleBarClick}
+                cursor={onSelectRun ? 'pointer' : 'default'}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* SECONDARY — audit confidence and tokens side by side, smaller */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 12 }}>
+        <div style={{ ...cardStyle, minHeight: 180 }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 6 }}>
+            <div style={sectionLabel}>
+              <span>Audit confidence per run</span>
+              <InfoDot title="Read this as: how reliable were the audits?">
+                Reflects the run evaluator's view of each audit — coverage, iterations, calibration.
+                A dip here means a less-trustworthy audit, <em>not</em> dirtier data. Don't read this
+                line as a quality trend for the collection.
+              </InfoDot>
+            </div>
+            <span style={{ fontSize: 10.5, color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>
+              not a data-quality metric
+            </span>
+          </div>
+          <div style={{ flex: 1, minHeight: 140 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={rows} margin={{ top: 8, right: 16, bottom: 4, left: -12 }}>
+                <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+                <XAxis dataKey="label" {...axisProps} />
+                <YAxis domain={[0, 100]} {...axisProps} />
+                <Tooltip content={<ConfidenceTooltip />} cursor={{ stroke: 'var(--accent)', strokeOpacity: 0.3 }} />
+                <ReferenceLine y={80} stroke="#3a8c5f" strokeDasharray="2 4" strokeOpacity={0.5} />
+                <ReferenceLine y={60} stroke="#c98d42" strokeDasharray="2 4" strokeOpacity={0.5} />
+                <Line
+                  type="monotone"
+                  dataKey="confidence"
+                  stroke="var(--muted)"
+                  strokeWidth={1.5}
+                  dot={(props: { cx?: number; cy?: number; payload?: ChartRow }) => {
+                    const { cx, cy, payload } = props;
+                    if (cx == null || cy == null || !payload) return <g />;
+                    const isCurrent = payload.reportId === currentReportId;
+                    return (
+                      <circle
+                        cx={cx}
+                        cy={cy}
+                        r={isCurrent ? 4.5 : 3}
+                        fill={isCurrent ? 'var(--accent)' : 'var(--panel)'}
+                        stroke={isCurrent ? 'var(--accent)' : 'var(--muted)'}
+                        strokeWidth={1.5}
+                      />
+                    );
+                  }}
+                  connectNulls
+                  isAnimationActive={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+
+        <div style={{ ...cardStyle, minHeight: 180 }}>
+          <div style={sectionLabel}>Tokens per run</div>
+          <div style={{ flex: 1, minHeight: 140, marginTop: 6 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={rows} margin={{ top: 8, right: 16, bottom: 4, left: -4 }}>
+                <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+                <XAxis dataKey="label" {...axisProps} />
+                <YAxis
+                  {...axisProps}
+                  tickFormatter={(v: number) => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v)}
+                />
+                <Tooltip content={<TokensTooltip />} cursor={{ fill: 'var(--accent-soft)' }} />
+                <Bar
+                  dataKey="tokens"
+                  fill="var(--accent)"
+                  radius={[3, 3, 0, 0]}
+                  isAnimationActive={false}
+                  onClick={handleBarClick}
+                  cursor={onSelectRun ? 'pointer' : 'default'}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      </div>
+
+      {onSelectRun && (
+        <div style={{ fontSize: 11, color: 'var(--muted)', fontFamily: 'var(--font-body)', textAlign: 'center' }}>
+          Click any bar to open that run.
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/components/FindingRatingButtons.tsx
+++ b/frontend/components/FindingRatingButtons.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { rateArgusFinding, ArgusUserLabel } from '../services/argusService';
+
+/**
+ * Arm A — post-hoc finding rating.
+ *
+ * Optimistically swaps the selected label, calls the backend, and rolls back
+ * with an inline error if the request fails. Compact enough to live in the
+ * finding-detail header without crowding existing chips.
+ */
+export const FindingRatingButtons: React.FC<{
+  reportId: string;
+  findingId: string;
+  value: ArgusUserLabel | null | undefined;
+  onChange?: (label: ArgusUserLabel) => void;
+}> = ({ reportId, findingId, value, onChange }) => {
+  const [busy, setBusy] = useState<ArgusUserLabel | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [local, setLocal] = useState<ArgusUserLabel | null>(value ?? null);
+
+  // Keep the optimistic local state in sync when the caller swaps findings.
+  React.useEffect(() => { setLocal(value ?? null); }, [value, findingId]);
+
+  const submit = async (label: ArgusUserLabel) => {
+    if (busy || local === label) return;
+    const previous = local;
+    setBusy(label);
+    setError(null);
+    setLocal(label);
+    try {
+      await rateArgusFinding({ reportId, findingId, label });
+      onChange?.(label);
+    } catch (e) {
+      setLocal(previous);
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const button = (label: ArgusUserLabel) => {
+    const selected = local === label;
+    const isTp = label === 'tp';
+    const accent = isTp ? 'var(--status-ok)' : 'var(--status-err)';
+    return (
+      <button
+        key={label}
+        type="button"
+        onClick={() => submit(label)}
+        disabled={!!busy}
+        title={isTp ? 'Mark this finding as a true positive' : 'Mark this finding as a false positive'}
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 4,
+          padding: '3px 8px', borderRadius: 999, fontSize: 11,
+          fontFamily: 'var(--font-body)', fontWeight: 500,
+          border: `1px solid ${selected ? accent : 'var(--border)'}`,
+          background: selected ? `color-mix(in oklch, ${accent} 12%, var(--panel))` : 'var(--panel)',
+          color: selected ? accent : 'var(--muted)',
+          cursor: busy ? 'progress' : 'pointer',
+          opacity: busy && busy !== label ? 0.6 : 1,
+          transition: 'background 0.12s, color 0.12s, border-color 0.12s',
+        }}
+      >
+        {isTp ? (
+          <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M3 8l3 3 7-7" />
+          </svg>
+        ) : (
+          <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M3 3l10 10M13 3L3 13" />
+          </svg>
+        )}
+        {isTp ? 'True positive' : 'False positive'}
+      </button>
+    );
+  };
+
+  return (
+    <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+      {button('tp')}
+      {button('fp')}
+      {error && (
+        <span
+          role="alert"
+          style={{ fontSize: 10.5, color: 'var(--status-err)', fontFamily: 'var(--font-body)' }}
+        >
+          {error}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/frontend/contexts/NotificationsContext.tsx
+++ b/frontend/contexts/NotificationsContext.tsx
@@ -1,0 +1,180 @@
+import React, { createContext, useContext, useEffect, useRef, useState, useCallback, ReactNode } from 'react';
+import { getArgusJob } from '../services/argusService';
+
+export type NotificationKind = 'argus_done' | 'argus_error';
+
+export interface AppNotification {
+  id: string;
+  kind: NotificationKind;
+  title: string;
+  body: string;
+  createdAt: number;
+  read: boolean;
+  // Routing hints for click-through.
+  accountId?: string;
+  database?: string;
+  collection?: string;
+  reportId?: string;
+}
+
+interface TrackedRun {
+  jobId: string;
+  accountId: string;
+  database: string;
+  collection: string;
+  startedAt: number;
+}
+
+interface NotificationsContextType {
+  notifications: AppNotification[];
+  unreadCount: number;
+  activeRuns: TrackedRun[];
+  trackArgusRun: (run: TrackedRun) => void;
+  markAllRead: () => void;
+  markRead: (id: string) => void;
+  dismiss: (id: string) => void;
+  clearAll: () => void;
+}
+
+const NotificationsContext = createContext<NotificationsContextType | undefined>(undefined);
+
+const NOTIFS_KEY = 'qp:notifications:v1';
+const RUNS_KEY = 'qp:notifications:active-runs:v1';
+const POLL_MS = 4000;
+const MAX_NOTIFS = 50;
+
+const readNotifs = (): AppNotification[] => {
+  try {
+    const raw = localStorage.getItem(NOTIFS_KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr : [];
+  } catch { return []; }
+};
+const writeNotifs = (n: AppNotification[]) => {
+  try { localStorage.setItem(NOTIFS_KEY, JSON.stringify(n.slice(0, MAX_NOTIFS))); } catch { /* quota */ }
+};
+const readRuns = (): TrackedRun[] => {
+  try {
+    const raw = localStorage.getItem(RUNS_KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr : [];
+  } catch { return []; }
+};
+const writeRuns = (r: TrackedRun[]) => {
+  try { localStorage.setItem(RUNS_KEY, JSON.stringify(r)); } catch { /* quota */ }
+};
+
+const makeId = () => `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+export const NotificationsProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [notifications, setNotifications] = useState<AppNotification[]>(() => readNotifs());
+  const [activeRuns, setActiveRuns] = useState<TrackedRun[]>(() => readRuns());
+  const runsRef = useRef<TrackedRun[]>(activeRuns);
+  runsRef.current = activeRuns;
+  const pollingRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => { writeNotifs(notifications); }, [notifications]);
+  useEffect(() => { writeRuns(activeRuns); }, [activeRuns]);
+
+  const pushNotification = useCallback((n: Omit<AppNotification, 'id' | 'createdAt' | 'read'>) => {
+    setNotifications((prev) => [
+      { ...n, id: makeId(), createdAt: Date.now(), read: false },
+      ...prev,
+    ].slice(0, MAX_NOTIFS));
+  }, []);
+
+  const removeRun = useCallback((jobId: string) => {
+    setActiveRuns((prev) => prev.filter((r) => r.jobId !== jobId));
+  }, []);
+
+  const pollOnce = useCallback(async (run: TrackedRun) => {
+    if (pollingRef.current.has(run.jobId)) return;
+    pollingRef.current.add(run.jobId);
+    try {
+      const job = await getArgusJob(run.jobId);
+      if (job.status === 'done') {
+        const findingsCount = job.report?.findings.length ?? 0;
+        pushNotification({
+          kind: 'argus_done',
+          title: `Audit complete — ${run.collection}`,
+          body: findingsCount === 0
+            ? 'No data-quality findings.'
+            : `${findingsCount} finding${findingsCount === 1 ? '' : 's'} reported.`,
+          accountId: run.accountId,
+          database: run.database,
+          collection: run.collection,
+          reportId: job.report?.report_id,
+        });
+        removeRun(run.jobId);
+      } else if (job.status === 'error') {
+        pushNotification({
+          kind: 'argus_error',
+          title: `Audit failed — ${run.collection}`,
+          body: job.error || 'The audit job returned an error.',
+          accountId: run.accountId,
+          database: run.database,
+          collection: run.collection,
+        });
+        removeRun(run.jobId);
+      }
+    } catch (e) {
+      // 404 means the job was evicted (backend restart). Drop it silently —
+      // the local AnalyticsPage poll will surface the error inline if needed.
+      removeRun(run.jobId);
+      // Avoid logging on every interval tick.
+      void e;
+    } finally {
+      pollingRef.current.delete(run.jobId);
+    }
+  }, [pushNotification, removeRun]);
+
+  useEffect(() => {
+    const tick = () => {
+      const runs = runsRef.current;
+      if (runs.length === 0) return;
+      runs.forEach((r) => { void pollOnce(r); });
+    };
+    // Fire immediately on mount so a freshly tracked run gets checked without
+    // waiting a full interval.
+    tick();
+    const handle = window.setInterval(tick, POLL_MS);
+    return () => window.clearInterval(handle);
+  }, [pollOnce]);
+
+  const trackArgusRun = useCallback((run: TrackedRun) => {
+    setActiveRuns((prev) => {
+      if (prev.some((r) => r.jobId === run.jobId)) return prev;
+      return [...prev, run];
+    });
+  }, []);
+
+  const markAllRead = useCallback(() => {
+    setNotifications((prev) => prev.map((n) => n.read ? n : { ...n, read: true }));
+  }, []);
+  const markRead = useCallback((id: string) => {
+    setNotifications((prev) => prev.map((n) => n.id === id ? { ...n, read: true } : n));
+  }, []);
+  const dismiss = useCallback((id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, []);
+  const clearAll = useCallback(() => setNotifications([]), []);
+
+  const unreadCount = notifications.reduce((acc, n) => acc + (n.read ? 0 : 1), 0);
+
+  return (
+    <NotificationsContext.Provider value={{
+      notifications, unreadCount, activeRuns,
+      trackArgusRun, markAllRead, markRead, dismiss, clearAll,
+    }}>
+      {children}
+    </NotificationsContext.Provider>
+  );
+};
+
+export const useNotifications = (): NotificationsContextType => {
+  const ctx = useContext(NotificationsContext);
+  if (!ctx) throw new Error('useNotifications must be used within NotificationsProvider');
+  return ctx;
+};

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -5,6 +5,7 @@ import { MsalProvider } from '@azure/msal-react';
 import { msalInstance } from './authConfig';
 import { AuthProvider } from './contexts/AuthContext';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { NotificationsProvider } from './contexts/NotificationsContext';
 import { USE_MSAL_AUTH } from './app.config';
 
 const rootElement = document.getElementById('root');
@@ -30,7 +31,9 @@ if (USE_MSAL_AUTH) {
       <React.StrictMode>
         <ThemeProvider>
           <MsalProvider instance={msalInstance}>
-            <App />
+            <NotificationsProvider>
+              <App />
+            </NotificationsProvider>
           </MsalProvider>
         </ThemeProvider>
       </React.StrictMode>
@@ -43,7 +46,9 @@ if (USE_MSAL_AUTH) {
       <React.StrictMode>
         <ThemeProvider>
           <MsalProvider instance={msalInstance}>
-            <App />
+            <NotificationsProvider>
+              <App />
+            </NotificationsProvider>
           </MsalProvider>
         </ThemeProvider>
       </React.StrictMode>
@@ -55,7 +60,9 @@ if (USE_MSAL_AUTH) {
     <React.StrictMode>
       <ThemeProvider>
         <AuthProvider>
-          <App />
+          <NotificationsProvider>
+            <App />
+          </NotificationsProvider>
         </AuthProvider>
       </ThemeProvider>
     </React.StrictMode>

--- a/frontend/pages/AnalyticsPage.tsx
+++ b/frontend/pages/AnalyticsPage.tsx
@@ -31,7 +31,9 @@ const DEFAULT_LLM_MODEL = 'gemini-2.5-flash';
 const MIN_SEVERITIES: ArgusMinSeverity[] = ['low', 'medium', 'high', 'critical'];
 
 type EvalStrategy = 'none' | 'rules' | 'self' | 'judge' | 'composite';
-type JudgeProvider = 'gemini' | 'openai' | 'anthropic';
+// Only Gemini is wired up end-to-end in our deployment; openai/anthropic
+// remain valid backend values but aren't surfaced as options in the UI.
+type JudgeProvider = 'gemini';
 type RejectedPolicy = 'drop' | 'log_only' | 'demote_severity';
 type RunFailPolicy = 'continue' | 'warn_only' | 'abort';
 
@@ -64,14 +66,14 @@ const PROFILE_BASELINES: Record<ArgusProfile, EvalState> = {
   },
   thorough: {
     action_evaluator: 'rules', finding_evaluator: 'composite', run_evaluator: 'judge',
-    judge_provider: 'openai', judge_model: 'gpt-4o',
+    judge_provider: 'gemini', judge_model: 'gemini-2.5-pro',
     action_pass_threshold: 0.6, finding_pass_threshold: 0.7, run_pass_threshold: 0.5,
     rejected_finding_policy: 'log_only', run_fail_policy: 'continue',
   },
 };
 
 const EVAL_STRATEGIES: EvalStrategy[] = ['none', 'rules', 'self', 'judge', 'composite'];
-const JUDGE_PROVIDERS: JudgeProvider[] = ['gemini', 'openai', 'anthropic'];
+const JUDGE_PROVIDERS: JudgeProvider[] = ['gemini'];
 const REJECTED_POLICIES: RejectedPolicy[] = ['drop', 'log_only', 'demote_severity'];
 const RUN_FAIL_POLICIES: RunFailPolicy[] = ['continue', 'warn_only', 'abort'];
 
@@ -1195,10 +1197,8 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
                 </div>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 220 }}>
                   <div style={sectionLabel}><span>Judge model</span></div>
-                  <input
-                    type="text"
+                  <select
                     disabled={!judgeEnabled}
-                    placeholder="e.g. gpt-4o"
                     value={evalState.judge_model ?? ''}
                     onChange={(e) => updateEval('judge_model', e.target.value || null)}
                     style={{
@@ -1206,7 +1206,12 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
                       background: 'var(--panel)', color: 'var(--fg)',
                       border: '1px solid var(--border)', fontFamily: 'var(--font-mono)',
                     }}
-                  />
+                  >
+                    <option value="">(default)</option>
+                    {availableModels.map((m) => (
+                      <option key={m} value={m}>{m}</option>
+                    ))}
+                  </select>
                 </div>
               </div>
 
@@ -1483,6 +1488,39 @@ const ReportBody: React.FC<{
   const scoreBand = score >= 80 ? 'Good' : score >= 60 ? 'Moderate' : 'Poor';
   const scoreBandColor = score >= 80 ? '#3a8c5f' : score >= 60 ? '#c98d42' : '#c94250';
 
+  // Build tailored hints when the audit confidence isn't Good. We surface the
+  // run evaluator's actual reason when present, then list remedies — context-
+  // weighted by symptoms readable from the report.
+  const improvementHints = useMemo<string[]>(() => {
+    if (scoreBand === 'Good') return [];
+    const hints: string[] = [];
+    if (report.profile === 'fast') {
+      hints.push('Switch profile to Balanced or Thorough — Fast skips the AI review of findings, which often trips the run evaluator.');
+    } else if (report.profile === 'balanced') {
+      hints.push('Try Thorough — it adds an independent judge model that catches issues self-review misses.');
+    }
+    if (report.iterations <= 8) {
+      hints.push(`Raise Max iterations (Customize → Max iterations). The agent stopped after ${report.iterations} rounds — give it more room to probe.`);
+    }
+    if (report.documents_sampled > 0 && report.documents_sampled < 200) {
+      hints.push(`Increase Sample size (currently ${report.documents_sampled} docs). Larger samples reveal rarer issues and stabilize the score.`);
+    }
+    if (report.findings.length === 0) {
+      hints.push('Zero findings on a non-trivial sample usually means the agent gave up early — re-run with more iterations or a deeper profile.');
+    }
+    hints.push('Lower the Minimum severity floor (Customize → Minimum severity) so borderline findings count toward the evaluator.');
+    hints.push('Switch the run evaluator strategy to judge or composite (Advanced) — adds an independent grader on top of the rules.');
+    hints.push('Try a stronger main model (e.g. gemini-2.5-pro). Heavier models miss fewer edge cases per iteration.');
+    return hints;
+  }, [scoreBand, report.profile, report.iterations, report.documents_sampled, report.findings.length]);
+
+  const runEvalReason = report.run_evaluation?.reason;
+  const runEvalCritique = report.run_evaluation?.critique;
+  // Default open whenever the hint card is shown (Moderate/Poor); collapses
+  // per-report so opening a different run resets to the default.
+  const [hintsCollapsed, setHintsCollapsed] = useState(false);
+  useEffect(() => { setHintsCollapsed(false); }, [report.report_id]);
+
   type FindingsSort = 'severity' | 'affected_desc' | 'affected_asc' | 'field' | 'verdict';
   type VerdictFilter = 'all' | 'rated' | 'unrated' | 'tp' | 'fp';
   const [sortBy, setSortBy] = useState<FindingsSort>('severity');
@@ -1594,6 +1632,76 @@ const ReportBody: React.FC<{
             ))}
           </div>
         </div>
+
+        {/* Improvement hint — shown when audit confidence is Moderate or Poor */}
+        {improvementHints.length > 0 && (
+          <div style={{
+            padding: '10px 16px',
+            borderBottom: '1px solid var(--border)',
+            background: scoreBand === 'Poor' ? '#fdf0f1' : '#fdf6ed',
+            display: 'flex', alignItems: 'flex-start', gap: 10,
+            fontFamily: 'var(--font-body)', flexShrink: 0,
+          }}>
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none"
+              stroke={scoreBandColor} strokeWidth="1.5" style={{ marginTop: 2, flexShrink: 0 }}>
+              <circle cx="8" cy="8" r="6" />
+              <path d="M8 5v3.5M8 11v.01" strokeLinecap="round" />
+            </svg>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <button
+                type="button"
+                onClick={() => setHintsCollapsed((v) => !v)}
+                aria-expanded={!hintsCollapsed}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 6,
+                  background: 'none', border: 'none', padding: 0,
+                  cursor: 'pointer', color: 'var(--fg)',
+                  fontFamily: 'var(--font-body)', fontSize: 12, fontWeight: 500,
+                  marginBottom: hintsCollapsed ? 0 : 4,
+                }}
+              >
+                <svg width="9" height="9" viewBox="0 0 16 16" fill="none"
+                  stroke="currentColor" strokeWidth="1.8"
+                  style={{
+                    transform: hintsCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)',
+                    transition: 'transform 0.15s',
+                  }}>
+                  <path d="M4 6l4 4 4-4" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                How to improve next run
+                {hintsCollapsed && (
+                  <span style={{ color: 'var(--muted)', fontWeight: 400, fontSize: 11 }}>
+                    · {improvementHints.length} suggestion{improvementHints.length === 1 ? '' : 's'}
+                  </span>
+                )}
+              </button>
+              {!hintsCollapsed && (
+                <>
+                  {runEvalReason && (
+                    <div style={{
+                      fontSize: 11.5, color: 'var(--fg)', marginBottom: 6,
+                      lineHeight: 1.45,
+                    }}>
+                      <span style={{ color: 'var(--muted)' }}>Evaluator: </span>
+                      {runEvalReason}
+                      {runEvalCritique && (
+                        <span style={{ color: 'var(--muted)' }}> — {runEvalCritique}</span>
+                      )}
+                    </div>
+                  )}
+                  <ul style={{
+                    margin: 0, paddingLeft: 16, fontSize: 11.5,
+                    color: 'var(--muted)', lineHeight: 1.45,
+                  }}>
+                    {improvementHints.map((h, i) => (
+                      <li key={i} style={{ marginBottom: 2 }}>{h}</li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+          </div>
+        )}
 
         {/* Tab bar */}
         <div style={{ display: 'flex', borderBottom: '1px solid var(--border)', background: 'var(--bg)', flexShrink: 0 }}>

--- a/frontend/pages/AnalyticsPage.tsx
+++ b/frontend/pages/AnalyticsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { CollectionSummary } from '../types';
 import {
   ArgusDiff,
@@ -374,6 +375,9 @@ interface AnalyticsPageProps {
   accountId?: string;
   databaseName?: string;
   collections?: CollectionSummary[];
+  collection: string;
+  onCollectionChange: (name: string) => void;
+  collectionDefaulting?: boolean;
 }
 
 const SEVER_COLOR: Record<ArgusSeverity, string> = {
@@ -438,42 +442,17 @@ const sectionLabel: React.CSSProperties = {
   fontFamily: 'var(--font-body)',
 };
 
-const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, collections }) => {
+const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
+  accountId,
+  databaseName,
+  collections,
+  collection,
+  onCollectionChange,
+  collectionDefaulting = false,
+}) => {
   const hasConnection = !!(accountId && databaseName);
   const { trackArgusRun } = useNotifications();
-  const [collection, setCollection] = useState<string>(() => {
-    if (!collections || collections.length === 0) return '';
-    return [...collections].sort((a, b) => a.name.localeCompare(b.name))[0].name;
-  });
-  const [collectionDefaulting, setCollectionDefaulting] = useState(false);
-  const userPickedCollectionRef = useRef(false);
-  // Reset the "user picked" flag whenever the account/database scope changes
-  // so the next auto-default can run for the new scope.
-  useEffect(() => { userPickedCollectionRef.current = false; }, [accountId, databaseName]);
-  // Default the dropdown to the collection with the most recent persisted run
-  // for this account/database; fall back to the first alphabetical collection.
-  useEffect(() => {
-    if (userPickedCollectionRef.current) return;
-    if (!collections || collections.length === 0) return;
-    const alphaFirst = [...collections].sort((a, b) => a.name.localeCompare(b.name))[0].name;
-    let cancelled = false;
-    setCollectionDefaulting(true);
-    (async () => {
-      let target = alphaFirst;
-      if (accountId && databaseName) {
-        try {
-          const rows = await listArgusRuns({ accountId, database: databaseName, limit: 1 });
-          const recent = rows[0]?.collection;
-          if (recent && collections.some((c) => c.name === recent)) target = recent;
-        } catch {
-          // ignore — fall back to alphabetical
-        }
-      }
-      if (!cancelled && !userPickedCollectionRef.current) setCollection(target);
-      if (!cancelled) setCollectionDefaulting(false);
-    })();
-    return () => { cancelled = true; };
-  }, [accountId, databaseName, collections]);
+  const setCollection = onCollectionChange;
   const [profile, setProfile] = useState<ArgusProfile>('fast');
   const [report, setReport] = useState<ArgusReport | null>(null);
   const [jobStatus, setJobStatus] = useState<ArgusJobStatus | null>(null);
@@ -484,6 +463,10 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
   const [historyLoading, setHistoryLoading] = useState(false);
   const [openingReportId, setOpeningReportId] = useState<string | null>(null);
   const pollRef = useRef<number | null>(null);
+  // When we load a historical report and sync the sidebar collection to match,
+  // we want to skip the next "collection changed → reset report" effect run,
+  // otherwise the freshly-loaded report would be cleared immediately.
+  const skipNextCollectionResetRef = useRef(false);
 
   // Tier 2 — Customize this run
   const [customizeOpen, setCustomizeOpen] = useState(false);
@@ -648,12 +631,33 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
       setReport(r);
       setSelId(r.findings[0]?.id ?? null);
       setActiveTab('findings');
+      // Sync the sidebar / dropdown selection to whatever collection this
+      // report belongs to — otherwise opening a report (e.g. from a
+      // notification) leaves the left rail pointing at a different collection.
+      // The resume-poll effect would normally clear our freshly-loaded report
+      // when `collection` changes; flag it to skip that reset for one cycle.
+      if (r.collection && r.collection !== collection) {
+        skipNextCollectionResetRef.current = true;
+        onCollectionChange(r.collection);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setOpeningReportId(null);
     }
-  }, []);
+  }, [collection, onCollectionChange]);
+
+  // If we landed here via a notification click, location.state carries the
+  // reportId to auto-open. Consume it once, then clear it so back/refresh
+  // doesn't keep reloading the same report.
+  const location = useLocation();
+  const navigate = useNavigate();
+  useEffect(() => {
+    const reportId = (location.state as { reportId?: string } | null)?.reportId;
+    if (!reportId) return;
+    loadHistoricalReport(reportId);
+    navigate(location.pathname, { replace: true, state: null });
+  }, [location.state, location.pathname, loadHistoricalReport, navigate]);
 
   const loading = jobStatus === 'queued' || jobStatus === 'running';
 
@@ -702,11 +706,18 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
   // Resume an in-flight poll when the page mounts or the collection changes.
   useEffect(() => {
     clearPoll();
-    setReport(null);
-    setError(null);
-    setJobStatus(null);
-    setSelId(null);
-    setActiveTab('findings');
+    if (skipNextCollectionResetRef.current) {
+      // Caller (loadHistoricalReport) just set this collection to match the
+      // report it loaded. Don't wipe the report — but still resume any
+      // in-flight poll for the new scope below.
+      skipNextCollectionResetRef.current = false;
+    } else {
+      setReport(null);
+      setError(null);
+      setJobStatus(null);
+      setSelId(null);
+      setActiveTab('findings');
+    }
     if (!accountId || !databaseName || !collection) return;
     const stored = readJobMap()[jobKey(accountId, databaseName, collection)];
     if (!stored) return;
@@ -806,7 +817,7 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
           <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
             <select
               value={collection}
-              onChange={(e) => { userPickedCollectionRef.current = true; setCollection(e.target.value); }}
+              onChange={(e) => { setCollection(e.target.value); }}
               disabled={collectionDefaulting}
               style={{
                 fontFamily: 'var(--font-mono)', fontSize: 12,
@@ -1429,6 +1440,33 @@ const ReportBody: React.FC<{
   const scoreBand = score >= 80 ? 'Good' : score >= 60 ? 'Moderate' : 'Poor';
   const scoreBandColor = score >= 80 ? '#3a8c5f' : score >= 60 ? '#c98d42' : '#c94250';
 
+  type FindingsSort = 'severity' | 'affected_desc' | 'affected_asc' | 'field' | 'verdict';
+  type VerdictFilter = 'all' | 'rated' | 'unrated' | 'tp' | 'fp';
+  const [sortBy, setSortBy] = useState<FindingsSort>('severity');
+  const [hiddenSev, setHiddenSev] = useState<{ critical: boolean; warning: boolean; info: boolean }>({ critical: false, warning: false, info: false });
+  const [verdictFilter, setVerdictFilter] = useState<VerdictFilter>('all');
+
+  const SEVER_RANK: Record<ArgusSeverity, number> = { critical: 0, warning: 1, info: 2 };
+
+  const visibleFindings = useMemo(() => {
+    let list = findings.filter((f) => !hiddenSev[f.severity]);
+    if (verdictFilter === 'rated') list = list.filter((f) => f.user_label != null);
+    else if (verdictFilter === 'unrated') list = list.filter((f) => f.user_label == null);
+    else if (verdictFilter === 'tp') list = list.filter((f) => f.user_label === 'tp');
+    else if (verdictFilter === 'fp') list = list.filter((f) => f.user_label === 'fp');
+
+    const sorted = [...list];
+    if (sortBy === 'severity') sorted.sort((a, b) => SEVER_RANK[a.severity] - SEVER_RANK[b.severity] || b.affected - a.affected);
+    else if (sortBy === 'affected_desc') sorted.sort((a, b) => b.affected - a.affected);
+    else if (sortBy === 'affected_asc') sorted.sort((a, b) => a.affected - b.affected);
+    else if (sortBy === 'field') sorted.sort((a, b) => a.field.localeCompare(b.field));
+    else if (sortBy === 'verdict') sorted.sort((a, b) => {
+      const rank = (l: 'tp' | 'fp' | null | undefined) => l === 'tp' ? 0 : l === 'fp' ? 1 : 2;
+      return rank(a.user_label) - rank(b.user_label) || SEVER_RANK[a.severity] - SEVER_RANK[b.severity];
+    });
+    return sorted;
+  }, [findings, hiddenSev, verdictFilter, sortBy]);
+
   return (
     <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 400px', minHeight: 0, position: 'relative' }}>
       {openingReportId && (
@@ -1558,8 +1596,98 @@ const ReportBody: React.FC<{
             onSelectRun={onSelectHistorical}
           />
         ) : (
-        <div style={{ flex: 1, overflowY: 'auto' }}>
-          {findings.map((f) => {
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+          {/* Findings toolbar — sort + filters */}
+          <div style={{
+            display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8,
+            padding: '8px 16px', borderBottom: '1px solid var(--border)',
+            background: 'var(--bg)', fontFamily: 'var(--font-body)', flexShrink: 0,
+          }}>
+            <span style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)' }}>
+              Sort
+            </span>
+            <select
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value as FindingsSort)}
+              style={{
+                fontSize: 11.5, fontFamily: 'var(--font-body)',
+                padding: '3px 6px', borderRadius: 6,
+                background: 'var(--panel)', color: 'var(--fg)',
+                border: '1px solid var(--border)', cursor: 'pointer',
+              }}
+            >
+              <option value="severity">Severity</option>
+              <option value="affected_desc">Most affected docs</option>
+              <option value="affected_asc">Fewest affected docs</option>
+              <option value="field">Field name</option>
+              <option value="verdict">Verdict (TP → FP → unrated)</option>
+            </select>
+
+            <span style={{ width: 1, height: 16, background: 'var(--border)', margin: '0 2px' }} />
+
+            {(['critical', 'warning', 'info'] as const).map((sev) => {
+              const on = !hiddenSev[sev];
+              return (
+                <button
+                  key={sev}
+                  onClick={() => setHiddenSev((h) => ({ ...h, [sev]: !h[sev] }))}
+                  title={on ? `Hide ${sev}` : `Show ${sev}`}
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 5,
+                    padding: '2px 8px', borderRadius: 999,
+                    fontSize: 11, fontFamily: 'var(--font-body)',
+                    border: `1px solid ${on ? SEVER_COLOR[sev] : 'var(--border)'}`,
+                    background: on ? SEVER_BG[sev] : 'var(--panel)',
+                    color: on ? SEVER_COLOR[sev] : 'var(--muted)',
+                    cursor: 'pointer', textTransform: 'capitalize',
+                    opacity: on ? 1 : 0.55,
+                  }}
+                >
+                  <span style={{ width: 6, height: 6, borderRadius: 999, background: SEVER_COLOR[sev] }} />
+                  {sev}
+                </button>
+              );
+            })}
+
+            <span style={{ width: 1, height: 16, background: 'var(--border)', margin: '0 2px' }} />
+
+            <span style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)' }}>
+              Verdict
+            </span>
+            <select
+              value={verdictFilter}
+              onChange={(e) => setVerdictFilter(e.target.value as VerdictFilter)}
+              style={{
+                fontSize: 11.5, fontFamily: 'var(--font-body)',
+                padding: '3px 6px', borderRadius: 6,
+                background: 'var(--panel)', color: 'var(--fg)',
+                border: '1px solid var(--border)', cursor: 'pointer',
+              }}
+            >
+              <option value="all">All</option>
+              <option value="rated">Rated</option>
+              <option value="unrated">Unrated</option>
+              <option value="tp">True positive</option>
+              <option value="fp">False positive</option>
+            </select>
+
+            <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--muted)', fontFamily: 'var(--font-mono)' }}>
+              {visibleFindings.length === findings.length
+                ? `${findings.length}`
+                : `${visibleFindings.length} / ${findings.length}`}
+            </span>
+          </div>
+
+          {visibleFindings.length === 0 ? (
+            <div style={{
+              padding: '24px 16px', fontSize: 12.5, color: 'var(--muted)',
+              fontFamily: 'var(--font-body)', textAlign: 'center',
+            }}>
+              No findings match the current filters.
+            </div>
+          ) : (
+          <div style={{ flex: 1, overflowY: 'auto' }}>
+          {visibleFindings.map((f) => {
             const isSel = f.id === (selId ?? findings[0]?.id);
             return (
               <div
@@ -1582,6 +1710,27 @@ const ReportBody: React.FC<{
                       ...tagStyle, background: SEVER_BG[f.severity], color: SEVER_COLOR[f.severity],
                       borderColor: 'transparent',
                     }}>{f.category.replace(/_/g, ' ')}</span>
+                    {f.user_label && (
+                      <span
+                        title={f.user_label === 'tp' ? 'You marked this as true positive' : 'You marked this as false positive'}
+                        style={{
+                          display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                          width: 14, height: 14, borderRadius: 999, flexShrink: 0,
+                          background: f.user_label === 'tp' ? 'var(--status-ok)' : 'var(--status-err)',
+                          color: '#fff',
+                        }}
+                      >
+                        {f.user_label === 'tp' ? (
+                          <svg width="8" height="8" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="3">
+                            <path d="M3 8l3 3 7-7" />
+                          </svg>
+                        ) : (
+                          <svg width="8" height="8" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="3">
+                            <path d="M3 3l10 10M13 3L3 13" />
+                          </svg>
+                        )}
+                      </span>
+                    )}
                     {f.diff !== 'existing' && (
                       <span style={{
                         fontSize: 10, color: DIFF_COLOR[f.diff],
@@ -1602,6 +1751,8 @@ const ReportBody: React.FC<{
               </div>
             );
           })}
+        </div>
+        )}
         </div>
         )}
       </div>

--- a/frontend/pages/AnalyticsPage.tsx
+++ b/frontend/pages/AnalyticsPage.tsx
@@ -4,15 +4,81 @@ import {
   ArgusDiff,
   ArgusFinding,
   ArgusJobStatus,
+  ArgusMinSeverity,
   ArgusProfile,
   ArgusReport,
   ArgusRunSummary,
   ArgusSeverity,
+  SavedArgusProfile,
+  createSavedProfile,
+  deleteSavedProfile,
   getArgusJob,
   getArgusReport,
   listArgusRuns,
+  listSavedProfiles,
   startArgusAudit,
 } from '../services/argusService';
+
+const DEFAULT_MAX_ITER = 20;
+const DEFAULT_SAMPLE_SIZE = 200;
+const DEFAULT_MIN_SEVERITY: ArgusMinSeverity = 'low';
+const MIN_SEVERITIES: ArgusMinSeverity[] = ['low', 'medium', 'high', 'critical'];
+
+type EvalStrategy = 'none' | 'rules' | 'self' | 'judge' | 'composite';
+type JudgeProvider = 'gemini' | 'openai' | 'anthropic';
+type RejectedPolicy = 'drop' | 'log_only' | 'demote_severity';
+type RunFailPolicy = 'continue' | 'warn_only' | 'abort';
+
+interface EvalState {
+  action_evaluator: EvalStrategy;
+  finding_evaluator: EvalStrategy;
+  run_evaluator: EvalStrategy;
+  judge_provider: JudgeProvider | null;
+  judge_model: string | null;
+  action_pass_threshold: number;
+  finding_pass_threshold: number;
+  run_pass_threshold: number;
+  rejected_finding_policy: RejectedPolicy;
+  run_fail_policy: RunFailPolicy;
+}
+
+// Baselines must match backend `PROFILE_*` in queryargus/models/config.py.
+const PROFILE_BASELINES: Record<ArgusProfile, EvalState> = {
+  fast: {
+    action_evaluator: 'rules', finding_evaluator: 'rules', run_evaluator: 'rules',
+    judge_provider: null, judge_model: null,
+    action_pass_threshold: 0.6, finding_pass_threshold: 0.7, run_pass_threshold: 0.5,
+    rejected_finding_policy: 'log_only', run_fail_policy: 'continue',
+  },
+  balanced: {
+    action_evaluator: 'rules', finding_evaluator: 'composite', run_evaluator: 'self',
+    judge_provider: null, judge_model: null,
+    action_pass_threshold: 0.6, finding_pass_threshold: 0.7, run_pass_threshold: 0.5,
+    rejected_finding_policy: 'log_only', run_fail_policy: 'continue',
+  },
+  thorough: {
+    action_evaluator: 'rules', finding_evaluator: 'composite', run_evaluator: 'judge',
+    judge_provider: 'openai', judge_model: 'gpt-4o',
+    action_pass_threshold: 0.6, finding_pass_threshold: 0.7, run_pass_threshold: 0.5,
+    rejected_finding_policy: 'log_only', run_fail_policy: 'continue',
+  },
+};
+
+const EVAL_STRATEGIES: EvalStrategy[] = ['none', 'rules', 'self', 'judge', 'composite'];
+const JUDGE_PROVIDERS: JudgeProvider[] = ['gemini', 'openai', 'anthropic'];
+const REJECTED_POLICIES: RejectedPolicy[] = ['drop', 'log_only', 'demote_severity'];
+const RUN_FAIL_POLICIES: RunFailPolicy[] = ['continue', 'warn_only', 'abort'];
+
+const diffEvalState = (
+  current: EvalState,
+  baseline: EvalState,
+): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  (Object.keys(baseline) as Array<keyof EvalState>).forEach((k) => {
+    if (current[k] !== baseline[k]) out[k] = current[k];
+  });
+  return out;
+};
 
 const JOB_STORAGE_KEY = 'qp_argus_jobs';
 
@@ -159,6 +225,147 @@ const ProfileChip: React.FC<{
   );
 };
 
+const SavedProfileChip: React.FC<{
+  profile: SavedArgusProfile;
+  active: boolean;
+  onSelect: () => void;
+  onDelete: () => void;
+}> = ({ profile, active, onSelect, onDelete }) => {
+  const [hover, setHover] = useState(false);
+  return (
+    <span
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: 4,
+        padding: '2px 6px 2px 8px', borderRadius: 4, fontSize: 11.5,
+        background: active ? 'var(--panel)' : 'transparent',
+        boxShadow: active ? '0 0 0 1px var(--border)' : 'none',
+        color: active ? 'var(--fg)' : 'var(--muted)',
+        cursor: 'pointer', fontFamily: 'var(--font-body)',
+      }}
+      title={`Based on ${profile.base_profile}`}
+    >
+      <span onClick={onSelect} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+        <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <path d="M4 2h6l2 2v10l-4-2-4 2V2z" strokeLinejoin="round" />
+        </svg>
+        {profile.name}
+      </span>
+      {hover && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); if (confirm(`Delete profile "${profile.name}"?`)) onDelete(); }}
+          aria-label="Delete profile"
+          style={{
+            background: 'transparent', border: 'none', cursor: 'pointer',
+            color: 'var(--muted)', padding: 0, display: 'inline-flex',
+            alignItems: 'center', justifyContent: 'center', width: 12, height: 12,
+          }}
+        >
+          <svg width="9" height="9" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M4 4l8 8M12 4l-8 8" strokeLinecap="round" />
+          </svg>
+        </button>
+      )}
+    </span>
+  );
+};
+
+const OverrideSlider: React.FC<{
+  label: string;
+  help: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  defaultValue: number;
+  onChange: (v: number) => void;
+}> = ({ label, help, min, max, step, value, defaultValue, onChange }) => {
+  const modified = value !== defaultValue;
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6, minWidth: 240, flex: '0 1 280px' }}>
+      <div style={{
+        fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em',
+        color: 'var(--muted)', display: 'flex', alignItems: 'center', gap: 6,
+        fontFamily: 'var(--font-body)',
+      }}>
+        <span>{label}</span>
+        <InfoPopover title={label}>{help}</InfoPopover>
+        {modified && (
+          <span style={{
+            marginLeft: 'auto', fontSize: 9, color: 'var(--accent)',
+            background: 'var(--accent-soft)', padding: '0 5px', borderRadius: 8,
+            textTransform: 'none', letterSpacing: 0,
+          }}>modified</span>
+        )}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <input
+          type="range"
+          min={min} max={max} step={step}
+          value={value}
+          onChange={(e) => onChange(Number(e.target.value))}
+          style={{ flex: 1, accentColor: 'var(--accent)' }}
+        />
+        <span style={{
+          fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg)',
+          minWidth: 40, textAlign: 'right',
+        }}>{value}</span>
+      </div>
+      <div style={{ fontSize: 10.5, color: 'var(--muted)', display: 'flex', justifyContent: 'space-between' }}>
+        <span>{min}</span>
+        <span>default {defaultValue}</span>
+        <span>{max}</span>
+      </div>
+    </div>
+  );
+};
+
+const ThresholdInput: React.FC<{
+  label: string;
+  help: string;
+  value: number;
+  defaultValue: number;
+  onChange: (v: number) => void;
+}> = ({ label, help, value, defaultValue, onChange }) => {
+  const modified = value !== defaultValue;
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 140 }}>
+      <div style={{
+        fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em',
+        color: 'var(--muted)', display: 'flex', alignItems: 'center', gap: 6,
+        fontFamily: 'var(--font-body)',
+      }}>
+        <span>{label}</span>
+        <InfoPopover title={label}>{help}</InfoPopover>
+        {modified && (
+          <span style={{
+            fontSize: 9, color: 'var(--accent)', background: 'var(--accent-soft)',
+            padding: '0 5px', borderRadius: 8, textTransform: 'none', letterSpacing: 0,
+          }}>modified</span>
+        )}
+      </div>
+      <input
+        type="number"
+        min={0} max={1} step={0.05}
+        value={value}
+        onChange={(e) => {
+          const n = Number(e.target.value);
+          if (Number.isNaN(n)) return;
+          onChange(Math.min(1, Math.max(0, n)));
+        }}
+        style={{
+          padding: '4px 8px', borderRadius: 6, fontSize: 12,
+          background: 'var(--panel)', color: 'var(--fg)',
+          border: '1px solid var(--border)', fontFamily: 'var(--font-mono)',
+          width: 90,
+        }}
+      />
+    </div>
+  );
+};
+
 interface AnalyticsPageProps {
   accountId?: string;
   databaseName?: string;
@@ -239,6 +446,123 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
   const [history, setHistory] = useState<ArgusRunSummary[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
   const pollRef = useRef<number | null>(null);
+
+  // Tier 2 — Customize this run
+  const [customizeOpen, setCustomizeOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [maxIter, setMaxIter] = useState<number>(DEFAULT_MAX_ITER);
+  const [sampleSize, setSampleSize] = useState<number>(DEFAULT_SAMPLE_SIZE);
+  const [minSeverity, setMinSeverity] = useState<ArgusMinSeverity>(DEFAULT_MIN_SEVERITY);
+  // Tier 3 — Advanced evaluator config (rebased onto profile baseline)
+  const [evalState, setEvalState] = useState<EvalState>(PROFILE_BASELINES.fast);
+  // Reset evaluator state when profile changes so the matrix reflects the new baseline.
+  useEffect(() => { setEvalState(PROFILE_BASELINES[profile]); }, [profile]);
+  const evalBaseline = PROFILE_BASELINES[profile];
+  const evalDiff = useMemo(() => diffEvalState(evalState, evalBaseline), [evalState, evalBaseline]);
+  const evalOverrideCount = Object.keys(evalDiff).length;
+  const overrideCount =
+    (maxIter !== DEFAULT_MAX_ITER ? 1 : 0) +
+    (sampleSize !== DEFAULT_SAMPLE_SIZE ? 1 : 0) +
+    (minSeverity !== DEFAULT_MIN_SEVERITY ? 1 : 0) +
+    evalOverrideCount;
+  const judgeEnabled = evalState.action_evaluator === 'judge' || evalState.action_evaluator === 'composite' ||
+    evalState.finding_evaluator === 'judge' || evalState.finding_evaluator === 'composite' ||
+    evalState.run_evaluator === 'judge' || evalState.run_evaluator === 'composite';
+  const resetOverrides = () => {
+    setMaxIter(DEFAULT_MAX_ITER);
+    setSampleSize(DEFAULT_SAMPLE_SIZE);
+    setMinSeverity(DEFAULT_MIN_SEVERITY);
+    setEvalState(PROFILE_BASELINES[profile]);
+  };
+  const updateEval = <K extends keyof EvalState>(k: K, v: EvalState[K]) =>
+    setEvalState((s) => ({ ...s, [k]: v }));
+
+  // Tier 4 — saved custom profiles
+  const [savedProfiles, setSavedProfiles] = useState<SavedArgusProfile[]>([]);
+  const [activeSavedId, setActiveSavedId] = useState<string | null>(null);
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [saveName, setSaveName] = useState('');
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveBusy, setSaveBusy] = useState(false);
+
+  const refreshProfiles = useCallback(async () => {
+    try {
+      const rows = await listSavedProfiles();
+      setSavedProfiles(rows);
+    } catch (e) {
+      console.warn('listSavedProfiles failed', e);
+    }
+  }, []);
+  useEffect(() => { refreshProfiles(); }, [refreshProfiles]);
+
+  const applySavedProfile = (p: SavedArgusProfile) => {
+    setActiveSavedId(p.id);
+    setProfile(p.base_profile);
+    // setProfile schedules a useEffect that resets evalState to baseline;
+    // queue our overrides for the next tick.
+    setTimeout(() => {
+      const base = PROFILE_BASELINES[p.base_profile];
+      setEvalState({ ...base, ...p.evaluator_overrides } as EvalState);
+      const argus = p.argus_overrides || {};
+      setMaxIter(typeof argus.max_iterations === 'number' ? argus.max_iterations : DEFAULT_MAX_ITER);
+      setSampleSize(typeof argus.sample_size === 'number' ? argus.sample_size : DEFAULT_SAMPLE_SIZE);
+      setMinSeverity((argus.min_severity as ArgusMinSeverity | undefined) ?? DEFAULT_MIN_SEVERITY);
+    }, 0);
+  };
+
+  // Clear the active saved-profile pointer when the user tweaks anything by hand.
+  useEffect(() => {
+    if (!activeSavedId) return;
+    const sp = savedProfiles.find((p) => p.id === activeSavedId);
+    if (!sp) return;
+    const base = PROFILE_BASELINES[sp.base_profile];
+    const expectedEval = { ...base, ...sp.evaluator_overrides };
+    const matchesEval = (Object.keys(base) as Array<keyof EvalState>).every(
+      (k) => (expectedEval as EvalState)[k] === evalState[k],
+    );
+    const argus = sp.argus_overrides || {};
+    const matchesArgus =
+      maxIter === (typeof argus.max_iterations === 'number' ? argus.max_iterations : DEFAULT_MAX_ITER) &&
+      sampleSize === (typeof argus.sample_size === 'number' ? argus.sample_size : DEFAULT_SAMPLE_SIZE) &&
+      minSeverity === ((argus.min_severity as ArgusMinSeverity | undefined) ?? DEFAULT_MIN_SEVERITY) &&
+      sp.base_profile === profile;
+    if (!matchesEval || !matchesArgus) setActiveSavedId(null);
+  }, [evalState, maxIter, sampleSize, minSeverity, profile, activeSavedId, savedProfiles]);
+
+  const handleSaveProfile = async () => {
+    if (!saveName.trim()) { setSaveError('Name is required'); return; }
+    setSaveBusy(true); setSaveError(null);
+    try {
+      const argus: Record<string, unknown> = {};
+      if (maxIter !== DEFAULT_MAX_ITER) argus.max_iterations = maxIter;
+      if (sampleSize !== DEFAULT_SAMPLE_SIZE) argus.sample_size = sampleSize;
+      if (minSeverity !== DEFAULT_MIN_SEVERITY) argus.min_severity = minSeverity;
+      const created = await createSavedProfile({
+        name: saveName.trim(),
+        baseProfile: profile,
+        evaluatorOverrides: evalDiff as never,
+        argusOverrides: argus as never,
+      });
+      setSavedProfiles((s) => [created, ...s]);
+      setActiveSavedId(created.id);
+      setSaveDialogOpen(false);
+      setSaveName('');
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaveBusy(false);
+    }
+  };
+
+  const handleDeleteSaved = async (id: string) => {
+    try {
+      await deleteSavedProfile(id);
+      setSavedProfiles((s) => s.filter((p) => p.id !== id));
+      if (activeSavedId === id) setActiveSavedId(null);
+    } catch (e) {
+      console.warn('deleteSavedProfile failed', e);
+    }
+  };
 
   const refreshHistory = useCallback(async () => {
     if (!accountId || !databaseName || !collection) {
@@ -349,11 +673,19 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
     setSelId(null);
     setJobStatus('queued');
     try {
+      const argusOverrides: Record<string, unknown> = {};
+      if (maxIter !== DEFAULT_MAX_ITER) argusOverrides.max_iterations = maxIter;
+      if (sampleSize !== DEFAULT_SAMPLE_SIZE) argusOverrides.sample_size = sampleSize;
+      if (minSeverity !== DEFAULT_MIN_SEVERITY) argusOverrides.min_severity = minSeverity;
       const { job_id } = await startArgusAudit({
         accountId,
         database: databaseName,
         collection,
         profile,
+        maxIterations: maxIter,
+        argusOverrides: Object.keys(argusOverrides).length ? argusOverrides : undefined,
+        configOverrides: evalOverrideCount > 0 ? (evalDiff as never) : undefined,
+        savedProfileId: activeSavedId ?? undefined,
       });
       const map = readJobMap();
       map[jobKey(accountId, databaseName, collection)] = job_id;
@@ -437,9 +769,54 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
             border: '1px solid var(--border)', padding: 2, gap: 1,
           }}>
             {(['fast', 'balanced', 'thorough'] as ArgusProfile[]).map((p) => (
-              <ProfileChip key={p} p={p} active={p === profile} onSelect={() => setProfile(p)} />
+              <ProfileChip key={p} p={p} active={p === profile && !activeSavedId} onSelect={() => { setProfile(p); setActiveSavedId(null); }} />
             ))}
           </div>
+          {savedProfiles.length > 0 && (
+            <div style={{
+              display: 'flex', background: 'var(--soft)', borderRadius: 6,
+              border: '1px solid var(--border)', padding: 2, gap: 1,
+              maxWidth: 280, overflowX: 'auto',
+            }}>
+              {savedProfiles.map((sp) => (
+                <SavedProfileChip
+                  key={sp.id}
+                  profile={sp}
+                  active={activeSavedId === sp.id}
+                  onSelect={() => applySavedProfile(sp)}
+                  onDelete={() => handleDeleteSaved(sp.id)}
+                />
+              ))}
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={() => setCustomizeOpen(v => !v)}
+            title="Customize this run"
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 4,
+              padding: '4px 8px', borderRadius: 6, fontSize: 11.5,
+              background: customizeOpen || overrideCount > 0 ? 'var(--accent-soft)' : 'var(--soft)',
+              color: overrideCount > 0 ? 'var(--accent)' : 'var(--fg)',
+              border: '1px solid var(--border)', cursor: 'pointer',
+              fontFamily: 'var(--font-body)',
+            }}
+          >
+            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M3 5h10M5 8h6M7 11h2" strokeLinecap="round" />
+            </svg>
+            Customize
+            {overrideCount > 0 && (
+              <span style={{
+                background: 'var(--accent)', color: 'var(--bg)',
+                padding: '0 5px', borderRadius: 8, fontSize: 10, fontWeight: 500,
+              }}>+{overrideCount}</span>
+            )}
+            <svg width="9" height="9" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8"
+              style={{ transform: customizeOpen ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.15s' }}>
+              <path d="M4 6l4 4 4-4" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
           <button
             className="qa-btn primary"
             disabled={!hasConnection || !collection || loading}
@@ -467,6 +844,281 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
           </button>
         </div>
       </div>
+
+      {/* Tier 2 — Customize this run */}
+      {customizeOpen && (
+        <div style={{
+          padding: '12px 18px', borderBottom: '1px solid var(--border)',
+          background: 'var(--soft)', flexShrink: 0, fontFamily: 'var(--font-body)',
+          display: 'flex', flexDirection: 'column', gap: 14,
+        }}>
+        <div style={{ display: 'flex', gap: 24, alignItems: 'flex-start', flexWrap: 'wrap' }}>
+          <OverrideSlider
+            label="Max iterations"
+            help="How many think-and-check rounds the agent runs. Higher = more thorough, more cost."
+            min={5} max={50} step={1} value={maxIter}
+            defaultValue={DEFAULT_MAX_ITER}
+            onChange={setMaxIter}
+          />
+          <OverrideSlider
+            label="Sample size"
+            help="How many documents the agent samples per probe. Larger samples catch rarer issues but cost more."
+            min={50} max={1000} step={50} value={sampleSize}
+            defaultValue={DEFAULT_SAMPLE_SIZE}
+            onChange={setSampleSize}
+          />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, minWidth: 240 }}>
+            <div style={sectionLabel}>
+              <span>Minimum severity</span>
+              <InfoPopover title="Minimum severity">
+                Drops findings below this level from the report. Use higher floors when you only care
+                about issues worth acting on right now.
+              </InfoPopover>
+            </div>
+            <div style={{
+              display: 'flex', background: 'var(--panel)', borderRadius: 6,
+              border: '1px solid var(--border)', padding: 2, width: 'fit-content',
+            }}>
+              {MIN_SEVERITIES.map((s) => (
+                <span
+                  key={s}
+                  onClick={() => setMinSeverity(s)}
+                  style={{
+                    padding: '3px 10px', borderRadius: 4, fontSize: 11.5,
+                    cursor: 'pointer', textTransform: 'capitalize',
+                    background: minSeverity === s ? 'var(--soft)' : 'transparent',
+                    color: minSeverity === s ? 'var(--fg)' : 'var(--muted)',
+                    boxShadow: minSeverity === s ? '0 0 0 1px var(--border)' : 'none',
+                  }}
+                >{s}</span>
+              ))}
+            </div>
+          </div>
+          <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+            {overrideCount > 0 && (
+              <button
+                type="button"
+                onClick={resetOverrides}
+                style={{
+                  background: 'transparent', border: 'none', cursor: 'pointer',
+                  color: 'var(--muted)', fontSize: 11.5, fontFamily: 'var(--font-body)',
+                  textDecoration: 'underline',
+                }}
+              >Reset to profile defaults</button>
+            )}
+            {overrideCount > 0 && (
+              <button
+                type="button"
+                onClick={() => { setSaveDialogOpen(true); setSaveError(null); }}
+                className="qa-btn"
+                style={{ fontSize: 11.5 }}
+              >Save as profile…</button>
+            )}
+          </div>
+        </div>
+
+        {/* Tier 3 — Advanced */}
+        <div style={{ borderTop: '1px solid var(--border)', paddingTop: 10 }}>
+          <button
+            type="button"
+            onClick={() => setAdvancedOpen(v => !v)}
+            style={{
+              background: 'transparent', border: 'none', cursor: 'pointer',
+              color: 'var(--fg)', fontSize: 11.5, fontFamily: 'var(--font-body)',
+              display: 'inline-flex', alignItems: 'center', gap: 6, padding: 0,
+            }}
+          >
+            <svg width="9" height="9" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8"
+              style={{ transform: advancedOpen ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 0.15s' }}>
+              <path d="M6 4l4 4-4 4" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            Advanced
+            {evalOverrideCount > 0 && (
+              <span style={{
+                background: 'var(--accent)', color: 'var(--bg)',
+                padding: '0 5px', borderRadius: 8, fontSize: 10, fontWeight: 500,
+              }}>+{evalOverrideCount}</span>
+            )}
+            <InfoPopover title="Advanced evaluator controls">
+              Tune QueryArgus's quality gates per-gate. Most users should not need this — the profile
+              presets pick sensible defaults. Overriding here applies to this run only.
+            </InfoPopover>
+          </button>
+
+          {advancedOpen && (
+            <div style={{ marginTop: 10, display: 'flex', flexDirection: 'column', gap: 14 }}>
+              {/* Per-gate strategy matrix */}
+              <div>
+                <div style={{ ...sectionLabel, marginBottom: 8 }}>
+                  <span>Evaluator strategy per gate</span>
+                  <InfoPopover title="Evaluator strategy">
+                    Each gate decides whether an action, a finding, or the whole run passes.
+                    <strong> Rules</strong> is fast and deterministic; <strong>self</strong> asks the same model;
+                    <strong> judge</strong> uses an independent model; <strong>composite</strong> combines them.
+                  </InfoPopover>
+                </div>
+                <table style={{ borderCollapse: 'collapse', fontFamily: 'var(--font-body)', fontSize: 11.5 }}>
+                  <thead>
+                    <tr>
+                      <th style={{ padding: '4px 8px', color: 'var(--muted)', fontWeight: 400, textAlign: 'left' }}>Gate</th>
+                      {EVAL_STRATEGIES.map(s => (
+                        <th key={s} style={{ padding: '4px 10px', color: 'var(--muted)', fontWeight: 400, textTransform: 'capitalize' }}>{s}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(['action_evaluator', 'finding_evaluator', 'run_evaluator'] as const).map((gate) => {
+                      const label = gate.replace('_evaluator', '');
+                      const current = evalState[gate];
+                      const baseline = evalBaseline[gate];
+                      const modified = current !== baseline;
+                      return (
+                        <tr key={gate}>
+                          <td style={{ padding: '4px 8px', color: 'var(--fg)', textTransform: 'capitalize' }}>
+                            {label}
+                            {modified && (
+                              <span style={{
+                                marginLeft: 6, fontSize: 9, color: 'var(--accent)',
+                                background: 'var(--accent-soft)', padding: '0 5px', borderRadius: 8,
+                              }}>modified</span>
+                            )}
+                          </td>
+                          {EVAL_STRATEGIES.map(s => {
+                            const isCurrent = current === s;
+                            const isBaseline = baseline === s;
+                            return (
+                              <td key={s} style={{ padding: 2, textAlign: 'center' }}>
+                                <span
+                                  onClick={() => updateEval(gate, s)}
+                                  title={isBaseline ? 'Profile default' : undefined}
+                                  style={{
+                                    display: 'inline-block', padding: '3px 10px', borderRadius: 4,
+                                    cursor: 'pointer', textTransform: 'capitalize',
+                                    background: isCurrent ? 'var(--panel)' : 'transparent',
+                                    color: isCurrent ? 'var(--fg)' : 'var(--muted)',
+                                    boxShadow: isCurrent ? '0 0 0 1px var(--border)' : 'none',
+                                    border: isBaseline && !isCurrent ? '1px dashed var(--border)' : '1px solid transparent',
+                                  }}
+                                >{s}</span>
+                              </td>
+                            );
+                          })}
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+                <div style={{ fontSize: 10.5, color: 'var(--muted)', marginTop: 4 }}>
+                  Dashed cells are the profile default.
+                </div>
+              </div>
+
+              {/* Thresholds */}
+              <div style={{ display: 'flex', gap: 18, flexWrap: 'wrap' }}>
+                <ThresholdInput label="Action pass" help="Minimum score (0–1) for an action to pass the action gate."
+                  value={evalState.action_pass_threshold} defaultValue={evalBaseline.action_pass_threshold}
+                  onChange={(v) => updateEval('action_pass_threshold', v)} />
+                <ThresholdInput label="Finding pass" help="Minimum score (0–1) for a finding to be kept."
+                  value={evalState.finding_pass_threshold} defaultValue={evalBaseline.finding_pass_threshold}
+                  onChange={(v) => updateEval('finding_pass_threshold', v)} />
+                <ThresholdInput label="Run pass" help="Minimum score (0–1) for the run to be considered successful."
+                  value={evalState.run_pass_threshold} defaultValue={evalBaseline.run_pass_threshold}
+                  onChange={(v) => updateEval('run_pass_threshold', v)} />
+              </div>
+
+              {/* Judge */}
+              <div style={{
+                display: 'flex', gap: 12, alignItems: 'flex-end',
+                opacity: judgeEnabled ? 1 : 0.5,
+              }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 160 }}>
+                  <div style={sectionLabel}>
+                    <span>Judge provider</span>
+                    <InfoPopover title="Judge model">
+                      The independent model used by the <strong>judge</strong> and <strong>composite</strong> strategies.
+                      Disabled when no gate uses them.
+                    </InfoPopover>
+                  </div>
+                  <select
+                    disabled={!judgeEnabled}
+                    value={evalState.judge_provider ?? ''}
+                    onChange={(e) => updateEval('judge_provider', (e.target.value || null) as JudgeProvider | null)}
+                    style={{
+                      padding: '4px 8px', borderRadius: 6, fontSize: 12,
+                      background: 'var(--panel)', color: 'var(--fg)',
+                      border: '1px solid var(--border)', fontFamily: 'var(--font-body)',
+                    }}
+                  >
+                    <option value="">(none)</option>
+                    {JUDGE_PROVIDERS.map(p => <option key={p} value={p}>{p}</option>)}
+                  </select>
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 220 }}>
+                  <div style={sectionLabel}><span>Judge model</span></div>
+                  <input
+                    type="text"
+                    disabled={!judgeEnabled}
+                    placeholder="e.g. gpt-4o"
+                    value={evalState.judge_model ?? ''}
+                    onChange={(e) => updateEval('judge_model', e.target.value || null)}
+                    style={{
+                      padding: '4px 8px', borderRadius: 6, fontSize: 12,
+                      background: 'var(--panel)', color: 'var(--fg)',
+                      border: '1px solid var(--border)', fontFamily: 'var(--font-mono)',
+                    }}
+                  />
+                </div>
+              </div>
+
+              {/* Policies */}
+              <div style={{ display: 'flex', gap: 18, flexWrap: 'wrap' }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 220 }}>
+                  <div style={sectionLabel}>
+                    <span>Rejected finding policy</span>
+                    <InfoPopover title="Rejected finding policy">
+                      What to do with findings the evaluator rejects. <strong>drop</strong> hides them,
+                      <strong> log_only</strong> keeps them visible as dismissed,
+                      <strong> demote_severity</strong> downgrades them one notch.
+                    </InfoPopover>
+                  </div>
+                  <select
+                    value={evalState.rejected_finding_policy}
+                    onChange={(e) => updateEval('rejected_finding_policy', e.target.value as RejectedPolicy)}
+                    style={{
+                      padding: '4px 8px', borderRadius: 6, fontSize: 12,
+                      background: 'var(--panel)', color: 'var(--fg)',
+                      border: '1px solid var(--border)', fontFamily: 'var(--font-body)',
+                    }}
+                  >
+                    {REJECTED_POLICIES.map(p => <option key={p} value={p}>{p}</option>)}
+                  </select>
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 200 }}>
+                  <div style={sectionLabel}>
+                    <span>Run fail policy</span>
+                    <InfoPopover title="Run fail policy">
+                      What happens if the run gate fails. <strong>continue</strong> emits the report anyway,
+                      <strong> warn_only</strong> tags it with a warning, <strong>abort</strong> discards it.
+                    </InfoPopover>
+                  </div>
+                  <select
+                    value={evalState.run_fail_policy}
+                    onChange={(e) => updateEval('run_fail_policy', e.target.value as RunFailPolicy)}
+                    style={{
+                      padding: '4px 8px', borderRadius: 6, fontSize: 12,
+                      background: 'var(--panel)', color: 'var(--fg)',
+                      border: '1px solid var(--border)', fontFamily: 'var(--font-body)',
+                    }}
+                  >
+                    {RUN_FAIL_POLICIES.map(p => <option key={p} value={p}>{p}</option>)}
+                  </select>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+        </div>
+      )}
 
       {/* Status bar */}
       {report && (
@@ -561,6 +1213,67 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
       ) : report ? (
         <EmptyState title="No findings" body="QueryArgus completed without flagging any data-quality issues in this collection." />
       ) : null}
+
+      {/* Tier 4 — Save profile dialog */}
+      {saveDialogOpen && (
+        <div
+          role="dialog"
+          onClick={() => !saveBusy && setSaveDialogOpen(false)}
+          style={{
+            position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.35)',
+            zIndex: 1000, display: 'grid', placeItems: 'center',
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              background: 'var(--panel)', borderRadius: 10, padding: 18,
+              width: 360, border: '1px solid var(--border)',
+              fontFamily: 'var(--font-body)',
+              boxShadow: '0 20px 60px rgba(0,0,0,0.25)',
+            }}
+          >
+            <div style={{ fontSize: 14, fontWeight: 500, marginBottom: 8 }}>Save as profile</div>
+            <div style={{ fontSize: 11.5, color: 'var(--muted)', marginBottom: 12 }}>
+              Save the current overrides on top of <strong style={{ color: 'var(--fg)' }}>{profile}</strong>.
+              Visible only to you.
+            </div>
+            <input
+              type="text"
+              autoFocus
+              placeholder="Profile name"
+              value={saveName}
+              onChange={(e) => setSaveName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter' && !saveBusy) handleSaveProfile(); }}
+              style={{
+                width: '100%', padding: '6px 10px', borderRadius: 6,
+                background: 'var(--bg)', color: 'var(--fg)',
+                border: '1px solid var(--border)', fontSize: 12,
+                fontFamily: 'var(--font-body)', marginBottom: 8, boxSizing: 'border-box',
+              }}
+            />
+            {saveError && (
+              <div style={{ fontSize: 11.5, color: '#c94250', marginBottom: 8 }}>{saveError}</div>
+            )}
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button
+                type="button"
+                onClick={() => setSaveDialogOpen(false)}
+                disabled={saveBusy}
+                className="qa-btn"
+                style={{ fontSize: 12 }}
+              >Cancel</button>
+              <button
+                type="button"
+                onClick={handleSaveProfile}
+                disabled={saveBusy}
+                className="qa-btn primary"
+                style={{ fontSize: 12 }}
+              >{saveBusy ? 'Saving…' : 'Save'}</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/pages/AnalyticsPage.tsx
+++ b/frontend/pages/AnalyticsPage.tsx
@@ -1,13 +1,163 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CollectionSummary } from '../types';
 import {
   ArgusDiff,
   ArgusFinding,
+  ArgusJobStatus,
   ArgusProfile,
   ArgusReport,
+  ArgusRunSummary,
   ArgusSeverity,
-  runArgusAudit,
+  getArgusJob,
+  getArgusReport,
+  listArgusRuns,
+  startArgusAudit,
 } from '../services/argusService';
+
+const JOB_STORAGE_KEY = 'qp_argus_jobs';
+
+type JobMap = Record<string, string>;
+
+const readJobMap = (): JobMap => {
+  try { return JSON.parse(sessionStorage.getItem(JOB_STORAGE_KEY) ?? '{}'); }
+  catch { return {}; }
+};
+
+const writeJobMap = (map: JobMap) => {
+  sessionStorage.setItem(JOB_STORAGE_KEY, JSON.stringify(map));
+};
+
+const jobKey = (accountId: string, database: string, collection: string) =>
+  `${accountId}::${database}::${collection}`;
+
+const PROFILE_INFO: Record<ArgusProfile, { tagline: string; speed: string; cost: string; body: string }> = {
+  fast: {
+    tagline: 'Quick scan — rule-based checks only.',
+    speed: '~20–40s',
+    cost: 'lowest',
+    body: 'Looks for missing fields, type mismatches, and obvious anomalies using fixed rules. No second-pass review, so findings reflect the agent\'s initial judgment. Best for a quick health check or smoke test before a deeper run.',
+  },
+  balanced: {
+    tagline: 'Recommended — rules + a self-review pass.',
+    speed: '~40–90s',
+    cost: 'moderate',
+    body: 'Runs the same rule checks, then has the agent re-examine each finding and weigh them against the overall picture before reporting. Catches more real issues and filters out noise. The best default for most collections.',
+  },
+  thorough: {
+    tagline: 'Deepest review — uses a separate judge model.',
+    speed: '~2–4 min',
+    cost: 'highest',
+    body: 'Adds a second, independent AI model that audits the run end-to-end and grades each finding. Slowest and priciest, but the most defensible results — use before sharing a report externally or making schema changes.',
+  },
+};
+
+interface InfoPopoverProps {
+  title: string;
+  children: React.ReactNode;
+  align?: 'left' | 'right';
+}
+
+const InfoPopover: React.FC<InfoPopoverProps> = ({ title, children, align = 'left' }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  return (
+    <span ref={ref} style={{ position: 'relative', display: 'inline-flex' }}>
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); setOpen(v => !v); }}
+        aria-label={`About ${title}`}
+        title={title}
+        style={{
+          width: 14, height: 14, borderRadius: '50%',
+          border: '1px solid var(--border)', background: 'var(--soft)',
+          color: 'var(--muted)', cursor: 'pointer', padding: 0,
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 9, fontFamily: 'var(--font-body)', lineHeight: 1, fontWeight: 600,
+        }}
+      >?</button>
+      {open && (
+        <div
+          role="dialog"
+          style={{
+            position: 'absolute', top: 'calc(100% + 6px)',
+            [align === 'right' ? 'right' : 'left']: 0,
+            zIndex: 200, width: 280,
+            background: 'var(--panel)', border: '1px solid var(--border)',
+            borderRadius: 8, boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+            padding: '10px 12px', fontFamily: 'var(--font-body)',
+          }}
+        >
+          <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--fg)', marginBottom: 4 }}>{title}</div>
+          <div style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--muted)' }}>{children}</div>
+        </div>
+      )}
+    </span>
+  );
+};
+
+const ProfileChip: React.FC<{
+  p: ArgusProfile;
+  active: boolean;
+  onSelect: () => void;
+}> = ({ p, active, onSelect }) => {
+  const [hover, setHover] = useState(false);
+  const info = PROFILE_INFO[p];
+  return (
+    <span style={{ position: 'relative' }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <span
+        onClick={onSelect}
+        style={{
+          display: 'inline-block', padding: '2px 8px', borderRadius: 4, fontSize: 11.5,
+          background: active ? 'var(--panel)' : 'transparent',
+          boxShadow: active ? '0 0 0 1px var(--border)' : 'none',
+          color: active ? 'var(--fg)' : 'var(--muted)',
+          cursor: 'pointer', fontFamily: 'var(--font-body)',
+          textTransform: 'capitalize',
+        }}
+      >{p}</span>
+      {hover && (
+        <div style={{
+          position: 'absolute', top: 'calc(100% + 6px)', left: '50%',
+          transform: 'translateX(-50%)', zIndex: 200, width: 240,
+          background: 'var(--panel)', border: '1px solid var(--border)',
+          borderRadius: 8, boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+          padding: '8px 10px', fontFamily: 'var(--font-body)',
+          pointerEvents: 'none',
+        }}>
+          <div style={{ fontSize: 11.5, fontWeight: 500, color: 'var(--fg)', marginBottom: 3, textTransform: 'capitalize' }}>
+            {p} · {info.tagline}
+          </div>
+          <div style={{ fontSize: 11, lineHeight: 1.5, color: 'var(--muted)', marginBottom: 5 }}>
+            {info.body}
+          </div>
+          <div style={{ fontSize: 10.5, color: 'var(--muted)', display: 'flex', gap: 10 }}>
+            <span><span style={{ color: 'var(--fg)' }}>{info.speed}</span> typical</span>
+            <span>·</span>
+            <span><span style={{ color: 'var(--fg)' }}>{info.cost}</span> cost</span>
+          </div>
+        </div>
+      )}
+    </span>
+  );
+};
 
 interface AnalyticsPageProps {
   accountId?: string;
@@ -82,9 +232,52 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
   const [collection, setCollection] = useState<string>(collections?.[0]?.name ?? '');
   const [profile, setProfile] = useState<ArgusProfile>('fast');
   const [report, setReport] = useState<ArgusReport | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [jobStatus, setJobStatus] = useState<ArgusJobStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selId, setSelId] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<'findings' | 'history'>('findings');
+  const [history, setHistory] = useState<ArgusRunSummary[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const pollRef = useRef<number | null>(null);
+
+  const refreshHistory = useCallback(async () => {
+    if (!accountId || !databaseName || !collection) {
+      setHistory([]);
+      return;
+    }
+    setHistoryLoading(true);
+    try {
+      const rows = await listArgusRuns({
+        accountId,
+        database: databaseName,
+        collection,
+        limit: 20,
+      });
+      setHistory(rows);
+    } catch (e) {
+      // History fetch failures shouldn't block the run flow.
+      console.warn('listArgusRuns failed', e);
+      setHistory([]);
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, [accountId, databaseName, collection]);
+
+  useEffect(() => { refreshHistory(); }, [refreshHistory]);
+
+  const loadHistoricalReport = useCallback(async (reportId: string) => {
+    setError(null);
+    try {
+      const r = await getArgusReport(reportId);
+      setReport(r);
+      setSelId(r.findings[0]?.id ?? null);
+      setActiveTab('findings');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  const loading = jobStatus === 'queued' || jobStatus === 'running';
 
   const findings = report?.findings ?? [];
   const sel: ArgusFinding | null = useMemo(() => {
@@ -92,25 +285,87 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
     return findings.find((f) => f.id === selId) ?? findings[0];
   }, [findings, selId]);
 
+  const clearPoll = () => {
+    if (pollRef.current != null) {
+      window.clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  };
+
+  const clearStoredJob = useCallback((aid: string, db: string, col: string) => {
+    const map = readJobMap();
+    delete map[jobKey(aid, db, col)];
+    writeJobMap(map);
+  }, []);
+
+  const pollJob = useCallback(async (id: string, aid: string, db: string, col: string) => {
+    try {
+      const job = await getArgusJob(id);
+      setJobStatus(job.status);
+      if (job.status === 'done' && job.report) {
+        setReport(job.report);
+        setSelId(job.report.findings[0]?.id ?? null);
+        clearPoll();
+        clearStoredJob(aid, db, col);
+        refreshHistory();
+      } else if (job.status === 'error') {
+        setError(job.error || 'Audit failed.');
+        clearPoll();
+        clearStoredJob(aid, db, col);
+      }
+    } catch (e) {
+      // 404 means the job was evicted (backend restarted, etc.) — drop it.
+      setError(e instanceof Error ? e.message : String(e));
+      clearPoll();
+      clearStoredJob(aid, db, col);
+    }
+  }, [clearStoredJob, refreshHistory]);
+
+  // Resume an in-flight poll when the page mounts or the collection changes.
+  useEffect(() => {
+    clearPoll();
+    setReport(null);
+    setError(null);
+    setJobStatus(null);
+    setSelId(null);
+    setActiveTab('findings');
+    if (!accountId || !databaseName || !collection) return;
+    const stored = readJobMap()[jobKey(accountId, databaseName, collection)];
+    if (!stored) return;
+    setJobStatus('running');
+    pollJob(stored, accountId, databaseName, collection);
+    pollRef.current = window.setInterval(
+      () => pollJob(stored, accountId, databaseName, collection),
+      3000,
+    );
+    return clearPoll;
+  }, [accountId, databaseName, collection, pollJob]);
+
   const runAudit = async () => {
     if (!accountId || !databaseName || !collection) return;
-    setLoading(true);
+    clearPoll();
     setError(null);
     setReport(null);
     setSelId(null);
+    setJobStatus('queued');
     try {
-      const r = await runArgusAudit({
+      const { job_id } = await startArgusAudit({
         accountId,
         database: databaseName,
         collection,
         profile,
       });
-      setReport(r);
-      setSelId(r.findings[0]?.id ?? null);
+      const map = readJobMap();
+      map[jobKey(accountId, databaseName, collection)] = job_id;
+      writeJobMap(map);
+      pollJob(job_id, accountId, databaseName, collection);
+      pollRef.current = window.setInterval(
+        () => pollJob(job_id, accountId, databaseName, collection),
+        3000,
+      );
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setLoading(false);
+      setJobStatus('error');
     }
   };
 
@@ -128,6 +383,20 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
           }}>A</div>
           <span style={{ fontSize: 13, fontWeight: 500, fontFamily: 'var(--font-body)' }}>QueryArgus</span>
           <span style={tagStyle}>data quality</span>
+          <InfoPopover title="What is QueryArgus?">
+            <p style={{ margin: '0 0 6px' }}>
+              QueryArgus is an automated reviewer that inspects a collection and flags data-quality issues
+              — missing fields, inconsistent types, duplicate keys, suspicious values, and more.
+            </p>
+            <p style={{ margin: '0 0 6px' }}>
+              It works like a careful analyst: it samples documents, asks itself questions, runs follow-up
+              queries to confirm hunches, and writes a short report with evidence for every finding.
+            </p>
+            <p style={{ margin: 0 }}>
+              Use it before a migration, when onboarding a new collection, or whenever a dashboard
+              starts looking wrong. No changes are made to your data.
+            </p>
+          </InfoPopover>
         </div>
         <span style={{ color: 'var(--border)' }}>·</span>
         <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--muted)' }}>
@@ -151,22 +420,24 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
         )}
         <div style={{ marginLeft: 'auto', display: 'flex', gap: 6, alignItems: 'center' }}>
           <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>Profile</span>
+          <InfoPopover title="Profiles" align="right">
+            <p style={{ margin: '0 0 6px' }}>
+              Profiles control how carefully QueryArgus checks itself — they trade speed and cost for
+              confidence in the report.
+            </p>
+            <ul style={{ margin: 0, paddingLeft: 16 }}>
+              <li style={{ marginBottom: 4 }}><strong style={{ color: 'var(--fg)' }}>Fast</strong> — rules only, no AI review of findings.</li>
+              <li style={{ marginBottom: 4 }}><strong style={{ color: 'var(--fg)' }}>Balanced</strong> — adds a self-review pass. Recommended.</li>
+              <li><strong style={{ color: 'var(--fg)' }}>Thorough</strong> — adds an independent judge model.</li>
+            </ul>
+            <p style={{ margin: '6px 0 0', fontSize: 11 }}>Hover any profile chip for full details.</p>
+          </InfoPopover>
           <div style={{
             display: 'flex', background: 'var(--soft)', borderRadius: 6,
             border: '1px solid var(--border)', padding: 2, gap: 1,
           }}>
             {(['fast', 'balanced', 'thorough'] as ArgusProfile[]).map((p) => (
-              <span
-                key={p}
-                onClick={() => setProfile(p)}
-                style={{
-                  padding: '2px 8px', borderRadius: 4, fontSize: 11.5,
-                  background: p === profile ? 'var(--panel)' : 'transparent',
-                  boxShadow: p === profile ? '0 0 0 1px var(--border)' : 'none',
-                  color: p === profile ? 'var(--fg)' : 'var(--muted)',
-                  cursor: 'pointer', fontFamily: 'var(--font-body)',
-                }}
-              >{p}</span>
+              <ProfileChip key={p} p={p} active={p === profile} onSelect={() => setProfile(p)} />
             ))}
           </div>
           <button
@@ -212,6 +483,12 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
           <span>{report.iterations} iterations · {report.total_tokens.toLocaleString()} tokens</span>
           <span>·</span>
           <span>{report.model} · {report.profile}</span>
+          {report.created_by && (
+            <>
+              <span>·</span>
+              <span>Ran by <span style={{ color: 'var(--fg)' }}>{report.created_by}</span></span>
+            </>
+          )}
           <span style={{ marginLeft: 'auto', display: 'flex', gap: 10 }}>
             {report.diff.new > 0 && (
               <span style={{ color: '#1d6cf2', display: 'flex', alignItems: 'center', gap: 4 }}>
@@ -252,13 +529,22 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
           title="No database connected"
           body="Connect to a Cosmos DB from Workspace or Explorer first, then return here to run an audit."
         />
+      ) : !report && !loading && history.length > 0 ? (
+        <PreRunHistory
+          history={history}
+          historyLoading={historyLoading}
+          onSelect={loadHistoricalReport}
+        />
       ) : !report && !loading ? (
         <EmptyState
           title="Run an audit"
           body={`QueryArgus will sample ${collection || 'a collection'} and report data-quality findings. Pick a profile and press Run.`}
         />
       ) : loading && !report ? (
-        <EmptyState title="Running audit…" body="The ReAct agent is sampling, querying, and writing findings. This usually takes 20–90 seconds depending on profile." />
+        <EmptyState
+          title={jobStatus === 'queued' ? 'Queued…' : 'Running audit…'}
+          body="The ReAct agent is sampling, querying, and writing findings. Safe to navigate away — results will be waiting when you return to this collection."
+        />
       ) : report && sel ? (
         <ReportBody
           report={report}
@@ -266,6 +552,11 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
           sel={sel}
           selId={selId ?? findings[0]?.id ?? null}
           onSelect={setSelId}
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+          history={history}
+          historyLoading={historyLoading}
+          onSelectHistorical={loadHistoricalReport}
         />
       ) : report ? (
         <EmptyState title="No findings" body="QueryArgus completed without flagging any data-quality issues in this collection." />
@@ -298,7 +589,12 @@ const ReportBody: React.FC<{
   sel: ArgusFinding;
   selId: string | null;
   onSelect: (id: string) => void;
-}> = ({ report, findings, sel, selId, onSelect }) => {
+  activeTab: 'findings' | 'history';
+  onTabChange: (tab: 'findings' | 'history') => void;
+  history: ArgusRunSummary[];
+  historyLoading: boolean;
+  onSelectHistorical: (reportId: string) => void;
+}> = ({ report, findings, sel, selId, onSelect, activeTab, onTabChange, history, historyLoading, onSelectHistorical }) => {
   const { counts } = report;
   const score = report.quality_score ?? 0;
 
@@ -334,25 +630,39 @@ const ReportBody: React.FC<{
           </div>
         </div>
 
-        {/* Tab bar (history deferred) */}
+        {/* Tab bar */}
         <div style={{ display: 'flex', borderBottom: '1px solid var(--border)', background: 'var(--bg)', flexShrink: 0 }}>
-          <div style={{
-            padding: '8px 16px', fontSize: 12.5, color: 'var(--fg)',
-            borderBottom: '2px solid var(--accent)', fontWeight: 500,
-            fontFamily: 'var(--font-body)',
-          }}>
-            Findings · {findings.length}
-          </div>
-          <div style={{
-            padding: '8px 16px', fontSize: 12.5, color: 'var(--muted)',
-            borderBottom: '2px solid transparent', cursor: 'not-allowed',
-            fontFamily: 'var(--font-body)',
-          }} title="Run history requires ReportStore persistence (not yet wired).">
-            Run history
-          </div>
+          {(['findings', 'history'] as const).map(tab => {
+            const active = activeTab === tab;
+            return (
+              <button
+                key={tab}
+                onClick={() => onTabChange(tab)}
+                style={{
+                  padding: '8px 16px', fontSize: 12.5,
+                  color: active ? 'var(--fg)' : 'var(--muted)',
+                  borderBottom: active ? '2px solid var(--accent)' : '2px solid transparent',
+                  fontWeight: active ? 500 : 400,
+                  fontFamily: 'var(--font-body)',
+                  background: 'none', border: 'none', borderRadius: 0,
+                  cursor: 'pointer',
+                }}
+              >
+                {tab === 'findings' ? `Findings · ${findings.length}` : `Run history · ${history.length}`}
+              </button>
+            );
+          })}
         </div>
 
-        {/* Findings list */}
+        {/* Tab body */}
+        {activeTab === 'history' ? (
+          <HistoryList
+            history={history}
+            historyLoading={historyLoading}
+            currentReportId={report.report_id}
+            onSelect={onSelectHistorical}
+          />
+        ) : (
         <div style={{ flex: 1, overflowY: 'auto' }}>
           {findings.map((f) => {
             const isSel = f.id === (selId ?? findings[0]?.id);
@@ -398,6 +708,7 @@ const ReportBody: React.FC<{
             );
           })}
         </div>
+        )}
       </div>
 
       {/* RIGHT — detail */}
@@ -475,5 +786,95 @@ const ReportBody: React.FC<{
     </div>
   );
 };
+
+const localPart = (email: string | null) =>
+  email ? email.split('@')[0] : 'unknown';
+
+const HistoryList: React.FC<{
+  history: ArgusRunSummary[];
+  historyLoading: boolean;
+  currentReportId?: string;
+  onSelect: (reportId: string) => void;
+}> = ({ history, historyLoading, currentReportId, onSelect }) => {
+  if (historyLoading && history.length === 0) {
+    return (
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--muted)', fontSize: 12.5, fontFamily: 'var(--font-body)' }}>
+        Loading run history…
+      </div>
+    );
+  }
+  if (history.length === 0) {
+    return (
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--muted)', fontSize: 12.5, fontFamily: 'var(--font-body)' }}>
+        No prior runs for this collection yet.
+      </div>
+    );
+  }
+  return (
+    <div style={{ flex: 1, overflowY: 'auto' }}>
+      {history.map((row) => {
+        const isCurrent = row.report_id === currentReportId;
+        const score = row.quality_score;
+        const scoreColor = score == null
+          ? 'var(--muted)'
+          : score >= 80 ? '#3a8c5f' : score >= 60 ? '#c98d42' : '#c94250';
+        return (
+          <div
+            key={row.report_id}
+            onClick={() => onSelect(row.report_id)}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 12,
+              padding: '10px 16px', borderBottom: '1px solid var(--border)',
+              cursor: 'pointer',
+              background: isCurrent ? 'var(--accent-soft)' : 'transparent',
+              fontFamily: 'var(--font-body)',
+            }}
+          >
+            <div style={{
+              width: 32, textAlign: 'center', fontFamily: 'var(--font-display)',
+              fontSize: 18, fontWeight: 500, color: scoreColor, flexShrink: 0,
+            }}>
+              {score ?? '—'}
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 12.5, color: 'var(--fg)' }}>
+                {row.run_at ? new Date(row.run_at).toLocaleString() : '—'}
+                {isCurrent && (
+                  <span style={{ ...tagStyle, marginLeft: 8, fontSize: 10 }}>current</span>
+                )}
+              </div>
+              <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 2 }}>
+                <span style={{ fontFamily: 'var(--font-mono)' }}>{localPart(row.created_by)}</span>
+                {' · '}{row.findings_count} findings
+                {' · '}{row.total_tokens.toLocaleString()} tokens
+                {row.run_eval_verdict && <> · <span>{row.run_eval_verdict}</span></>}
+              </div>
+            </div>
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ color: 'var(--muted)', flexShrink: 0 }}>
+              <path d="M6 4l4 4-4 4" />
+            </svg>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const PreRunHistory: React.FC<{
+  history: ArgusRunSummary[];
+  historyLoading: boolean;
+  onSelect: (reportId: string) => void;
+}> = ({ history, historyLoading, onSelect }) => (
+  <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+    <div style={{
+      padding: '12px 18px 8px', fontSize: 11,
+      color: 'var(--muted)', fontFamily: 'var(--font-body)',
+      borderBottom: '1px solid var(--border)',
+    }}>
+      Prior runs for this collection — pick one to load, or press Run to start a fresh audit.
+    </div>
+    <HistoryList history={history} historyLoading={historyLoading} onSelect={onSelect} />
+  </div>
+);
 
 export default AnalyticsPage;

--- a/frontend/pages/AnalyticsPage.tsx
+++ b/frontend/pages/AnalyticsPage.tsx
@@ -18,6 +18,7 @@ import {
   listSavedProfiles,
   startArgusAudit,
 } from '../services/argusService';
+import { ArgusTrendsPanel } from '../components/ArgusTrendsPanel';
 
 const DEFAULT_MAX_ITER = 20;
 const DEFAULT_SAMPLE_SIZE = 200;
@@ -166,6 +167,7 @@ const InfoPopover: React.FC<InfoPopoverProps> = ({ title, children, align = 'lef
             background: 'var(--panel)', border: '1px solid var(--border)',
             borderRadius: 8, boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
             padding: '10px 12px', fontFamily: 'var(--font-body)',
+            textTransform: 'none', letterSpacing: 'normal',
           }}
         >
           <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--fg)', marginBottom: 4 }}>{title}</div>
@@ -414,7 +416,7 @@ const ScoreArc: React.FC<{ score: number }> = ({ score }) => {
       <text x="60" y="58" textAnchor="middle" fontSize="22" fontWeight="500" fontFamily="var(--font-display)" fill="var(--fg)">{score}</text>
       <text x="60" y="72" textAnchor="middle" fontSize="10" fill="var(--muted)" fontFamily="var(--font-body)">/ 100</text>
       <text x="60" y="88" textAnchor="middle" fontSize="9" fill={col} fontFamily="var(--font-body)">
-        {score >= 80 ? 'GOOD' : score >= 60 ? 'MODERATE' : 'POOR'}
+        {score >= 80 ? 'Good' : score >= 60 ? 'Moderate' : 'Poor'}
       </text>
     </svg>
   );
@@ -442,9 +444,10 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
   const [jobStatus, setJobStatus] = useState<ArgusJobStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selId, setSelId] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<'findings' | 'history'>('findings');
+  const [activeTab, setActiveTab] = useState<'findings' | 'history' | 'trends'>('findings');
   const [history, setHistory] = useState<ArgusRunSummary[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
+  const [openingReportId, setOpeningReportId] = useState<string | null>(null);
   const pollRef = useRef<number | null>(null);
 
   // Tier 2 — Customize this run
@@ -591,6 +594,7 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
 
   const loadHistoricalReport = useCallback(async (reportId: string) => {
     setError(null);
+    setOpeningReportId(reportId);
     try {
       const r = await getArgusReport(reportId);
       setReport(r);
@@ -598,6 +602,8 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
       setActiveTab('findings');
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setOpeningReportId(null);
     }
   }, []);
 
@@ -745,9 +751,11 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
               border: '1px solid var(--border)', cursor: 'pointer',
             }}
           >
-            {collections!.map((c) => (
-              <option key={c.name} value={c.name}>{c.name}</option>
-            ))}
+            {[...collections!]
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((c) => (
+                <option key={c.name} value={c.name}>{c.name}</option>
+              ))}
           </select>
         )}
         <div style={{ marginLeft: 'auto', display: 'flex', gap: 6, alignItems: 'center' }}>
@@ -1141,7 +1149,24 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
               <span>Ran by <span style={{ color: 'var(--fg)' }}>{report.created_by}</span></span>
             </>
           )}
-          <span style={{ marginLeft: 'auto', display: 'flex', gap: 10 }}>
+          <span style={{ marginLeft: 'auto', display: 'flex', gap: 10, alignItems: 'center' }}>
+            <span style={{ fontSize: 10.5, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+              vs prior run
+            </span>
+            <InfoPopover title="What the diff badges mean" align="right">
+              <p style={{ margin: '0 0 6px' }}>Compared against the previous persisted run on the same collection:</p>
+              <ul style={{ margin: 0, paddingLeft: 16 }}>
+                <li style={{ marginBottom: 3 }}><strong style={{ color: '#1d6cf2' }}>New</strong> — first time this field+category combination has been flagged.</li>
+                <li style={{ marginBottom: 3 }}><strong style={{ color: '#c98d42' }}>Regressed</strong> — the same field is flagged at a higher severity than before.</li>
+                <li><strong style={{ color: 'var(--accent)' }}>Resolved</strong> — present in the prior run but no longer flagged.</li>
+              </ul>
+              <p style={{ margin: '6px 0 0', fontSize: 11 }}>
+                If this is the first run for the collection, everything counts as new.
+              </p>
+            </InfoPopover>
+            {report.diff.new === 0 && report.diff.resolved === 0 && report.diff.regressed === 0 && (
+              <span style={{ color: 'var(--muted)', fontStyle: 'italic' }}>no changes</span>
+            )}
             {report.diff.new > 0 && (
               <span style={{ color: '#1d6cf2', display: 'flex', alignItems: 'center', gap: 4 }}>
                 <span style={{ width: 5, height: 5, borderRadius: 99, background: 'currentColor' }} />
@@ -1185,6 +1210,7 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
         <PreRunHistory
           history={history}
           historyLoading={historyLoading}
+          openingReportId={openingReportId}
           onSelect={loadHistoricalReport}
         />
       ) : !report && !loading ? (
@@ -1208,6 +1234,7 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
           onTabChange={setActiveTab}
           history={history}
           historyLoading={historyLoading}
+          openingReportId={openingReportId}
           onSelectHistorical={loadHistoricalReport}
         />
       ) : report ? (
@@ -1296,23 +1323,51 @@ const EmptyState: React.FC<{ title: string; body: string }> = ({ title, body }) 
   </div>
 );
 
+const COUNT_HELP: Record<string, string> = {
+  Critical: 'Severe data-quality issues that almost certainly need action — broken constraints, large-scale corruption, or unsafe values.',
+  Warning: 'Real issues worth reviewing but not necessarily urgent — drift, partial inconsistencies, or noisy fields.',
+  Info: 'Observations and minor anomalies. Useful for context, rarely actionable on their own.',
+  Dismissed: 'Findings the evaluator rejected (low confidence, weak evidence, or filtered by the rejected-finding policy). Kept here for transparency.',
+};
+
 const ReportBody: React.FC<{
   report: ArgusReport;
   findings: ArgusFinding[];
   sel: ArgusFinding;
   selId: string | null;
   onSelect: (id: string) => void;
-  activeTab: 'findings' | 'history';
-  onTabChange: (tab: 'findings' | 'history') => void;
+  activeTab: 'findings' | 'history' | 'trends';
+  onTabChange: (tab: 'findings' | 'history' | 'trends') => void;
   history: ArgusRunSummary[];
   historyLoading: boolean;
+  openingReportId: string | null;
   onSelectHistorical: (reportId: string) => void;
-}> = ({ report, findings, sel, selId, onSelect, activeTab, onTabChange, history, historyLoading, onSelectHistorical }) => {
+}> = ({ report, findings, sel, selId, onSelect, activeTab, onTabChange, history, historyLoading, openingReportId, onSelectHistorical }) => {
   const { counts } = report;
   const score = report.quality_score ?? 0;
+  const scoreBand = score >= 80 ? 'Good' : score >= 60 ? 'Moderate' : 'Poor';
+  const scoreBandColor = score >= 80 ? '#3a8c5f' : score >= 60 ? '#c98d42' : '#c94250';
 
   return (
-    <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 400px', minHeight: 0 }}>
+    <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 400px', minHeight: 0, position: 'relative' }}>
+      {openingReportId && (
+        <div style={{
+          position: 'absolute', inset: 0, zIndex: 50,
+          background: 'rgba(255,255,255,0.55)',
+          backdropFilter: 'blur(1px)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          gap: 8, color: 'var(--muted)', fontSize: 12.5,
+          fontFamily: 'var(--font-body)', pointerEvents: 'all',
+        }}>
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <circle cx="8" cy="8" r="6" opacity="0.3" />
+            <path d="M14 8a6 6 0 0 0-6-6">
+              <animateTransform attributeName="transform" type="rotate" from="0 8 8" to="360 8 8" dur="0.9s" repeatCount="indefinite" />
+            </path>
+          </svg>
+          Loading report…
+        </div>
+      )}
       {/* LEFT — score + findings */}
       <div style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden', borderRight: '1px solid var(--border)' }}>
         {/* Score row */}
@@ -1320,7 +1375,38 @@ const ReportBody: React.FC<{
           display: 'flex', alignItems: 'center', gap: 0,
           padding: '14px 16px', borderBottom: '1px solid var(--border)', flexShrink: 0,
         }}>
-          <ScoreArc score={score} />
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+            <ScoreArc score={score} />
+            <div style={{
+              display: 'inline-flex', alignItems: 'center', gap: 5,
+              fontSize: 10.5, color: 'var(--muted)', fontFamily: 'var(--font-body)',
+            }}>
+              <span>Audit confidence</span>
+              <InfoPopover title="How audit confidence works">
+                <p style={{ margin: '0 0 6px' }}>
+                  The score (0–100) is produced by the <strong>run evaluator</strong> — a sanity check
+                  on the audit itself, not the data. It does not deduct points per finding.
+                </p>
+                <p style={{ margin: '0 0 6px' }}>
+                  The evaluator runs a set of rules; each triggered rule contributes a verdict:
+                  <strong> pass = 1.0</strong>, <strong>warn = 0.5</strong>, <strong>fail = 0.0</strong>.
+                  The final score is the <strong>worst</strong> rule's score × 100.
+                </p>
+                <p style={{ margin: '0 0 6px' }}>Typical bands:</p>
+                <ul style={{ margin: '0 0 6px', paddingLeft: 16 }}>
+                  <li><strong style={{ color: '#3a8c5f' }}>≥ 80 Good</strong> — no rules tripped; trust the report.</li>
+                  <li><strong style={{ color: '#c98d42' }}>60–79 Moderate</strong> — a warn rule fired (e.g. zero findings on a large sample).</li>
+                  <li><strong style={{ color: '#c94250' }}>&lt; 60 Poor</strong> — the audit ended too early or covered too few fields. Re-run with more iterations.</li>
+                </ul>
+                <p style={{ margin: 0, fontSize: 11 }}>
+                  The score does <em>not</em> reflect how clean your data is — a perfect-score run can still surface critical findings.
+                </p>
+              </InfoPopover>
+            </div>
+            <span style={{ fontSize: 10, color: scoreBandColor, fontFamily: 'var(--font-body)' }}>
+              {scoreBand} audit
+            </span>
+          </div>
           <div style={{ flex: 1, display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 10, paddingLeft: 18 }}>
             {([
               ['Critical', counts.critical, '#c94250', '#fdf0f1'],
@@ -1336,7 +1422,11 @@ const ReportBody: React.FC<{
                 <span style={{
                   fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em',
                   color: 'var(--muted)', fontFamily: 'var(--font-body)',
-                }}>{l}</span>
+                  display: 'inline-flex', alignItems: 'center', gap: 4,
+                }}>
+                  {l}
+                  <InfoPopover title={l}>{COUNT_HELP[l]}</InfoPopover>
+                </span>
                 <span style={{ fontFamily: 'var(--font-display)', fontSize: 26, color: c, lineHeight: 1 }}>{v}</span>
               </div>
             ))}
@@ -1345,8 +1435,12 @@ const ReportBody: React.FC<{
 
         {/* Tab bar */}
         <div style={{ display: 'flex', borderBottom: '1px solid var(--border)', background: 'var(--bg)', flexShrink: 0 }}>
-          {(['findings', 'history'] as const).map(tab => {
+          {(['findings', 'history', 'trends'] as const).map(tab => {
             const active = activeTab === tab;
+            const label =
+              tab === 'findings' ? `Findings · ${findings.length}`
+              : tab === 'history' ? `Run history · ${history.length}`
+              : `Trends · ${history.length}`;
             return (
               <button
                 key={tab}
@@ -1361,7 +1455,7 @@ const ReportBody: React.FC<{
                   cursor: 'pointer',
                 }}
               >
-                {tab === 'findings' ? `Findings · ${findings.length}` : `Run history · ${history.length}`}
+                {label}
               </button>
             );
           })}
@@ -1373,7 +1467,14 @@ const ReportBody: React.FC<{
             history={history}
             historyLoading={historyLoading}
             currentReportId={report.report_id}
+            openingReportId={openingReportId}
             onSelect={onSelectHistorical}
+          />
+        ) : activeTab === 'trends' ? (
+          <ArgusTrendsPanel
+            history={history}
+            currentReportId={report.report_id}
+            onSelectRun={onSelectHistorical}
           />
         ) : (
         <div style={{ flex: 1, overflowY: 'auto' }}>
@@ -1471,6 +1572,11 @@ const ReportBody: React.FC<{
                 <path d="M2 4h12M2 8h8M2 12h5" />
               </svg>
               Evidence query
+              <InfoPopover title="Evidence query">
+                The MongoDB query the agent ran to confirm this finding. Paste it into Mongo
+                shell or the Data Explorer to reproduce the result yourself — every claim in the
+                report is backed by one of these.
+              </InfoPopover>
             </div>
             <pre style={{
               margin: 0, fontFamily: 'var(--font-mono)', fontSize: 11, lineHeight: 1.65,
@@ -1486,6 +1592,11 @@ const ReportBody: React.FC<{
                 <path d="M3 8l3 3 7-7" />
               </svg>
               ReAct trace
+              <InfoPopover title="ReAct trace">
+                The agent's step-by-step reasoning that led to this finding — each line is one
+                think-and-check round. Useful for spotting false positives or understanding why a
+                field was flagged the way it was.
+              </InfoPopover>
             </div>
             <pre style={{
               margin: 0, fontFamily: 'var(--font-mono)', fontSize: 11, lineHeight: 1.7,
@@ -1503,12 +1614,35 @@ const ReportBody: React.FC<{
 const localPart = (email: string | null) =>
   email ? email.split('@')[0] : 'unknown';
 
+const SeverityChip: React.FC<{
+  value: number;
+  color: string;
+  bg: string;
+  label: string;
+}> = ({ value, color, bg, label }) => (
+  <span
+    title={`${value} ${label}`}
+    style={{
+      display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+      minWidth: 22, height: 20, padding: '0 5px',
+      borderRadius: 4, fontFamily: 'var(--font-mono)', fontSize: 11.5,
+      color: value > 0 ? color : 'var(--muted)',
+      background: value > 0 ? bg : 'transparent',
+      border: `1px solid ${value > 0 ? 'transparent' : 'var(--border)'}`,
+      opacity: value > 0 ? 1 : 0.55,
+    }}
+  >
+    {value}
+  </span>
+);
+
 const HistoryList: React.FC<{
   history: ArgusRunSummary[];
   historyLoading: boolean;
   currentReportId?: string;
+  openingReportId?: string | null;
   onSelect: (reportId: string) => void;
-}> = ({ history, historyLoading, currentReportId, onSelect }) => {
+}> = ({ history, historyLoading, currentReportId, openingReportId, onSelect }) => {
   if (historyLoading && history.length === 0) {
     return (
       <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--muted)', fontSize: 12.5, fontFamily: 'var(--font-body)' }}>
@@ -1527,45 +1661,91 @@ const HistoryList: React.FC<{
     <div style={{ flex: 1, overflowY: 'auto' }}>
       {history.map((row) => {
         const isCurrent = row.report_id === currentReportId;
+        const isOpening = row.report_id === openingReportId;
         const score = row.quality_score;
         const scoreColor = score == null
           ? 'var(--muted)'
           : score >= 80 ? '#3a8c5f' : score >= 60 ? '#c98d42' : '#c94250';
+        const counts = row.counts;
         return (
           <div
             key={row.report_id}
-            onClick={() => onSelect(row.report_id)}
+            onClick={() => { if (!openingReportId) onSelect(row.report_id); }}
             style={{
               display: 'flex', alignItems: 'center', gap: 12,
               padding: '10px 16px', borderBottom: '1px solid var(--border)',
-              cursor: 'pointer',
-              background: isCurrent ? 'var(--accent-soft)' : 'transparent',
+              cursor: openingReportId ? 'wait' : 'pointer',
+              background: isOpening
+                ? 'var(--accent-soft)'
+                : isCurrent ? 'var(--accent-soft)' : 'transparent',
+              opacity: openingReportId && !isOpening ? 0.55 : 1,
               fontFamily: 'var(--font-body)',
+              transition: 'background 0.12s, opacity 0.12s',
             }}
           >
-            <div style={{
-              width: 32, textAlign: 'center', fontFamily: 'var(--font-display)',
-              fontSize: 18, fontWeight: 500, color: scoreColor, flexShrink: 0,
-            }}>
-              {score ?? '—'}
-            </div>
+            {/* PRIMARY — data-quality signal (severity strip) */}
+            {counts ? (
+              <div
+                style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0, minWidth: 96 }}
+                title={`${counts.critical} critical · ${counts.warning} warning · ${counts.info} info`}
+              >
+                <SeverityChip color="#c94250" bg="#fdf0f1" value={counts.critical} label="critical" />
+                <SeverityChip color="#c98d42" bg="#fdf6ed" value={counts.warning} label="warning" />
+                <SeverityChip color="var(--muted)" bg="var(--soft)" value={counts.info} label="info" />
+              </div>
+            ) : (
+              <div style={{
+                minWidth: 96, fontFamily: 'var(--font-mono)', fontSize: 12,
+                color: 'var(--muted)', flexShrink: 0,
+              }}>
+                {row.findings_count} findings
+              </div>
+            )}
             <div style={{ flex: 1, minWidth: 0 }}>
               <div style={{ fontSize: 12.5, color: 'var(--fg)' }}>
                 {row.run_at ? new Date(row.run_at).toLocaleString() : '—'}
                 {isCurrent && (
                   <span style={{ ...tagStyle, marginLeft: 8, fontSize: 10 }}>current</span>
                 )}
+                {isOpening && (
+                  <span style={{ ...tagStyle, marginLeft: 8, fontSize: 10, color: 'var(--accent)', borderColor: 'var(--accent)' }}>
+                    loading…
+                  </span>
+                )}
               </div>
               <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 2 }}>
                 <span style={{ fontFamily: 'var(--font-mono)' }}>{localPart(row.created_by)}</span>
-                {' · '}{row.findings_count} findings
                 {' · '}{row.total_tokens.toLocaleString()} tokens
                 {row.run_eval_verdict && <> · <span>{row.run_eval_verdict}</span></>}
               </div>
             </div>
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ color: 'var(--muted)', flexShrink: 0 }}>
-              <path d="M6 4l4 4-4 4" />
-            </svg>
+            {/* SECONDARY — audit confidence (not data quality) */}
+            <div
+              title="Audit confidence — how reliable this audit was, not how clean the data is"
+              style={{
+                display: 'flex', flexDirection: 'column', alignItems: 'flex-end',
+                gap: 1, flexShrink: 0, marginRight: 6,
+              }}
+            >
+              <span style={{
+                fontFamily: 'var(--font-mono)', fontSize: 12, color: scoreColor, lineHeight: 1,
+              }}>
+                {score ?? '—'}
+              </span>
+              <span style={{ fontSize: 9, color: 'var(--muted)' }}>confidence</span>
+            </div>
+            {isOpening ? (
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.5" style={{ flexShrink: 0 }}>
+                <circle cx="8" cy="8" r="6" opacity="0.3" />
+                <path d="M14 8a6 6 0 0 0-6-6">
+                  <animateTransform attributeName="transform" type="rotate" from="0 8 8" to="360 8 8" dur="0.9s" repeatCount="indefinite" />
+                </path>
+              </svg>
+            ) : (
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ color: 'var(--muted)', flexShrink: 0 }}>
+                <path d="M6 4l4 4-4 4" />
+              </svg>
+            )}
           </div>
         );
       })}
@@ -1576,8 +1756,9 @@ const HistoryList: React.FC<{
 const PreRunHistory: React.FC<{
   history: ArgusRunSummary[];
   historyLoading: boolean;
+  openingReportId: string | null;
   onSelect: (reportId: string) => void;
-}> = ({ history, historyLoading, onSelect }) => (
+}> = ({ history, historyLoading, openingReportId, onSelect }) => (
   <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
     <div style={{
       padding: '12px 18px 8px', fontSize: 11,
@@ -1586,7 +1767,12 @@ const PreRunHistory: React.FC<{
     }}>
       Prior runs for this collection — pick one to load, or press Run to start a fresh audit.
     </div>
-    <HistoryList history={history} historyLoading={historyLoading} onSelect={onSelect} />
+    <HistoryList
+      history={history}
+      historyLoading={historyLoading}
+      openingReportId={openingReportId}
+      onSelect={onSelect}
+    />
   </div>
 );
 

--- a/frontend/pages/AnalyticsPage.tsx
+++ b/frontend/pages/AnalyticsPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '../services/argusService';
 import { ArgusTrendsPanel } from '../components/ArgusTrendsPanel';
 import { useNotifications } from '../contexts/NotificationsContext';
+import { FindingRatingButtons } from '../components/FindingRatingButtons';
 
 const DEFAULT_MAX_ITER = 20;
 const DEFAULT_SAMPLE_SIZE = 200;
@@ -625,6 +626,19 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
   }, [accountId, databaseName, collection]);
 
   useEffect(() => { refreshHistory(); }, [refreshHistory]);
+
+  // Arm A — mirror the persisted verdict into local report state so the
+  // rating buttons stay in their post-click state when the user re-selects
+  // the same finding without a full refetch.
+  const handleRateFinding = useCallback((findingId: string, label: 'tp' | 'fp') => {
+    setReport((prev) => {
+      if (!prev) return prev;
+      const updated = prev.findings.map((f) =>
+        f.id === findingId ? { ...f, user_label: label } : f,
+      );
+      return { ...prev, findings: updated };
+    });
+  }, []);
 
   const loadHistoricalReport = useCallback(async (reportId: string) => {
     setError(null);
@@ -1300,6 +1314,7 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
           historyLoading={historyLoading}
           openingReportId={openingReportId}
           onSelectHistorical={loadHistoricalReport}
+          onRateFinding={handleRateFinding}
         />
       ) : report ? (
         <EmptyState title="No findings" body="QueryArgus completed without flagging any data-quality issues in this collection." />
@@ -1407,7 +1422,8 @@ const ReportBody: React.FC<{
   historyLoading: boolean;
   openingReportId: string | null;
   onSelectHistorical: (reportId: string) => void;
-}> = ({ report, findings, sel, selId, onSelect, activeTab, onTabChange, history, historyLoading, openingReportId, onSelectHistorical }) => {
+  onRateFinding: (findingId: string, label: 'tp' | 'fp') => void;
+}> = ({ report, findings, sel, selId, onSelect, activeTab, onTabChange, history, historyLoading, openingReportId, onSelectHistorical, onRateFinding }) => {
   const { counts } = report;
   const score = report.quality_score ?? 0;
   const scoreBand = score >= 80 ? 'Good' : score >= 60 ? 'Moderate' : 'Poor';
@@ -1627,6 +1643,23 @@ const ReportBody: React.FC<{
                 {sel.affected_pct.toFixed(1)}%
               </span>{' '}of collection
             </span>
+          </div>
+          {/* Arm A — post-hoc rating. Verdict drives the next-run planner via
+              HistoricalContext.user_verdicts. */}
+          <div style={{
+            marginTop: 10, paddingTop: 10, borderTop: '1px dashed var(--border)',
+            display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap',
+          }}>
+            <span style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em',
+              color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>
+              Your verdict
+            </span>
+            <FindingRatingButtons
+              reportId={report.report_id}
+              findingId={sel.id}
+              value={sel.user_label ?? null}
+              onChange={(label) => onRateFinding(sel.id, label)}
+            />
           </div>
         </div>
 

--- a/frontend/pages/AnalyticsPage.tsx
+++ b/frontend/pages/AnalyticsPage.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { CollectionSummary } from '../types';
 import {
   ArgusDiff,
   ArgusFinding,
@@ -378,7 +377,6 @@ const ThresholdInput: React.FC<{
 interface AnalyticsPageProps {
   accountId?: string;
   databaseName?: string;
-  collections?: CollectionSummary[];
   collection: string;
   onCollectionChange: (name: string) => void;
   collectionDefaulting?: boolean;
@@ -437,6 +435,7 @@ const tagStyle: React.CSSProperties = {
   padding: '0 6px', height: 18, borderRadius: 4,
   fontSize: 10, fontFamily: 'var(--font-body)',
   border: '1px solid var(--border)', background: 'var(--soft)',
+  whiteSpace: 'nowrap', flexShrink: 0,
 };
 
 const sectionLabel: React.CSSProperties = {
@@ -449,7 +448,6 @@ const sectionLabel: React.CSSProperties = {
 const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
   accountId,
   databaseName,
-  collections,
   collection,
   onCollectionChange,
   collectionDefaulting = false,
@@ -794,19 +792,24 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
     }
   };
 
+  const collectionSwitching =
+    !!collection && historyLoading && !report && jobStatus !== 'running' && jobStatus !== 'queued';
+
   return (
-    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', minHeight: 0 }}>
+    <div style={{ position: 'relative', flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', minHeight: 0 }}>
       {/* QueryArgus + controls row */}
       <div style={{
         padding: '10px 18px', display: 'flex', alignItems: 'center', gap: 10,
+        rowGap: 8, flexWrap: 'wrap',
         borderBottom: '1px solid var(--border)', background: 'var(--bg)', flexShrink: 0,
       }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0, flexWrap: 'nowrap' }}>
           <div style={{
             width: 20, height: 20, borderRadius: 4, background: 'var(--fg)', color: 'var(--bg)',
             display: 'grid', placeItems: 'center', fontSize: 11, fontFamily: 'var(--font-display)', fontWeight: 600,
+            flexShrink: 0,
           }}>A</div>
-          <span style={{ fontSize: 13, fontWeight: 500, fontFamily: 'var(--font-body)' }}>QueryArgus</span>
+          <span style={{ fontSize: 13, fontWeight: 500, fontFamily: 'var(--font-body)', whiteSpace: 'nowrap' }}>QueryArgus</span>
           <span style={tagStyle}>data quality</span>
           <InfoPopover title="What is QueryArgus?">
             <p style={{ margin: '0 0 6px' }}>
@@ -824,44 +827,27 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
           </InfoPopover>
         </div>
         <span style={{ color: 'var(--border)' }}>·</span>
-        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--muted)' }}>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--muted)', whiteSpace: 'nowrap' }}>
           {databaseName ?? '—'}
+          {collection && (
+            <>
+              <span style={{ margin: '0 6px', color: 'var(--border)' }}>/</span>
+              <span style={{ color: 'var(--fg)' }}>{collection}</span>
+            </>
+          )}
         </span>
-        {hasConnection && (collections?.length ?? 0) > 0 && (
-          <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-            <select
-              value={collection}
-              onChange={(e) => { setCollection(e.target.value); }}
-              disabled={collectionDefaulting}
-              style={{
-                fontFamily: 'var(--font-mono)', fontSize: 12,
-                padding: '3px 8px', borderRadius: 6,
-                background: 'var(--panel)', color: 'var(--fg)',
-                border: '1px solid var(--border)',
-                cursor: collectionDefaulting ? 'progress' : 'pointer',
-                opacity: collectionDefaulting ? 0.7 : 1,
-              }}
-            >
-              {[...collections!]
-                .sort((a, b) => a.name.localeCompare(b.name))
-                .map((c) => (
-                  <option key={c.name} value={c.name}>{c.name}</option>
-                ))}
-            </select>
-            {collectionDefaulting && (
-              <svg
-                width="13" height="13" viewBox="0 0 16 16" fill="none"
-                stroke="var(--muted)" strokeWidth="1.5"
-                style={{ animation: 'qp-spin 0.8s linear infinite' }}
-                aria-label="Loading recent run"
-              >
-                <circle cx="8" cy="8" r="6" strokeOpacity="0.3" />
-                <path d="M8 2a6 6 0 0 1 6 6" />
-              </svg>
-            )}
-          </div>
+        {collectionDefaulting && (
+          <svg
+            width="13" height="13" viewBox="0 0 16 16" fill="none"
+            stroke="var(--muted)" strokeWidth="1.5"
+            style={{ animation: 'qp-spin 0.8s linear infinite', flexShrink: 0 }}
+            aria-label="Loading recent run"
+          >
+            <circle cx="8" cy="8" r="6" strokeOpacity="0.3" />
+            <path d="M8 2a6 6 0 0 1 6 6" />
+          </svg>
         )}
-        <div style={{ marginLeft: 'auto', display: 'flex', gap: 6, alignItems: 'center' }}>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap', rowGap: 6, justifyContent: 'flex-end' }}>
           <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>Profile</span>
           <InfoPopover title="Profiles" align="right">
             <p style={{ margin: '0 0 6px' }}>
@@ -1436,6 +1422,29 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
                 style={{ fontSize: 12 }}
               >{saveBusy ? 'Saving…' : 'Save'}</button>
             </div>
+          </div>
+        </div>
+      )}
+      {collectionSwitching && (
+        <div style={{
+          position: 'absolute', inset: 0, zIndex: 40,
+          background: 'rgba(0,0,0,0.18)', backdropFilter: 'blur(2px)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <div style={{
+            background: 'var(--panel)', borderRadius: 10,
+            boxShadow: '0 8px 30px rgba(0,0,0,0.12)',
+            padding: '12px 22px', display: 'flex', alignItems: 'center', gap: 10,
+            border: '1px solid var(--border)',
+          }}>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.5"
+                 style={{ animation: 'qp-spin 0.8s linear infinite' }}>
+              <circle cx="8" cy="8" r="6" strokeOpacity="0.3"/>
+              <path d="M8 2a6 6 0 0 1 6 6"/>
+            </svg>
+            <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
+              Loading {collection}…
+            </span>
           </div>
         </div>
       )}

--- a/frontend/pages/AnalyticsPage.tsx
+++ b/frontend/pages/AnalyticsPage.tsx
@@ -22,10 +22,12 @@ import {
 import { ArgusTrendsPanel } from '../components/ArgusTrendsPanel';
 import { useNotifications } from '../contexts/NotificationsContext';
 import { FindingRatingButtons } from '../components/FindingRatingButtons';
+import { getAvailableModels } from '../services/geminiService';
 
 const DEFAULT_MAX_ITER = 20;
 const DEFAULT_SAMPLE_SIZE = 200;
 const DEFAULT_MIN_SEVERITY: ArgusMinSeverity = 'low';
+const DEFAULT_LLM_MODEL = 'gemini-2.5-flash';
 const MIN_SEVERITIES: ArgusMinSeverity[] = ['low', 'medium', 'high', 'critical'];
 
 type EvalStrategy = 'none' | 'rules' | 'self' | 'judge' | 'composite';
@@ -454,6 +456,15 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
   const { trackArgusRun } = useNotifications();
   const setCollection = onCollectionChange;
   const [profile, setProfile] = useState<ArgusProfile>('fast');
+  const [selectedModel, setSelectedModel] = useState<string>(
+    () => localStorage.getItem('qp_selected_model') ?? DEFAULT_LLM_MODEL,
+  );
+  const [availableModels, setAvailableModels] = useState<string[]>([DEFAULT_LLM_MODEL]);
+  useEffect(() => {
+    getAvailableModels().then((models) => {
+      if (models.length > 0) setAvailableModels(models);
+    }).catch((e) => console.warn('getAvailableModels failed', e));
+  }, []);
   const [report, setReport] = useState<ArgusReport | null>(null);
   const [jobStatus, setJobStatus] = useState<ArgusJobStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -749,6 +760,7 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
       if (maxIter !== DEFAULT_MAX_ITER) argusOverrides.max_iterations = maxIter;
       if (sampleSize !== DEFAULT_SAMPLE_SIZE) argusOverrides.sample_size = sampleSize;
       if (minSeverity !== DEFAULT_MIN_SEVERITY) argusOverrides.min_severity = minSeverity;
+      if (selectedModel && selectedModel !== DEFAULT_LLM_MODEL) argusOverrides.llm_model = selectedModel;
       const { job_id } = await startArgusAudit({
         accountId,
         database: databaseName,
@@ -886,6 +898,37 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
               ))}
             </div>
           )}
+          <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            <label
+              htmlFor="argus-model-select"
+              style={{ fontSize: 11.5, color: 'var(--muted)', whiteSpace: 'nowrap' }}
+            >
+              Model
+            </label>
+            <select
+              id="argus-model-select"
+              value={selectedModel}
+              onChange={(e) => {
+                setSelectedModel(e.target.value);
+                localStorage.setItem('qp_selected_model', e.target.value);
+              }}
+              disabled={loading}
+              style={{
+                fontFamily: 'var(--font-mono)', fontSize: 11.5,
+                padding: '3px 8px', borderRadius: 6,
+                background: 'var(--panel)', color: 'var(--fg)',
+                border: '1px solid var(--border)',
+                cursor: loading ? 'not-allowed' : 'pointer',
+                maxWidth: 220,
+              }}
+              aria-label="Select AI model for audit"
+              title="AI model used by QueryArgus for this run"
+            >
+              {availableModels.map((m) => (
+                <option key={m} value={m}>{m}</option>
+              ))}
+            </select>
+          </div>
           <button
             type="button"
             onClick={() => setCustomizeOpen(v => !v)}

--- a/frontend/pages/AnalyticsPage.tsx
+++ b/frontend/pages/AnalyticsPage.tsx
@@ -1,199 +1,477 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
+import { CollectionSummary } from '../types';
+import {
+  ArgusDiff,
+  ArgusFinding,
+  ArgusProfile,
+  ArgusReport,
+  ArgusSeverity,
+  runArgusAudit,
+} from '../services/argusService';
 
 interface AnalyticsPageProps {
   accountId?: string;
   databaseName?: string;
+  collections?: CollectionSummary[];
 }
 
-const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName }) => {
+const SEVER_COLOR: Record<ArgusSeverity, string> = {
+  critical: '#c94250',
+  warning: '#c98d42',
+  info: 'var(--muted)',
+};
+const SEVER_BG: Record<ArgusSeverity, string> = {
+  critical: '#fdf0f1',
+  warning: '#fdf6ed',
+  info: 'var(--soft)',
+};
+const DIFF_COLOR: Record<ArgusDiff, string> = {
+  new: '#1d6cf2',
+  regressed: '#c98d42',
+  existing: 'var(--muted)',
+  resolved: 'var(--accent)',
+};
+
+const ScoreArc: React.FC<{ score: number }> = ({ score }) => {
+  const R = 48, cx = 60, cy = 60;
+  const pct = score / 100;
+  const col = score >= 80 ? '#3a8c5f' : score >= 60 ? '#c98d42' : '#c94250';
+  const sweep = 270;
+  const start = 135;
+  const rad = (deg: number) => (deg * Math.PI) / 180;
+  const x1 = cx + R * Math.cos(rad(start));
+  const y1 = cy + R * Math.sin(rad(start));
+  const end = start + sweep;
+  const x2 = cx + R * Math.cos(rad(end));
+  const y2 = cy + R * Math.sin(rad(end));
+  const bgArc = `M ${x1} ${y1} A ${R} ${R} 0 1 1 ${x2} ${y2}`;
+  const filledEnd = start + sweep * pct;
+  const xe = cx + R * Math.cos(rad(filledEnd));
+  const ye = cy + R * Math.sin(rad(filledEnd));
+  const largeArc = sweep * pct > 180 ? 1 : 0;
+  const fgArc = `M ${x1} ${y1} A ${R} ${R} 0 ${largeArc} 1 ${xe.toFixed(2)} ${ye.toFixed(2)}`;
+  return (
+    <svg width="120" height="120" viewBox="0 0 120 120">
+      <path d={bgArc} fill="none" stroke="var(--border)" strokeWidth="8" strokeLinecap="round" />
+      <path d={fgArc} fill="none" stroke={col} strokeWidth="8" strokeLinecap="round" />
+      <text x="60" y="58" textAnchor="middle" fontSize="22" fontWeight="500" fontFamily="var(--font-display)" fill="var(--fg)">{score}</text>
+      <text x="60" y="72" textAnchor="middle" fontSize="10" fill="var(--muted)" fontFamily="var(--font-body)">/ 100</text>
+      <text x="60" y="88" textAnchor="middle" fontSize="9" fill={col} fontFamily="var(--font-body)">
+        {score >= 80 ? 'GOOD' : score >= 60 ? 'MODERATE' : 'POOR'}
+      </text>
+    </svg>
+  );
+};
+
+const tagStyle: React.CSSProperties = {
+  display: 'inline-flex', alignItems: 'center',
+  padding: '0 6px', height: 18, borderRadius: 4,
+  fontSize: 10, fontFamily: 'var(--font-body)',
+  border: '1px solid var(--border)', background: 'var(--soft)',
+};
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em',
+  color: 'var(--muted)', marginBottom: 6,
+  display: 'flex', alignItems: 'center', gap: 6,
+  fontFamily: 'var(--font-body)',
+};
+
+const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, collections }) => {
   const hasConnection = !!(accountId && databaseName);
+  const [collection, setCollection] = useState<string>(collections?.[0]?.name ?? '');
+  const [profile, setProfile] = useState<ArgusProfile>('fast');
+  const [report, setReport] = useState<ArgusReport | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selId, setSelId] = useState<string | null>(null);
+
+  const findings = report?.findings ?? [];
+  const sel: ArgusFinding | null = useMemo(() => {
+    if (!findings.length) return null;
+    return findings.find((f) => f.id === selId) ?? findings[0];
+  }, [findings, selId]);
+
+  const runAudit = async () => {
+    if (!accountId || !databaseName || !collection) return;
+    setLoading(true);
+    setError(null);
+    setReport(null);
+    setSelId(null);
+    try {
+      const r = await runArgusAudit({
+        accountId,
+        database: databaseName,
+        collection,
+        profile,
+      });
+      setReport(r);
+      setSelId(r.findings[0]?.id ?? null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
-    <div style={{
-      flex: 1, display: 'flex', flexDirection: 'column',
-      background: 'var(--bg)', minHeight: 0,
-    }}>
-      {/* Page header */}
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', minHeight: 0 }}>
+      {/* QueryArgus + controls row */}
       <div style={{
-        padding: '20px 28px 16px',
-        borderBottom: '1px solid var(--border)',
-        background: 'var(--panel)',
-        flexShrink: 0,
+        padding: '10px 18px', display: 'flex', alignItems: 'center', gap: 10,
+        borderBottom: '1px solid var(--border)', background: 'var(--bg)', flexShrink: 0,
       }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <div style={{
-            width: 32, height: 32, borderRadius: 8, flexShrink: 0,
-            background: 'var(--accent-soft)',
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            width: 20, height: 20, borderRadius: 4, background: 'var(--fg)', color: 'var(--bg)',
+            display: 'grid', placeItems: 'center', fontSize: 11, fontFamily: 'var(--font-display)', fontWeight: 600,
+          }}>A</div>
+          <span style={{ fontSize: 13, fontWeight: 500, fontFamily: 'var(--font-body)' }}>QueryArgus</span>
+          <span style={tagStyle}>data quality</span>
+        </div>
+        <span style={{ color: 'var(--border)' }}>·</span>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--muted)' }}>
+          {databaseName ?? '—'}
+        </span>
+        {hasConnection && (collections?.length ?? 0) > 0 && (
+          <select
+            value={collection}
+            onChange={(e) => setCollection(e.target.value)}
+            style={{
+              fontFamily: 'var(--font-mono)', fontSize: 12,
+              padding: '3px 8px', borderRadius: 6,
+              background: 'var(--panel)', color: 'var(--fg)',
+              border: '1px solid var(--border)', cursor: 'pointer',
+            }}
+          >
+            {collections!.map((c) => (
+              <option key={c.name} value={c.name}>{c.name}</option>
+            ))}
+          </select>
+        )}
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 6, alignItems: 'center' }}>
+          <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>Profile</span>
+          <div style={{
+            display: 'flex', background: 'var(--soft)', borderRadius: 6,
+            border: '1px solid var(--border)', padding: 2, gap: 1,
           }}>
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.4">
-              <path d="M2 13h12M4 11V6M7 11V3M10 11V8M13 11V5"/>
-            </svg>
+            {(['fast', 'balanced', 'thorough'] as ArgusProfile[]).map((p) => (
+              <span
+                key={p}
+                onClick={() => setProfile(p)}
+                style={{
+                  padding: '2px 8px', borderRadius: 4, fontSize: 11.5,
+                  background: p === profile ? 'var(--panel)' : 'transparent',
+                  boxShadow: p === profile ? '0 0 0 1px var(--border)' : 'none',
+                  color: p === profile ? 'var(--fg)' : 'var(--muted)',
+                  cursor: 'pointer', fontFamily: 'var(--font-body)',
+                }}
+              >{p}</span>
+            ))}
           </div>
-          <div>
-            <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
-              Analytics
-            </div>
-            {hasConnection && (
-              <div style={{ fontSize: 11.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)', marginTop: 1 }}>
-                {databaseName}
-              </div>
+          <button
+            className="qa-btn primary"
+            disabled={!hasConnection || !collection || loading}
+            onClick={runAudit}
+            style={{ gap: 6, opacity: !hasConnection || !collection || loading ? 0.6 : 1 }}
+          >
+            {loading ? (
+              <>
+                <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <circle cx="8" cy="8" r="6" opacity="0.3" />
+                  <path d="M14 8a6 6 0 0 0-6-6">
+                    <animateTransform attributeName="transform" type="rotate" from="0 8 8" to="360 8 8" dur="0.9s" repeatCount="indefinite" />
+                  </path>
+                </svg>
+                Running…
+              </>
+            ) : (
+              <>
+                <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <polygon points="4,2 14,8 4,14" />
+                </svg>
+                Run audit
+              </>
             )}
-          </div>
-          <span className="qa-chip accent" style={{ marginLeft: 6 }}>Coming soon</span>
+          </button>
         </div>
       </div>
 
-      {/* Coming soon body */}
-      <div style={{
-        flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
-        padding: '48px 32px',
-      }}>
+      {/* Status bar */}
+      {report && (
         <div style={{
-          maxWidth: 560, width: '100%',
-          display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 32,
-          textAlign: 'center',
+          padding: '6px 18px', display: 'flex', alignItems: 'center', gap: 12,
+          borderBottom: '1px solid var(--border)', background: 'var(--soft)',
+          fontSize: 11, color: 'var(--muted)', flexShrink: 0, fontFamily: 'var(--font-body)',
         }}>
-          {/* Icon cluster */}
-          <div style={{ position: 'relative', width: 80, height: 80 }}>
-            <div style={{
-              width: 80, height: 80, borderRadius: 20,
-              background: 'var(--accent-soft)',
-              display: 'flex', alignItems: 'center', justifyContent: 'center',
-            }}>
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M3 18h18M6 14V9M9 14V5M12 14v-3M15 14V7M18 14v-6"/>
-              </svg>
-            </div>
-            {/* Small badge */}
-            <div style={{
-              position: 'absolute', bottom: -6, right: -6,
-              width: 24, height: 24, borderRadius: 8,
-              background: 'var(--panel)', border: '1px solid var(--border)',
-              display: 'flex', alignItems: 'center', justifyContent: 'center',
-              boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
-            }}>
-              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="var(--muted)" strokeWidth="1.5">
-                <circle cx="8" cy="8" r="6"/><path d="M8 5v4M8 10.5v.5"/>
-              </svg>
-            </div>
-          </div>
+          <span className="qa-dot ok"></span>
+          <span>
+            {new Date(report.run_at).toLocaleString()} · {report.duration_seconds.toFixed(1)}s
+          </span>
+          <span>·</span>
+          <span>{report.iterations} iterations · {report.total_tokens.toLocaleString()} tokens</span>
+          <span>·</span>
+          <span>{report.model} · {report.profile}</span>
+          <span style={{ marginLeft: 'auto', display: 'flex', gap: 10 }}>
+            {report.diff.new > 0 && (
+              <span style={{ color: '#1d6cf2', display: 'flex', alignItems: 'center', gap: 4 }}>
+                <span style={{ width: 5, height: 5, borderRadius: 99, background: 'currentColor' }} />
+                {report.diff.new} new
+              </span>
+            )}
+            {report.diff.resolved > 0 && (
+              <span style={{ color: 'var(--accent)', display: 'flex', alignItems: 'center', gap: 4 }}>
+                <span style={{ width: 5, height: 5, borderRadius: 99, background: 'currentColor' }} />
+                {report.diff.resolved} resolved
+              </span>
+            )}
+            {report.diff.regressed > 0 && (
+              <span style={{ color: '#c98d42', display: 'flex', alignItems: 'center', gap: 4 }}>
+                <span style={{ width: 5, height: 5, borderRadius: 99, background: 'currentColor' }} />
+                {report.diff.regressed} regressed
+              </span>
+            )}
+          </span>
+        </div>
+      )}
 
-          {/* Heading */}
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            <h2 style={{
-              fontSize: 22, fontWeight: 600, margin: 0,
-              fontFamily: 'var(--font-display)', color: 'var(--fg)',
-              letterSpacing: '-0.02em',
-            }}>
-              Database Audit & Insights
-            </h2>
-            <p style={{
-              fontSize: 13.5, color: 'var(--muted)', margin: 0, lineHeight: 1.6,
-              fontFamily: 'var(--font-body)',
-            }}>
-              {"This tab will surface automated collection audits powered by "}
-              <span style={{ color: 'var(--fg)', fontWeight: 500 }}>QueryArgus</span>
-              {" — an AI agent that analyses your collections for schema inconsistencies, missing indexes, high-cardinality fields, and query performance opportunities."}
-            </p>
-          </div>
+      {/* Error banner */}
+      {error && (
+        <div style={{
+          padding: '10px 18px', background: '#fdf0f1', color: '#c94250',
+          borderBottom: '1px solid var(--border)', fontSize: 12,
+          fontFamily: 'var(--font-body)', flexShrink: 0,
+        }}>
+          {error}
+        </div>
+      )}
 
-          {/* Feature preview cards */}
-          <div style={{
-            width: '100%', display: 'grid',
-            gridTemplateColumns: '1fr 1fr', gap: 12,
-          }}>
-            {[
-              {
-                icon: (
-                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
-                    <path d="M3 2h7l3 3v9H3z"/><path d="M6 7h5M6 9h5M6 11h3"/>
-                  </svg>
-                ),
-                title: 'Schema findings',
-                desc: 'Inconsistent field types, sparse fields, and structural anomalies across documents.',
-              },
-              {
-                icon: (
-                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
-                    <path d="M2 13h12M4 11V6M7 11V3M10 11V8M13 11V5"/>
-                  </svg>
-                ),
-                title: 'Performance insights',
-                desc: 'Missing index recommendations, high-cardinality fields, and costly query patterns.',
-              },
-              {
-                icon: (
-                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
-                    <circle cx="8" cy="8" r="6"/><path d="M8 5v3.5L10 10"/>
-                  </svg>
-                ),
-                title: 'Audit history',
-                desc: 'Track findings over time to measure how your database health evolves.',
-              },
-              {
-                icon: (
-                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
-                    <path d="M8 1L15 14H1L8 1z"/><path d="M8 6v4M8 11.5v.5"/>
-                  </svg>
-                ),
-                title: 'Severity scoring',
-                desc: 'Each finding is evaluated and scored so you can triage the most impactful issues first.',
-              },
-            ].map(({ icon, title, desc }) => (
-              <div key={title} style={{
-                background: 'var(--panel)', border: '1px solid var(--border)',
-                borderRadius: 10, padding: '14px 16px',
-                display: 'flex', flexDirection: 'column', gap: 6,
-                textAlign: 'left',
+      {/* Body */}
+      {!hasConnection ? (
+        <EmptyState
+          title="No database connected"
+          body="Connect to a Cosmos DB from Workspace or Explorer first, then return here to run an audit."
+        />
+      ) : !report && !loading ? (
+        <EmptyState
+          title="Run an audit"
+          body={`QueryArgus will sample ${collection || 'a collection'} and report data-quality findings. Pick a profile and press Run.`}
+        />
+      ) : loading && !report ? (
+        <EmptyState title="Running audit…" body="The ReAct agent is sampling, querying, and writing findings. This usually takes 20–90 seconds depending on profile." />
+      ) : report && sel ? (
+        <ReportBody
+          report={report}
+          findings={findings}
+          sel={sel}
+          selId={selId ?? findings[0]?.id ?? null}
+          onSelect={setSelId}
+        />
+      ) : report ? (
+        <EmptyState title="No findings" body="QueryArgus completed without flagging any data-quality issues in this collection." />
+      ) : null}
+    </div>
+  );
+};
+
+const EmptyState: React.FC<{ title: string; body: string }> = ({ title, body }) => (
+  <div style={{
+    flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+    padding: '48px 32px', minHeight: 0,
+  }}>
+    <div style={{ maxWidth: 460, textAlign: 'center' }}>
+      <div style={{
+        fontSize: 15, fontWeight: 500, color: 'var(--fg)',
+        fontFamily: 'var(--font-display)', marginBottom: 6,
+      }}>{title}</div>
+      <div style={{
+        fontSize: 13, color: 'var(--muted)', lineHeight: 1.55,
+        fontFamily: 'var(--font-body)',
+      }}>{body}</div>
+    </div>
+  </div>
+);
+
+const ReportBody: React.FC<{
+  report: ArgusReport;
+  findings: ArgusFinding[];
+  sel: ArgusFinding;
+  selId: string | null;
+  onSelect: (id: string) => void;
+}> = ({ report, findings, sel, selId, onSelect }) => {
+  const { counts } = report;
+  const score = report.quality_score ?? 0;
+
+  return (
+    <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 400px', minHeight: 0 }}>
+      {/* LEFT — score + findings */}
+      <div style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden', borderRight: '1px solid var(--border)' }}>
+        {/* Score row */}
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 0,
+          padding: '14px 16px', borderBottom: '1px solid var(--border)', flexShrink: 0,
+        }}>
+          <ScoreArc score={score} />
+          <div style={{ flex: 1, display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 10, paddingLeft: 18 }}>
+            {([
+              ['Critical', counts.critical, '#c94250', '#fdf0f1'],
+              ['Warning', counts.warning, '#c98d42', '#fdf6ed'],
+              ['Info', counts.info, 'var(--muted)', 'var(--soft)'],
+              ['Dismissed', counts.dismissed, 'var(--muted)', 'var(--soft)'],
+            ] as const).map(([l, v, c, bg]) => (
+              <div key={l} style={{
+                background: bg, borderRadius: 8, padding: '8px 10px',
+                display: 'flex', flexDirection: 'column', gap: 3,
+                border: '1px solid var(--border)',
               }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
-                  <span style={{ color: 'var(--accent)', display: 'flex', flexShrink: 0 }}>{icon}</span>
-                  <span style={{ fontSize: 12.5, fontWeight: 500, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
-                    {title}
-                  </span>
-                </div>
-                <p style={{ fontSize: 12, color: 'var(--muted)', margin: 0, lineHeight: 1.5, fontFamily: 'var(--font-body)' }}>
-                  {desc}
-                </p>
+                <span style={{
+                  fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em',
+                  color: 'var(--muted)', fontFamily: 'var(--font-body)',
+                }}>{l}</span>
+                <span style={{ fontFamily: 'var(--font-display)', fontSize: 26, color: c, lineHeight: 1 }}>{v}</span>
               </div>
             ))}
           </div>
+        </div>
 
-          {/* Context note */}
-          {hasConnection ? (
-            <div style={{
-              display: 'flex', alignItems: 'center', gap: 8,
-              padding: '10px 16px', borderRadius: 8,
-              background: 'var(--accent-soft)',
-              border: '1px solid color-mix(in oklch, var(--accent) 20%, var(--border))',
-            }}>
-              <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.5" style={{ flexShrink: 0 }}>
-                <circle cx="8" cy="8" r="6"/><path d="M8 7v4M8 5.5v.5"/>
-              </svg>
-              <span style={{ fontSize: 12, color: 'var(--accent)', fontFamily: 'var(--font-body)' }}>
-                {"When available, audits will run against "}
-                <span style={{ fontFamily: 'var(--font-mono)', fontWeight: 500 }}>{databaseName}</span>
-                {" — no reconnection needed."}
-              </span>
-            </div>
-          ) : (
-            <div style={{
-              display: 'flex', alignItems: 'center', gap: 8,
-              padding: '10px 16px', borderRadius: 8,
-              background: 'var(--soft)',
-              border: '1px solid var(--border)',
-            }}>
-              <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="var(--muted)" strokeWidth="1.5" style={{ flexShrink: 0 }}>
-                <circle cx="8" cy="8" r="6"/><path d="M8 7v4M8 5.5v.5"/>
-              </svg>
-              <span style={{ fontSize: 12, color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>
-                Connect to a database from Workspace or Explorer first, then return here to run an audit.
-              </span>
-            </div>
-          )}
+        {/* Tab bar (history deferred) */}
+        <div style={{ display: 'flex', borderBottom: '1px solid var(--border)', background: 'var(--bg)', flexShrink: 0 }}>
+          <div style={{
+            padding: '8px 16px', fontSize: 12.5, color: 'var(--fg)',
+            borderBottom: '2px solid var(--accent)', fontWeight: 500,
+            fontFamily: 'var(--font-body)',
+          }}>
+            Findings · {findings.length}
+          </div>
+          <div style={{
+            padding: '8px 16px', fontSize: 12.5, color: 'var(--muted)',
+            borderBottom: '2px solid transparent', cursor: 'not-allowed',
+            fontFamily: 'var(--font-body)',
+          }} title="Run history requires ReportStore persistence (not yet wired).">
+            Run history
+          </div>
+        </div>
+
+        {/* Findings list */}
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+          {findings.map((f) => {
+            const isSel = f.id === (selId ?? findings[0]?.id);
+            return (
+              <div
+                key={f.id}
+                onClick={() => onSelect(f.id)}
+                style={{
+                  display: 'flex', alignItems: 'flex-start', gap: 12,
+                  padding: '10px 16px', borderBottom: '1px solid var(--border)',
+                  cursor: 'pointer',
+                  background: isSel ? 'var(--accent-soft)' : 'transparent',
+                  borderLeft: `3px solid ${SEVER_COLOR[f.severity]}`,
+                }}
+              >
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3 }}>
+                    <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, fontWeight: 500, color: 'var(--fg)' }}>
+                      {f.field}
+                    </span>
+                    <span style={{
+                      ...tagStyle, background: SEVER_BG[f.severity], color: SEVER_COLOR[f.severity],
+                      borderColor: 'transparent',
+                    }}>{f.category.replace(/_/g, ' ')}</span>
+                    {f.diff !== 'existing' && (
+                      <span style={{
+                        fontSize: 10, color: DIFF_COLOR[f.diff],
+                        marginLeft: 'auto', flexShrink: 0, fontWeight: 500,
+                        textTransform: 'uppercase', letterSpacing: '0.06em',
+                        fontFamily: 'var(--font-body)',
+                      }}>{f.diff}</span>
+                    )}
+                  </div>
+                  <div style={{ fontSize: 12.5, lineHeight: 1.45, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
+                    {f.summary}
+                  </div>
+                  <div style={{ marginTop: 4, fontSize: 11, color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>
+                    <span style={{ fontFamily: 'var(--font-mono)' }}>{f.affected.toLocaleString()}</span>
+                    {' / '}{f.total.toLocaleString()} docs affected ({f.affected_pct.toFixed(1)}%)
+                  </div>
+                </div>
+              </div>
+            );
+          })}
         </div>
       </div>
+
+      {/* RIGHT — detail */}
+      <aside style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden', background: 'var(--bg)' }}>
+        <div style={{ padding: '12px 16px 10px', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6, flexWrap: 'wrap' }}>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 13, fontWeight: 500, color: SEVER_COLOR[sel.severity] }}>
+              {sel.field}
+            </span>
+            <span style={{ ...tagStyle, background: SEVER_BG[sel.severity], color: SEVER_COLOR[sel.severity], borderColor: 'transparent', fontSize: 10.5 }}>
+              {sel.category.replace(/_/g, ' ')}
+            </span>
+            <span style={{ ...tagStyle, background: SEVER_BG[sel.severity], color: SEVER_COLOR[sel.severity], borderColor: 'transparent', fontSize: 10.5 }}>
+              {sel.severity}
+            </span>
+            <span style={{
+              marginLeft: 'auto', fontSize: 10.5, fontWeight: 500,
+              textTransform: 'uppercase', letterSpacing: '0.06em',
+              color: DIFF_COLOR[sel.diff], fontFamily: 'var(--font-body)',
+            }}>{sel.diff}</span>
+          </div>
+          <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.55, color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
+            {sel.description}
+          </p>
+          <div style={{
+            marginTop: 8, fontSize: 11.5, color: 'var(--muted)',
+            display: 'flex', alignItems: 'center', gap: 12, fontFamily: 'var(--font-body)',
+          }}>
+            <span>
+              <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--fg)', fontWeight: 500 }}>
+                {sel.affected.toLocaleString()}
+              </span>{' '}docs affected
+            </span>
+            <span>·</span>
+            <span>
+              <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--fg)' }}>
+                {sel.affected_pct.toFixed(1)}%
+              </span>{' '}of collection
+            </span>
+          </div>
+        </div>
+
+        <div style={{ flex: 1, overflowY: 'auto', padding: '12px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div>
+            <div style={sectionLabel}>
+              <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M2 4h12M2 8h8M2 12h5" />
+              </svg>
+              Evidence query
+            </div>
+            <pre style={{
+              margin: 0, fontFamily: 'var(--font-mono)', fontSize: 11, lineHeight: 1.65,
+              background: 'var(--soft)', border: '1px solid var(--border)',
+              borderRadius: 8, padding: '10px 12px',
+              whiteSpace: 'pre-wrap', overflow: 'auto', color: 'var(--fg)',
+            }}>{sel.evidence}</pre>
+          </div>
+
+          <div>
+            <div style={sectionLabel}>
+              <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M3 8l3 3 7-7" />
+              </svg>
+              ReAct trace
+            </div>
+            <pre style={{
+              margin: 0, fontFamily: 'var(--font-mono)', fontSize: 11, lineHeight: 1.7,
+              background: 'var(--soft)', border: '1px solid var(--border)',
+              borderRadius: 8, padding: '10px 12px',
+              whiteSpace: 'pre-wrap', overflow: 'auto', color: 'var(--muted)',
+            }}>{sel.trace || '(no trace lines matched this field)'}</pre>
+          </div>
+        </div>
+      </aside>
     </div>
   );
 };

--- a/frontend/pages/AnalyticsPage.tsx
+++ b/frontend/pages/AnalyticsPage.tsx
@@ -19,6 +19,7 @@ import {
   startArgusAudit,
 } from '../services/argusService';
 import { ArgusTrendsPanel } from '../components/ArgusTrendsPanel';
+import { useNotifications } from '../contexts/NotificationsContext';
 
 const DEFAULT_MAX_ITER = 20;
 const DEFAULT_SAMPLE_SIZE = 200;
@@ -438,7 +439,40 @@ const sectionLabel: React.CSSProperties = {
 
 const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, collections }) => {
   const hasConnection = !!(accountId && databaseName);
-  const [collection, setCollection] = useState<string>(collections?.[0]?.name ?? '');
+  const { trackArgusRun } = useNotifications();
+  const [collection, setCollection] = useState<string>(() => {
+    if (!collections || collections.length === 0) return '';
+    return [...collections].sort((a, b) => a.name.localeCompare(b.name))[0].name;
+  });
+  const [collectionDefaulting, setCollectionDefaulting] = useState(false);
+  const userPickedCollectionRef = useRef(false);
+  // Reset the "user picked" flag whenever the account/database scope changes
+  // so the next auto-default can run for the new scope.
+  useEffect(() => { userPickedCollectionRef.current = false; }, [accountId, databaseName]);
+  // Default the dropdown to the collection with the most recent persisted run
+  // for this account/database; fall back to the first alphabetical collection.
+  useEffect(() => {
+    if (userPickedCollectionRef.current) return;
+    if (!collections || collections.length === 0) return;
+    const alphaFirst = [...collections].sort((a, b) => a.name.localeCompare(b.name))[0].name;
+    let cancelled = false;
+    setCollectionDefaulting(true);
+    (async () => {
+      let target = alphaFirst;
+      if (accountId && databaseName) {
+        try {
+          const rows = await listArgusRuns({ accountId, database: databaseName, limit: 1 });
+          const recent = rows[0]?.collection;
+          if (recent && collections.some((c) => c.name === recent)) target = recent;
+        } catch {
+          // ignore — fall back to alphabetical
+        }
+      }
+      if (!cancelled && !userPickedCollectionRef.current) setCollection(target);
+      if (!cancelled) setCollectionDefaulting(false);
+    })();
+    return () => { cancelled = true; };
+  }, [accountId, databaseName, collections]);
   const [profile, setProfile] = useState<ArgusProfile>('fast');
   const [report, setReport] = useState<ArgusReport | null>(null);
   const [jobStatus, setJobStatus] = useState<ArgusJobStatus | null>(null);
@@ -663,13 +697,20 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
     const stored = readJobMap()[jobKey(accountId, databaseName, collection)];
     if (!stored) return;
     setJobStatus('running');
+    trackArgusRun({
+      jobId: stored,
+      accountId,
+      database: databaseName,
+      collection,
+      startedAt: Date.now(),
+    });
     pollJob(stored, accountId, databaseName, collection);
     pollRef.current = window.setInterval(
       () => pollJob(stored, accountId, databaseName, collection),
       3000,
     );
     return clearPoll;
-  }, [accountId, databaseName, collection, pollJob]);
+  }, [accountId, databaseName, collection, pollJob, trackArgusRun]);
 
   const runAudit = async () => {
     if (!accountId || !databaseName || !collection) return;
@@ -696,6 +737,13 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
       const map = readJobMap();
       map[jobKey(accountId, databaseName, collection)] = job_id;
       writeJobMap(map);
+      trackArgusRun({
+        jobId: job_id,
+        accountId,
+        database: databaseName,
+        collection,
+        startedAt: Date.now(),
+      });
       pollJob(job_id, accountId, databaseName, collection);
       pollRef.current = window.setInterval(
         () => pollJob(job_id, accountId, databaseName, collection),
@@ -741,22 +789,38 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
           {databaseName ?? '—'}
         </span>
         {hasConnection && (collections?.length ?? 0) > 0 && (
-          <select
-            value={collection}
-            onChange={(e) => setCollection(e.target.value)}
-            style={{
-              fontFamily: 'var(--font-mono)', fontSize: 12,
-              padding: '3px 8px', borderRadius: 6,
-              background: 'var(--panel)', color: 'var(--fg)',
-              border: '1px solid var(--border)', cursor: 'pointer',
-            }}
-          >
-            {[...collections!]
-              .sort((a, b) => a.name.localeCompare(b.name))
-              .map((c) => (
-                <option key={c.name} value={c.name}>{c.name}</option>
-              ))}
-          </select>
+          <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            <select
+              value={collection}
+              onChange={(e) => { userPickedCollectionRef.current = true; setCollection(e.target.value); }}
+              disabled={collectionDefaulting}
+              style={{
+                fontFamily: 'var(--font-mono)', fontSize: 12,
+                padding: '3px 8px', borderRadius: 6,
+                background: 'var(--panel)', color: 'var(--fg)',
+                border: '1px solid var(--border)',
+                cursor: collectionDefaulting ? 'progress' : 'pointer',
+                opacity: collectionDefaulting ? 0.7 : 1,
+              }}
+            >
+              {[...collections!]
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map((c) => (
+                  <option key={c.name} value={c.name}>{c.name}</option>
+                ))}
+            </select>
+            {collectionDefaulting && (
+              <svg
+                width="13" height="13" viewBox="0 0 16 16" fill="none"
+                stroke="var(--muted)" strokeWidth="1.5"
+                style={{ animation: 'qp-spin 0.8s linear infinite' }}
+                aria-label="Loading recent run"
+              >
+                <circle cx="8" cy="8" r="6" strokeOpacity="0.3" />
+                <path d="M8 2a6 6 0 0 1 6 6" />
+              </svg>
+            )}
+          </div>
         )}
         <div style={{ marginLeft: 'auto', display: 'flex', gap: 6, alignItems: 'center' }}>
           <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>Profile</span>
@@ -1301,6 +1365,7 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ accountId, databaseName, 
           </div>
         </div>
       )}
+      <style>{`@keyframes qp-spin { to { transform: rotate(360deg); } }`}</style>
     </div>
   );
 };

--- a/frontend/pages/AnalyticsPageWrapper.tsx
+++ b/frontend/pages/AnalyticsPageWrapper.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import AppLayout from '../components/AppLayout';
 import AnalyticsPage from './AnalyticsPage';
 import { CollectionSummary, DbInfo, CosmosDBAccount } from '../types';
+import { getDatabasesForAccount } from '../services/dbService';
 
 interface SessionConnection {
   accountId?: string;
@@ -19,8 +20,44 @@ const readSessionConnection = (): SessionConnection | null => {
   } catch { return null; }
 };
 
+const writeSessionConnection = (conn: SessionConnection) => {
+  sessionStorage.setItem('qp_connection', JSON.stringify(conn));
+};
+
 const AnalyticsPageWrapper: React.FC = () => {
-  const conn = readSessionConnection();
+  const [conn, setConn] = useState<SessionConnection | null>(() => readSessionConnection());
+
+  const handleSwitchDatabase = useCallback((db: DbInfo) => {
+    if (!conn) return;
+    const next: SessionConnection = {
+      ...conn,
+      databaseName: db.name,
+      collections: db.collections,
+    };
+    writeSessionConnection(next);
+    setConn(next);
+  }, [conn]);
+
+  const handleSwitchAccount = useCallback(async (account: CosmosDBAccount) => {
+    if (!conn || account.id === conn.accountId) return;
+    try {
+      const databases = await getDatabasesForAccount(account.id);
+      if (!databases.length) return;
+      const firstDb = databases[0];
+      const next: SessionConnection = {
+        accountId: account.id,
+        accountName: account.name,
+        databaseName: firstDb.name,
+        collections: firstDb.collections,
+        availableAccounts: conn.availableAccounts,
+        availableDbs: databases,
+      };
+      writeSessionConnection(next);
+      setConn(next);
+    } catch (e) {
+      console.error('Failed to switch account:', e);
+    }
+  }, [conn]);
 
   return (
     <AppLayout
@@ -30,6 +67,8 @@ const AnalyticsPageWrapper: React.FC = () => {
       collections={conn?.collections}
       availableAccounts={conn?.availableAccounts}
       availableDbs={conn?.availableDbs}
+      onSwitchDatabase={handleSwitchDatabase}
+      onSwitchAccount={handleSwitchAccount}
     >
       <AnalyticsPage
         accountId={conn?.accountId}

--- a/frontend/pages/AnalyticsPageWrapper.tsx
+++ b/frontend/pages/AnalyticsPageWrapper.tsx
@@ -1,8 +1,11 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import AppLayout from '../components/AppLayout';
 import AnalyticsPage from './AnalyticsPage';
 import { CollectionSummary, DbInfo, CosmosDBAccount } from '../types';
 import { getDatabasesForAccount } from '../services/dbService';
+import { listArgusRuns } from '../services/argusService';
+
+export type CollectionAuditStatus = 'critical' | 'warning' | 'info' | 'clean';
 
 interface SessionConnection {
   accountId?: string;
@@ -24,8 +27,83 @@ const writeSessionConnection = (conn: SessionConnection) => {
   sessionStorage.setItem('qp_connection', JSON.stringify(conn));
 };
 
+const auditStatus = (
+  counts?: { critical: number; warning: number; info: number },
+): CollectionAuditStatus => {
+  if (counts?.critical) return 'critical';
+  if (counts?.warning) return 'warning';
+  if (counts?.info) return 'info';
+  return 'clean';
+};
+
 const AnalyticsPageWrapper: React.FC = () => {
   const [conn, setConn] = useState<SessionConnection | null>(() => readSessionConnection());
+  const [collection, setCollection] = useState<string>('');
+  const [collectionDefaulting, setCollectionDefaulting] = useState(false);
+  const [collectionSeverity, setCollectionSeverity] = useState<Record<string, CollectionAuditStatus>>({});
+  const [collectionFindings, setCollectionFindings] = useState<Record<string, number>>({});
+  const [isAccountSwitching, setIsAccountSwitching] = useState(false);
+  const userPickedRef = useRef(false);
+
+  const accountId = conn?.accountId;
+  const databaseName = conn?.databaseName;
+  const collections = conn?.collections;
+
+  // Reset "user picked" flag when scope changes so auto-default can re-run.
+  useEffect(() => {
+    userPickedRef.current = false;
+  }, [accountId, databaseName]);
+
+  // Fetch latest runs across all collections to build the severity map and
+  // pick a sensible default collection (most recent run, else alphabetical).
+  useEffect(() => {
+    if (!collections || collections.length === 0) {
+      setCollectionSeverity({});
+      setCollectionFindings({});
+      if (!userPickedRef.current) setCollection('');
+      return;
+    }
+    const alphaFirst = [...collections].sort((a, b) => a.name.localeCompare(b.name))[0].name;
+    let cancelled = false;
+    setCollectionDefaulting(true);
+    (async () => {
+      const severityMap: Record<string, CollectionAuditStatus> = {};
+      const findingsMap: Record<string, number> = {};
+      let recentCollection: string | undefined;
+      if (accountId && databaseName) {
+        try {
+          // Fetch a generous slice of recent runs; backend returns newest first.
+          const rows = await listArgusRuns({ accountId, database: databaseName, limit: 100 });
+          recentCollection = rows[0]?.collection;
+          const seen = new Set<string>();
+          for (const row of rows) {
+            if (seen.has(row.collection)) continue;
+            seen.add(row.collection);
+            severityMap[row.collection] = auditStatus(row.counts);
+            findingsMap[row.collection] = row.findings_count ?? 0;
+          }
+        } catch (e) {
+          console.warn('listArgusRuns failed (sidebar severity)', e);
+        }
+      }
+      if (cancelled) return;
+      setCollectionSeverity(severityMap);
+      setCollectionFindings(findingsMap);
+      if (!userPickedRef.current) {
+        const target = recentCollection && collections.some((c) => c.name === recentCollection)
+          ? recentCollection
+          : alphaFirst;
+        setCollection(target);
+      }
+      setCollectionDefaulting(false);
+    })();
+    return () => { cancelled = true; };
+  }, [accountId, databaseName, collections]);
+
+  const handleCollectionSelect = useCallback((name: string) => {
+    userPickedRef.current = true;
+    setCollection(name);
+  }, []);
 
   const handleSwitchDatabase = useCallback((db: DbInfo) => {
     if (!conn) return;
@@ -40,6 +118,7 @@ const AnalyticsPageWrapper: React.FC = () => {
 
   const handleSwitchAccount = useCallback(async (account: CosmosDBAccount) => {
     if (!conn || account.id === conn.accountId) return;
+    setIsAccountSwitching(true);
     try {
       const databases = await getDatabasesForAccount(account.id);
       if (!databases.length) return;
@@ -56,6 +135,8 @@ const AnalyticsPageWrapper: React.FC = () => {
       setConn(next);
     } catch (e) {
       console.error('Failed to switch account:', e);
+    } finally {
+      setIsAccountSwitching(false);
     }
   }, [conn]);
 
@@ -65,16 +146,35 @@ const AnalyticsPageWrapper: React.FC = () => {
       accountName={conn?.accountName}
       databaseName={conn?.databaseName}
       collections={conn?.collections}
+      activeCollection={collection || undefined}
+      onCollectionSelect={handleCollectionSelect}
+      collectionSeverity={collectionSeverity}
+      collectionFindings={collectionFindings}
       availableAccounts={conn?.availableAccounts}
       availableDbs={conn?.availableDbs}
       onSwitchDatabase={handleSwitchDatabase}
       onSwitchAccount={handleSwitchAccount}
     >
-      <AnalyticsPage
-        accountId={conn?.accountId}
-        databaseName={conn?.databaseName}
-        collections={conn?.collections}
-      />
+      <div style={{ position: 'relative', flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+        <AnalyticsPage
+          accountId={conn?.accountId}
+          databaseName={conn?.databaseName}
+          collections={conn?.collections}
+          collection={collection}
+          onCollectionChange={handleCollectionSelect}
+          collectionDefaulting={collectionDefaulting}
+        />
+        {isAccountSwitching && (
+          <div style={{ position: 'absolute', inset: 0, zIndex: 50, background: 'rgba(0,0,0,0.2)', backdropFilter: 'blur(2px)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <div style={{ background: 'var(--panel)', borderRadius: 10, boxShadow: '0 8px 30px rgba(0,0,0,0.12)', padding: '14px 24px', display: 'flex', alignItems: 'center', gap: 10, border: '1px solid var(--border)' }}>
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="var(--accent)" strokeWidth="1.5" style={{ animation: 'qp-spin 0.8s linear infinite' }}>
+                <circle cx="8" cy="8" r="6" strokeOpacity="0.3"/><path d="M8 2a6 6 0 0 1 6 6"/>
+              </svg>
+              <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)' }}>Switching account...</span>
+            </div>
+          </div>
+        )}
+      </div>
     </AppLayout>
   );
 };

--- a/frontend/pages/AnalyticsPageWrapper.tsx
+++ b/frontend/pages/AnalyticsPageWrapper.tsx
@@ -159,7 +159,6 @@ const AnalyticsPageWrapper: React.FC = () => {
         <AnalyticsPage
           accountId={conn?.accountId}
           databaseName={conn?.databaseName}
-          collections={conn?.collections}
           collection={collection}
           onCollectionChange={handleCollectionSelect}
           collectionDefaulting={collectionDefaulting}

--- a/frontend/pages/AnalyticsPageWrapper.tsx
+++ b/frontend/pages/AnalyticsPageWrapper.tsx
@@ -34,6 +34,7 @@ const AnalyticsPageWrapper: React.FC = () => {
       <AnalyticsPage
         accountId={conn?.accountId}
         databaseName={conn?.databaseName}
+        collections={conn?.collections}
       />
     </AppLayout>
   );

--- a/frontend/pages/DataExplorerPageWrapper.tsx
+++ b/frontend/pages/DataExplorerPageWrapper.tsx
@@ -13,6 +13,7 @@ interface LocationState {
   availableAccounts?: CosmosDBAccount[];
   initialCollection?: string;
   initialFilters?: FilterState[];
+  pendingAccountName?: string;
 }
 
 const DataExplorerPageWrapper: React.FC = () => {
@@ -61,8 +62,53 @@ const DataExplorerPageWrapper: React.FC = () => {
 
   useEffect(() => {
     const initializePageData = async () => {
-      if (!accountId || !databaseName) {
+      if (!accountId) {
         navigate('/query-generator');
+        return;
+      }
+
+      // No databaseName in URL: resolve the first database for this account, then replace URL.
+      if (!databaseName) {
+        try {
+          setLoading(true);
+          setError(null);
+          const decodedAccountId = decodeURIComponent(accountId);
+          const [accounts, databases] = await Promise.all([
+            getAzureCosmosAccounts(),
+            getDatabasesForAccount(decodedAccountId),
+          ]);
+          const account = accounts.find(acc => acc.id === decodedAccountId);
+          if (!account) {
+            throw new Error(`Cosmos DB account '${decodedAccountId}' not found`);
+          }
+          if (databases.length === 0) {
+            throw new Error(`No databases found in account '${account.name}'`);
+          }
+          const firstDb = databases[0];
+          sessionStorage.setItem('qp_connection', JSON.stringify({
+            accountId: decodedAccountId,
+            databaseName: firstDb.name,
+            accountName: account.name,
+            collections: firstDb.collections,
+            availableAccounts: accounts,
+            availableDbs: databases,
+          }));
+          navigate(
+            `/data-explorer/${encodeURIComponent(decodedAccountId)}/${encodeURIComponent(firstDb.name)}`,
+            {
+              replace: true,
+              state: {
+                dbInfo: firstDb,
+                accountName: account.name,
+                availableDbs: databases,
+                availableAccounts: accounts,
+              } as LocationState,
+            }
+          );
+        } catch (err) {
+          setError(err instanceof Error ? err.message : 'Failed to load data explorer');
+          setLoading(false);
+        }
         return;
       }
 
@@ -198,22 +244,13 @@ const DataExplorerPageWrapper: React.FC = () => {
     });
   }, [pageData, navigate]);
 
-  const handleSwitchAccount = useCallback(async (account: CosmosDBAccount) => {
+  const handleSwitchAccount = useCallback((account: CosmosDBAccount) => {
     if (!pageData || account.id === pageData.resource.accountId) return;
-    try {
-      const databases = await getDatabasesForAccount(account.id);
-      if (!databases.length) return;
-      navigate(`/data-explorer/${encodeURIComponent(account.id)}/${encodeURIComponent(databases[0].name)}`, {
-        state: {
-          dbInfo: databases[0],
-          accountName: account.name,
-          availableDbs: databases,
-          availableAccounts: pageData.availableAccounts,
-        },
-      });
-    } catch (e) {
-      console.error('Failed to switch account:', e);
-    }
+    // Navigate immediately so the wrapper renders the loading state with a
+    // blurred connection chip while the first database resolves.
+    navigate(`/data-explorer/${encodeURIComponent(account.id)}`, {
+      state: { pendingAccountName: account.name } as LocationState,
+    });
   }, [pageData, navigate]);
 
   if (loading) {
@@ -227,14 +264,22 @@ const DataExplorerPageWrapper: React.FC = () => {
       availableAccounts: pageData.availableAccounts,
       availableDbs: pageData.availableDbs,
     } : null);
+    const pendingFromState = state?.pendingAccountName;
+    const isPending = !databaseName;
+    // While resolving (no databaseName yet), prefer the incoming account name
+    // so the blurred chip reflects the destination, not the previous account.
+    const resolvedAccountName = isPending
+      ? (pendingFromState ?? sidebarFallback?.accountName)
+      : (sidebarFallback?.accountName ?? pendingFromState);
     return (
       <AppLayout
         accountId={decodedAccountId}
         databaseName={decodedDatabaseName}
-        accountName={sidebarFallback?.accountName}
+        accountName={resolvedAccountName}
         collections={sidebarFallback?.collections}
         availableAccounts={sidebarFallback?.availableAccounts}
         availableDbs={sidebarFallback?.availableDbs}
+        chipLoading={isPending}
       >
         <style>{`@keyframes qp-spin { to { transform: rotate(360deg); } }`}</style>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', background: 'var(--bg)' }}>

--- a/frontend/pages/HubPage.tsx
+++ b/frontend/pages/HubPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
 import { useTheme } from '../contexts/ThemeContext';
-import { getAzureCosmosAccounts, getDatabasesForAccount } from '../services/dbService';
+import { getAzureCosmosAccounts } from '../services/dbService';
 import { CosmosDBAccount } from '../types';
 import { API_BASE_URL } from '../app.config';
 
@@ -192,24 +192,15 @@ const HubPage: React.FC = () => {
     navigate('/query-generator', { state: { preselectedAccountId: account.id, preselectedAccountName: account.name } });
   };
 
-  const handleOpenExplorer = async (account: CosmosDBAccount) => {
+  const handleOpenExplorer = (account: CosmosDBAccount) => {
     if (busyAccountId) return;
     setBusyAccountId(account.id);
     setBusyAction('explorer');
-    try {
-      const databases = await getDatabasesForAccount(account.id);
-      if (databases.length === 0) {
-        setBusyAccountId(null);
-        setBusyAction(null);
-        return;
-      }
-      const firstDb = databases[0];
-      navigate(`/data-explorer/${encodeURIComponent(account.id)}/${encodeURIComponent(firstDb.name)}`);
-    } catch (e) {
-      console.error('Failed to open explorer:', e);
-      setBusyAccountId(null);
-      setBusyAction(null);
-    }
+    // Navigate immediately; the explorer wrapper resolves the first database
+    // and shows a blurred connection chip while it loads.
+    navigate(`/data-explorer/${encodeURIComponent(account.id)}`, {
+      state: { pendingAccountName: account.name },
+    });
   };
 
   return (

--- a/frontend/pages/HubPage.tsx
+++ b/frontend/pages/HubPage.tsx
@@ -182,18 +182,33 @@ const HubPage: React.FC = () => {
     ? user.name.split(' ').map((n) => n[0]).join('').slice(0, 2).toUpperCase()
     : 'U';
 
+  const [busyAccountId, setBusyAccountId] = useState<string | null>(null);
+  const [busyAction, setBusyAction] = useState<'open' | 'explorer' | null>(null);
+
   const handleOpenAccount = (account: CosmosDBAccount) => {
+    if (busyAccountId) return;
+    setBusyAccountId(account.id);
+    setBusyAction('open');
     navigate('/query-generator', { state: { preselectedAccountId: account.id, preselectedAccountName: account.name } });
   };
 
   const handleOpenExplorer = async (account: CosmosDBAccount) => {
+    if (busyAccountId) return;
+    setBusyAccountId(account.id);
+    setBusyAction('explorer');
     try {
       const databases = await getDatabasesForAccount(account.id);
-      if (databases.length === 0) return;
+      if (databases.length === 0) {
+        setBusyAccountId(null);
+        setBusyAction(null);
+        return;
+      }
       const firstDb = databases[0];
       navigate(`/data-explorer/${encodeURIComponent(account.id)}/${encodeURIComponent(firstDb.name)}`);
     } catch (e) {
       console.error('Failed to open explorer:', e);
+      setBusyAccountId(null);
+      setBusyAction(null);
     }
   };
 
@@ -320,7 +335,14 @@ const HubPage: React.FC = () => {
               </div>
             )}
             {accounts.map((account) => (
-              <ConnectionCard key={account.id} account={account} onOpen={handleOpenAccount} onOpenExplorer={handleOpenExplorer} />
+              <ConnectionCard
+                key={account.id}
+                account={account}
+                onOpen={handleOpenAccount}
+                onOpenExplorer={handleOpenExplorer}
+                busyAction={busyAccountId === account.id ? busyAction : null}
+                disabled={!!busyAccountId && busyAccountId !== account.id}
+              />
             ))}
           </div>
         </section>
@@ -402,26 +424,43 @@ const HubPage: React.FC = () => {
   );
 };
 
+/* ── Inline spinner ── */
+const Spinner: React.FC<{ size?: number }> = ({ size = 11 }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <circle cx="8" cy="8" r="6" opacity="0.3" />
+    <path d="M14 8a6 6 0 0 0-6-6">
+      <animateTransform attributeName="transform" type="rotate" from="0 8 8" to="360 8 8" dur="0.9s" repeatCount="indefinite" />
+    </path>
+  </svg>
+);
+
 /* ── Connection card ── */
 const ConnectionCard: React.FC<{
   account: CosmosDBAccount;
   onOpen: (a: CosmosDBAccount) => void;
   onOpenExplorer: (a: CosmosDBAccount) => void;
-}> = ({ account, onOpen, onOpenExplorer }) => {
+  busyAction: 'open' | 'explorer' | null;
+  disabled: boolean;
+}> = ({ account, onOpen, onOpenExplorer, busyAction, disabled }) => {
   const [hovered, setHovered] = useState(false);
   const [explorerHovered, setExplorerHovered] = useState(false);
+  const isOpenBusy = busyAction === 'open';
+  const isExplorerBusy = busyAction === 'explorer';
+  const anyBusy = !!busyAction;
+  const inert = disabled || anyBusy;
   return (
     <div
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
         background: 'var(--panel)',
-        border: `1px solid ${hovered ? 'color-mix(in oklch, var(--accent) 35%, var(--border))' : 'var(--border)'}`,
+        border: `1px solid ${hovered && !disabled ? 'color-mix(in oklch, var(--accent) 35%, var(--border))' : 'var(--border)'}`,
         borderRadius: 14, padding: 22,
         display: 'flex', flexDirection: 'column', gap: 14,
-        transform: hovered ? 'translateY(-1px)' : 'none',
-        boxShadow: hovered ? '0 12px 24px -16px rgba(20,18,14,0.18)' : 'none',
-        transition: 'transform 0.12s, border-color 0.12s, box-shadow 0.12s',
+        transform: hovered && !disabled ? 'translateY(-1px)' : 'none',
+        boxShadow: hovered && !disabled ? '0 12px 24px -16px rgba(20,18,14,0.18)' : 'none',
+        transition: 'transform 0.12s, border-color 0.12s, box-shadow 0.12s, opacity 0.12s',
+        opacity: disabled ? 0.5 : 1,
       }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
@@ -451,34 +490,57 @@ const ConnectionCard: React.FC<{
             onClick={() => onOpenExplorer(account)}
             onMouseEnter={() => setExplorerHovered(true)}
             onMouseLeave={() => setExplorerHovered(false)}
+            disabled={inert}
             style={{
               display: 'inline-flex', alignItems: 'center', gap: 4,
               fontSize: 12, padding: '5px 10px', borderRadius: 6,
-              border: `1px solid ${explorerHovered ? 'var(--accent)' : 'var(--border)'}`,
-              background: explorerHovered ? 'var(--accent-soft)' : 'var(--soft)',
-              color: explorerHovered ? 'var(--accent)' : 'var(--muted)',
-              cursor: 'pointer', fontFamily: 'var(--font-body)',
+              border: `1px solid ${isExplorerBusy ? 'var(--accent)' : explorerHovered && !inert ? 'var(--accent)' : 'var(--border)'}`,
+              background: isExplorerBusy ? 'var(--accent-soft)' : explorerHovered && !inert ? 'var(--accent-soft)' : 'var(--soft)',
+              color: isExplorerBusy ? 'var(--accent)' : explorerHovered && !inert ? 'var(--accent)' : 'var(--muted)',
+              cursor: inert ? 'not-allowed' : 'pointer', fontFamily: 'var(--font-body)',
               transition: 'border-color 0.12s, background 0.12s, color 0.12s',
+              opacity: inert && !isExplorerBusy ? 0.6 : 1,
             }}
           >
-            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-              <path d="M2 3h12v3H2zM2 7h12v3H2zM2 11h12v3H2z"/>
-            </svg>
-            Explorer
+            {isExplorerBusy ? (
+              <>
+                <Spinner />
+                Loading…
+              </>
+            ) : (
+              <>
+                <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <path d="M2 3h12v3H2zM2 7h12v3H2zM2 11h12v3H2z"/>
+                </svg>
+                Explorer
+              </>
+            )}
           </button>
           <button
             onClick={() => onOpen(account)}
+            disabled={inert}
             style={{
               display: 'inline-flex', alignItems: 'center', gap: 4,
               fontSize: 12.5, padding: '5px 10px', borderRadius: 6,
               border: 'none', background: 'none',
-              color: 'var(--accent)', cursor: 'pointer', fontFamily: 'var(--font-body)',
+              color: 'var(--accent)',
+              cursor: inert ? 'not-allowed' : 'pointer', fontFamily: 'var(--font-body)',
+              opacity: inert && !isOpenBusy ? 0.6 : 1,
             }}
           >
-            Open
-            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
-              <path d="M3 8h10M9 4l4 4-4 4"/>
-            </svg>
+            {isOpenBusy ? (
+              <>
+                <Spinner />
+                Loading…
+              </>
+            ) : (
+              <>
+                Open
+                <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
+                  <path d="M3 8h10M9 4l4 4-4 4"/>
+                </svg>
+              </>
+            )}
           </button>
         </div>
       </div>

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -405,10 +405,16 @@ export interface QueryGeneratorPageProps {
   onConnectionChange?: (accountId: string | null, databaseName: string | null, accountName?: string | null, collections?: CollectionSummary[], availableAccounts?: CosmosDBAccount[], availableDbs?: DbInfo[]) => void;
   embedded?: boolean;
   preselectedAccountId?: string;
+  /** Sidebar click trigger. The token must change on every click so the page
+   *  re-applies the selection even when the same name is clicked twice. */
+  sidebarCollectionClick?: { name: string; modifier: boolean; token: number } | null;
+  /** Notify the wrapper of the full current selection so it can highlight every
+   *  selected collection in the sidebar (multi-select aware). */
+  onSelectedCollectionsChange?: (collectionNames: string[]) => void;
 }
 
 // --- Main Page Component ---
-const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, onLogout, onNavigateToExplorer, onConnectionChange, embedded = false, preselectedAccountId }) => {
+const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, onLogout, onNavigateToExplorer, onConnectionChange, embedded = false, preselectedAccountId, sidebarCollectionClick, onSelectedCollectionsChange }) => {
   const navigate = useNavigate();
 
   const [userInput, setUserInput] = useState<string>(() => {
@@ -1093,6 +1099,28 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
       }
     });
   }, [connectedResource, selectedCollections, collectionDetailsMap, loadingCollections]);
+
+  // Sidebar-driven collection selection — mirrors the middle-panel buttons,
+  // including Cmd/Ctrl+click multi-select. Driven by a token so re-clicking the
+  // same collection (toggle off) still triggers the effect.
+  const lastSidebarToken = useRef<number | null>(null);
+  useEffect(() => {
+    if (!sidebarCollectionClick) return;
+    if (lastSidebarToken.current === sidebarCollectionClick.token) return;
+    lastSidebarToken.current = sidebarCollectionClick.token;
+    if (!connectedResource) return;
+    const fakeEvent = {
+      ctrlKey: sidebarCollectionClick.modifier,
+      metaKey: sidebarCollectionClick.modifier,
+    } as React.MouseEvent;
+    handleCollectionClick(sidebarCollectionClick.name, fakeEvent);
+  }, [sidebarCollectionClick, connectedResource, handleCollectionClick]);
+
+  // Report the full selection back so the sidebar can highlight every selected
+  // collection when picks come from the middle panel.
+  useEffect(() => {
+    onSelectedCollectionsChange?.(selectedCollections);
+  }, [selectedCollections, onSelectedCollectionsChange]);
 
   const handleAnalyzeRelationships = useCallback(async () => {
     if (!connectedResource || selectedCollections.length < 2) return;

--- a/frontend/pages/QueryGeneratorPageWrapper.tsx
+++ b/frontend/pages/QueryGeneratorPageWrapper.tsx
@@ -30,6 +30,13 @@ const MsalQueryGeneratorPageWrapper: React.FC = () => {
   const [connection, setConnection] = React.useState<ConnectionState | null>(() =>
     hubState.preselectedAccountId ? null : readSessionConnection()
   );
+  const [activeCollections, setActiveCollections] = React.useState<string[]>([]);
+  const [sidebarClick, setSidebarClick] = React.useState<{ name: string; modifier: boolean; token: number } | null>(null);
+  const sidebarTokenRef = React.useRef(0);
+  const handleSidebarCollectionSelect = React.useCallback((name: string, ev?: { ctrlKey?: boolean; metaKey?: boolean }) => {
+    sidebarTokenRef.current += 1;
+    setSidebarClick({ name, modifier: !!(ev?.ctrlKey || ev?.metaKey), token: sidebarTokenRef.current });
+  }, []);
 
   const name = accounts[0]?.name;
   const email = accounts[0]?.username;
@@ -58,6 +65,9 @@ const MsalQueryGeneratorPageWrapper: React.FC = () => {
       databaseName={connection?.databaseName}
       accountName={connection?.accountName}
       collections={connection?.collections}
+      activeCollection={activeCollections[0]}
+      activeCollections={activeCollections}
+      onCollectionSelect={handleSidebarCollectionSelect}
       availableAccounts={connection?.availableAccounts}
       availableDbs={connection?.availableDbs}
       onSwitchAccount={(acc) => navigate('/query-generator', { state: { preselectedAccountId: acc.id } })}
@@ -72,6 +82,8 @@ const MsalQueryGeneratorPageWrapper: React.FC = () => {
           setConnection(accountId && databaseName ? { accountId, databaseName, accountName: accountName ?? undefined, collections, availableAccounts, availableDbs } : null)
         }
         preselectedAccountId={hubState.preselectedAccountId}
+        sidebarCollectionClick={sidebarClick}
+        onSelectedCollectionsChange={setActiveCollections}
         embedded
       />
     </AppLayout>
@@ -87,6 +99,13 @@ const BypassQueryGeneratorPageWrapper: React.FC = () => {
   const [connection, setConnection] = React.useState<ConnectionState | null>(() =>
     hubState.preselectedAccountId ? null : readSessionConnection()
   );
+  const [activeCollections, setActiveCollections] = React.useState<string[]>([]);
+  const [sidebarClick, setSidebarClick] = React.useState<{ name: string; modifier: boolean; token: number } | null>(null);
+  const sidebarTokenRef = React.useRef(0);
+  const handleSidebarCollectionSelect = React.useCallback((name: string, ev?: { ctrlKey?: boolean; metaKey?: boolean }) => {
+    sidebarTokenRef.current += 1;
+    setSidebarClick({ name, modifier: !!(ev?.ctrlKey || ev?.metaKey), token: sidebarTokenRef.current });
+  }, []);
 
   const name = user?.name;
   const email = user?.email;
@@ -114,6 +133,9 @@ const BypassQueryGeneratorPageWrapper: React.FC = () => {
       databaseName={connection?.databaseName}
       accountName={connection?.accountName}
       collections={connection?.collections}
+      activeCollection={activeCollections[0]}
+      activeCollections={activeCollections}
+      onCollectionSelect={handleSidebarCollectionSelect}
       availableAccounts={connection?.availableAccounts}
       availableDbs={connection?.availableDbs}
       onSwitchAccount={(acc) => navigate('/query-generator', { state: { preselectedAccountId: acc.id } })}
@@ -128,6 +150,8 @@ const BypassQueryGeneratorPageWrapper: React.FC = () => {
           setConnection(accountId && databaseName ? { accountId, databaseName, accountName: accountName ?? undefined, collections, availableAccounts, availableDbs } : null)
         }
         preselectedAccountId={hubState.preselectedAccountId}
+        sidebarCollectionClick={sidebarClick}
+        onSelectedCollectionsChange={setActiveCollections}
         embedded
       />
     </AppLayout>

--- a/frontend/router.tsx
+++ b/frontend/router.tsx
@@ -50,6 +50,14 @@ export const router = createBrowserRouter([
     ),
   },
   {
+    path: "/data-explorer/:accountId",
+    element: (
+      <ProtectedRoute>
+        <DataExplorerPageWrapper />
+      </ProtectedRoute>
+    ),
+  },
+  {
     path: "/data-explorer/:accountId/:databaseName",
     element: (
       <ProtectedRoute>

--- a/frontend/services/argusService.ts
+++ b/frontend/services/argusService.ts
@@ -38,6 +38,13 @@ export interface ArgusReport {
   model: string;
   profile: ArgusProfile;
   quality_score: number | null;
+  run_evaluation: {
+    verdict: 'pass' | 'warn' | 'fail' | string;
+    score: number;
+    reason: string;
+    critique: string | null;
+    evaluated_by: string;
+  } | null;
   counts: { critical: number; warning: number; info: number; dismissed: number };
   diff: { new: number; resolved: number; regressed: number };
   findings: ArgusFinding[];

--- a/frontend/services/argusService.ts
+++ b/frontend/services/argusService.ts
@@ -54,12 +54,45 @@ export interface ArgusJob {
   error: string | null;
 }
 
+export type ArgusMinSeverity = 'low' | 'medium' | 'high' | 'critical';
+
+export interface ArgusOverrides {
+  sample_size?: number;
+  max_iterations?: number;
+  min_severity?: ArgusMinSeverity;
+}
+
+export interface EvaluatorOverrides {
+  action_evaluator?: 'none' | 'rules' | 'self' | 'judge' | 'composite';
+  finding_evaluator?: 'none' | 'rules' | 'self' | 'judge' | 'composite';
+  run_evaluator?: 'none' | 'rules' | 'self' | 'judge' | 'composite';
+  judge_provider?: 'gemini' | 'openai' | 'anthropic' | null;
+  judge_model?: string | null;
+  action_pass_threshold?: number;
+  finding_pass_threshold?: number;
+  run_pass_threshold?: number;
+  rejected_finding_policy?: 'drop' | 'log_only' | 'demote_severity';
+  run_fail_policy?: 'continue' | 'warn_only' | 'abort';
+}
+
 export interface StartArgusAuditArgs {
   accountId: string;
   database: string;
   collection: string;
   profile: ArgusProfile;
   maxIterations?: number;
+  argusOverrides?: ArgusOverrides;
+  configOverrides?: EvaluatorOverrides;
+  savedProfileId?: string;
+}
+
+export interface SavedArgusProfile {
+  id: string;
+  name: string;
+  base_profile: ArgusProfile;
+  evaluator_overrides: EvaluatorOverrides;
+  argus_overrides: ArgusOverrides;
+  created_at?: string | null;
 }
 
 const getToken = async (): Promise<string> => {
@@ -91,6 +124,9 @@ export const startArgusAudit = async (
       collection: args.collection,
       profile: args.profile,
       max_iterations: args.maxIterations ?? 20,
+      ...(args.argusOverrides ? { argus_overrides: args.argusOverrides } : {}),
+      ...(args.configOverrides ? { config_overrides: args.configOverrides } : {}),
+      ...(args.savedProfileId ? { saved_profile_id: args.savedProfileId } : {}),
     }),
   });
   if (!response.ok) {
@@ -155,6 +191,60 @@ export const getArgusReport = async (reportId: string): Promise<ArgusReport> => 
     throw new Error(err.detail || `Failed to fetch report (${response.status})`);
   }
   return response.json();
+};
+
+export const listSavedProfiles = async (): Promise<SavedArgusProfile[]> => {
+  if (!USE_MSAL_AUTH) return [];
+  const token = await getToken();
+  const response = await fetch(`${API_BASE_URL}/argus/profiles`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.detail || `Failed to list profiles (${response.status})`);
+  }
+  const data = await response.json();
+  return data.profiles ?? [];
+};
+
+export interface CreateSavedProfileArgs {
+  name: string;
+  baseProfile: ArgusProfile;
+  evaluatorOverrides: EvaluatorOverrides;
+  argusOverrides: ArgusOverrides;
+}
+
+export const createSavedProfile = async (
+  args: CreateSavedProfileArgs,
+): Promise<SavedArgusProfile> => {
+  const token = await getToken();
+  const response = await fetch(`${API_BASE_URL}/argus/profiles`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      name: args.name,
+      base_profile: args.baseProfile,
+      evaluator_overrides: args.evaluatorOverrides,
+      argus_overrides: args.argusOverrides,
+    }),
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.detail || `Failed to save profile (${response.status})`);
+  }
+  return response.json();
+};
+
+export const deleteSavedProfile = async (profileId: string): Promise<void> => {
+  const token = await getToken();
+  const response = await fetch(
+    `${API_BASE_URL}/argus/profiles/${encodeURIComponent(profileId)}`,
+    { method: 'DELETE', headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.detail || `Failed to delete profile (${response.status})`);
+  }
 };
 
 export const getArgusJob = async (jobId: string): Promise<ArgusJob> => {

--- a/frontend/services/argusService.ts
+++ b/frontend/services/argusService.ts
@@ -5,6 +5,7 @@ export type ArgusProfile = 'fast' | 'balanced' | 'thorough';
 export type ArgusSeverity = 'critical' | 'warning' | 'info';
 export type ArgusDiff = 'new' | 'regressed' | 'existing' | 'resolved';
 export type ArgusJobStatus = 'queued' | 'running' | 'done' | 'error';
+export type ArgusUserLabel = 'tp' | 'fp';
 
 export interface ArgusFinding {
   id: string;
@@ -19,6 +20,8 @@ export interface ArgusFinding {
   affected_pct: number;
   diff: ArgusDiff;
   trace: string;
+  // Arm A — most recent human verdict for this finding, when present.
+  user_label?: ArgusUserLabel | null;
 }
 
 export interface ArgusReport {
@@ -246,6 +249,35 @@ export const deleteSavedProfile = async (profileId: string): Promise<void> => {
     const err = await response.json().catch(() => ({}));
     throw new Error(err.detail || `Failed to delete profile (${response.status})`);
   }
+};
+
+export interface RateArgusFindingArgs {
+  reportId: string;
+  findingId: string;
+  label: ArgusUserLabel;
+}
+
+export const rateArgusFinding = async (
+  args: RateArgusFindingArgs,
+): Promise<{ user_label: ArgusUserLabel; rated_by: string }> => {
+  if (!USE_MSAL_AUTH) throw new Error('Sign in to rate findings.');
+  const token = await getToken();
+  const response = await fetch(
+    `${API_BASE_URL}/argus/findings/${encodeURIComponent(args.reportId)}/${encodeURIComponent(args.findingId)}/rate`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ label: args.label }),
+    },
+  );
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.detail || `Failed to rate finding (${response.status})`);
+  }
+  return response.json();
 };
 
 export const getArgusJob = async (jobId: string): Promise<ArgusJob> => {

--- a/frontend/services/argusService.ts
+++ b/frontend/services/argusService.ts
@@ -63,6 +63,7 @@ export interface ArgusOverrides {
   sample_size?: number;
   max_iterations?: number;
   min_severity?: ArgusMinSeverity;
+  llm_model?: string;
 }
 
 export interface EvaluatorOverrides {

--- a/frontend/services/argusService.ts
+++ b/frontend/services/argusService.ts
@@ -289,8 +289,10 @@ export const rateArgusFinding = async (
 };
 
 export const getArgusJob = async (jobId: string): Promise<ArgusJob> => {
+  const token = await getToken();
   const response = await fetch(`${API_BASE_URL}/argus/runs/${encodeURIComponent(jobId)}`, {
     method: 'GET',
+    headers: { Authorization: `Bearer ${token}` },
   });
   if (!response.ok) {
     const err = await response.json().catch(() => ({}));

--- a/frontend/services/argusService.ts
+++ b/frontend/services/argusService.ts
@@ -1,0 +1,85 @@
+import { USE_MSAL_AUTH, API_BASE_URL } from '../app.config';
+import { msalInstance, loginRequest } from '../authConfig';
+
+export type ArgusProfile = 'fast' | 'balanced' | 'thorough';
+export type ArgusSeverity = 'critical' | 'warning' | 'info';
+export type ArgusDiff = 'new' | 'regressed' | 'existing' | 'resolved';
+
+export interface ArgusFinding {
+  id: string;
+  severity: ArgusSeverity;
+  field: string;
+  category: string;
+  summary: string;
+  description: string;
+  evidence: string;
+  affected: number;
+  total: number;
+  affected_pct: number;
+  diff: ArgusDiff;
+  trace: string;
+}
+
+export interface ArgusReport {
+  report_id: string;
+  collection: string;
+  database: string;
+  cosmos_account: string;
+  run_at: string;
+  duration_seconds: number;
+  documents_sampled: number;
+  collection_size: number | null;
+  iterations: number;
+  total_tokens: number;
+  model: string;
+  profile: ArgusProfile;
+  quality_score: number | null;
+  counts: { critical: number; warning: number; info: number; dismissed: number };
+  diff: { new: number; resolved: number; regressed: number };
+  findings: ArgusFinding[];
+  history: unknown | null;
+}
+
+export interface RunArgusAuditArgs {
+  accountId: string;
+  database: string;
+  collection: string;
+  profile: ArgusProfile;
+  maxIterations?: number;
+}
+
+const getToken = async (): Promise<string> => {
+  const accounts = msalInstance.getAllAccounts();
+  if (accounts.length === 0) throw new Error('No signed-in user found.');
+  const response = await msalInstance.acquireTokenSilent({
+    ...loginRequest,
+    account: accounts[0],
+  });
+  return response.accessToken;
+};
+
+export const runArgusAudit = async (args: RunArgusAuditArgs): Promise<ArgusReport> => {
+  if (!USE_MSAL_AUTH) {
+    throw new Error('QueryArgus runs require Azure authentication. Enable MSAL in app.config.ts.');
+  }
+  const token = await getToken();
+  const response = await fetch(`${API_BASE_URL}/argus/run`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      account_id: args.accountId,
+      database: args.database,
+      collection: args.collection,
+      profile: args.profile,
+      max_iterations: args.maxIterations ?? 20,
+    }),
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.detail || `Argus run failed (${response.status})`);
+  }
+  return response.json();
+};

--- a/frontend/services/argusService.ts
+++ b/frontend/services/argusService.ts
@@ -147,6 +147,7 @@ export interface ArgusRunSummary {
   total_tokens: number;
   created_by: string | null;
   findings_count: number;
+  counts?: { critical: number; warning: number; info: number };
 }
 
 export interface ListArgusRunsArgs {

--- a/frontend/services/argusService.ts
+++ b/frontend/services/argusService.ts
@@ -4,6 +4,7 @@ import { msalInstance, loginRequest } from '../authConfig';
 export type ArgusProfile = 'fast' | 'balanced' | 'thorough';
 export type ArgusSeverity = 'critical' | 'warning' | 'info';
 export type ArgusDiff = 'new' | 'regressed' | 'existing' | 'resolved';
+export type ArgusJobStatus = 'queued' | 'running' | 'done' | 'error';
 
 export interface ArgusFinding {
   id: string;
@@ -37,10 +38,23 @@ export interface ArgusReport {
   counts: { critical: number; warning: number; info: number; dismissed: number };
   diff: { new: number; resolved: number; regressed: number };
   findings: ArgusFinding[];
+  created_by: string | null;
   history: unknown | null;
 }
 
-export interface RunArgusAuditArgs {
+export interface ArgusJob {
+  job_id: string;
+  status: ArgusJobStatus;
+  started_at: string;
+  finished_at: string | null;
+  collection: string;
+  database: string;
+  profile: ArgusProfile;
+  report: ArgusReport | null;
+  error: string | null;
+}
+
+export interface StartArgusAuditArgs {
   accountId: string;
   database: string;
   collection: string;
@@ -58,7 +72,9 @@ const getToken = async (): Promise<string> => {
   return response.accessToken;
 };
 
-export const runArgusAudit = async (args: RunArgusAuditArgs): Promise<ArgusReport> => {
+export const startArgusAudit = async (
+  args: StartArgusAuditArgs,
+): Promise<{ job_id: string; status: ArgusJobStatus }> => {
   if (!USE_MSAL_AUTH) {
     throw new Error('QueryArgus runs require Azure authentication. Enable MSAL in app.config.ts.');
   }
@@ -80,6 +96,74 @@ export const runArgusAudit = async (args: RunArgusAuditArgs): Promise<ArgusRepor
   if (!response.ok) {
     const err = await response.json().catch(() => ({}));
     throw new Error(err.detail || `Argus run failed (${response.status})`);
+  }
+  return response.json();
+};
+
+export interface ArgusRunSummary {
+  report_id: string;
+  collection: string;
+  database: string;
+  cosmos_account: string;
+  run_at: string | null;
+  quality_score: number | null;
+  run_eval_verdict: string | null;
+  total_tokens: number;
+  created_by: string | null;
+  findings_count: number;
+}
+
+export interface ListArgusRunsArgs {
+  accountId?: string;
+  database?: string;
+  collection?: string;
+  limit?: number;
+}
+
+export const listArgusRuns = async (
+  args: ListArgusRunsArgs = {},
+): Promise<ArgusRunSummary[]> => {
+  if (!USE_MSAL_AUTH) return [];
+  const token = await getToken();
+  const params = new URLSearchParams();
+  if (args.accountId) params.set('account_id', args.accountId);
+  if (args.database) params.set('database', args.database);
+  if (args.collection) params.set('collection', args.collection);
+  if (args.limit != null) params.set('limit', String(args.limit));
+  const qs = params.toString();
+  const response = await fetch(
+    `${API_BASE_URL}/argus/runs${qs ? `?${qs}` : ''}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.detail || `Failed to list runs (${response.status})`);
+  }
+  const data = await response.json();
+  return data.runs ?? [];
+};
+
+export const getArgusReport = async (reportId: string): Promise<ArgusReport> => {
+  if (!USE_MSAL_AUTH) throw new Error('Sign in to load reports.');
+  const token = await getToken();
+  const response = await fetch(
+    `${API_BASE_URL}/argus/reports/${encodeURIComponent(reportId)}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.detail || `Failed to fetch report (${response.status})`);
+  }
+  return response.json();
+};
+
+export const getArgusJob = async (jobId: string): Promise<ArgusJob> => {
+  const response = await fetch(`${API_BASE_URL}/argus/runs/${encodeURIComponent(jobId)}`, {
+    method: 'GET',
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.detail || `Failed to fetch job (${response.status})`);
   }
   return response.json();
 };

--- a/frontend/src/design-tokens.css
+++ b/frontend/src/design-tokens.css
@@ -182,3 +182,7 @@ html.dark {
 .qp-drawer {
   animation: qp-slide-in-right 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
+
+/* ── Spinner ────────────────────────────────────────────────── */
+
+@keyframes qp-spin { to { transform: rotate(360deg); } }


### PR DESCRIPTION
## Summary
- Integrates QueryArgus as the data-quality audit engine behind the Analytics page (async runs, persisted reports, history, trends, tiered profiles, saved overrides, model selection, finding rating).
- Adds notifications for async Argus runs with deep-linking from the topbar dropdown into the specific report.
- UX polish across Hub, Explorer, Analytics, and Workspace: per-card loaders, blurred connection-chip loader on Explorer switches, collection-switch loader on Analytics, sidebar-driven collection selection in Workspace with Cmd/Ctrl multi-select, and a non-wrapping Analytics header.

## Test plan
- [ ] Run a fresh QueryArgus audit on a collection (fast / balanced / thorough) and confirm the report persists and reloads from history.
- [ ] Trigger an async run, navigate away, and verify the topbar notification deep-links back to the report.
- [ ] Click "Explorer" on the Hub — page should open immediately with a blurred connection chip until the first DB resolves.
- [ ] Switch accounts/databases from the sidebar chip on Explorer — loader/blur should appear before the new page hydrates.
- [ ] Switch collections from the Analytics sidebar — loader overlay should appear during history fetch.
- [ ] In Workspace, select collections via sidebar (single click) and Cmd/Ctrl+click for multi-select; verify middle-panel and sidebar highlights stay in sync.
- [ ] Save and apply a custom QueryArgus profile; ensure inline overrides take precedence over saved settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)