### PR TITLE
release: dev → production (Argus observers + live progress)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,16 +1,37 @@
+import logging
 import os
 from contextlib import asynccontextmanager
 
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from queryargus.observability.logging_observer import JsonFormatter
 from routes import query, azure, system, user_queries, data_documents, audit, argus
+
+
+def _install_argus_log_handler() -> None:
+    """Route the ``queryargus.run`` logger to stderr as one JSON line per event.
+
+    Called from lifespan rather than at module import so test runners (which
+    rely on ``caplog`` propagating records to the root logger) are unaffected
+    when something imports ``main`` during collection.
+    """
+    logger = logging.getLogger("queryargus.run")
+    if any(getattr(h, "_querypal_argus", False) for h in logger.handlers):
+        return  # idempotent — lifespan may run twice under some test harnesses
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    handler._querypal_argus = True  # type: ignore[attr-defined]
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from services.argus_store import get_report_store
 
+    _install_argus_log_handler()
     get_report_store()
     yield
 

--- a/backend/routes/argus.py
+++ b/backend/routes/argus.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -22,6 +23,9 @@ from queryargus.models.config import (
 from queryargus.models.connection import CosmosConnection
 from queryargus.models.finding import Finding
 from queryargus.models.report import AuditReport
+from queryargus.observability.cost import CostTracker
+from queryargus.observability.logging_observer import StructuredLogObserver
+from services.argus_live_events import LiveEventBuffer
 from services.argus_profiles_service import (
     ProfileNameConflict,
     create_profile,
@@ -71,6 +75,11 @@ _SEVERITY_UI = {
 _JOBS: dict[str, dict[str, Any]] = {}
 _MAX_JOBS = 50
 
+# StructuredLogObserver carries no per-run state besides the current run_id
+# (re-set in on_run_start), so a module-level singleton is safe across requests.
+# CostTracker must be constructed per-request — it accumulates token buckets.
+_LOG_OBSERVER = StructuredLogObserver()
+
 
 class AuditRequest(BaseModel):
     account_id: str
@@ -97,6 +106,11 @@ def _summary(description: str) -> str:
 
 
 def _finding_trace(report: AuditReport, finding: Finding) -> str:
+    """One JSON object per relevant agent step (JSONL).
+
+    The frontend parses each line and renders a structured block. Falls back
+    gracefully to plain-text display if a line fails to parse.
+    """
     field = finding.field
     lines: list[str] = []
     for i, action in enumerate(report.run_trace, start=1):
@@ -104,10 +118,14 @@ def _finding_trace(report: AuditReport, finding: Finding) -> str:
         is_write = action.action == "write_finding" and field in inp_repr
         if field not in inp_repr and not is_write:
             continue
-        lines.append(f"iter {i} · {action.action}")
-        lines.append(f"reason: {action.reasoning}")
+        entry: dict[str, Any] = {
+            "iter": i,
+            "action": action.action,
+            "reason": action.reasoning,
+        }
         if is_write:
-            lines.append("finding gate: PASS")
+            entry["gate"] = "PASS"
+        lines.append(json.dumps(entry, ensure_ascii=False, default=str))
     return "\n".join(lines)
 
 
@@ -235,6 +253,9 @@ def _serialize_report(
         "counts": counts,
         "diff": diff_counts,
         "findings": findings,
+        "cost": (
+            report.cost.model_dump(mode="json") if report.cost is not None else None
+        ),
         "created_by": created_by,
         "history": None,
     }
@@ -362,11 +383,14 @@ async def _execute_job(
             else:
                 judge_model_name = jm
             judge_llm = GeminiClient(model=judge_model_name)
+        live = LiveEventBuffer()
+        job["live"] = live
         agent = ArgusAgent.from_config(
             config=config,
             llm=llm,
             judge_llm=judge_llm,
             judge_model_name=judge_model_name,
+            observers=[_LOG_OBSERVER, CostTracker(), live],
         )
 
         history = None
@@ -498,6 +522,38 @@ async def get_run(job_id: str, authorization: str = Header(...)):
             "error": job["error"],
         }
     )
+
+
+@router.get("/runs/{job_id}/events")
+async def get_run_events(
+    job_id: str,
+    authorization: str = Header(...),
+    cursor: int = Query(default=0, ge=0),
+):
+    """Live event snapshot for a still-running job.
+
+    `cursor` is the value returned in the previous poll's `next_cursor`. The
+    response also carries rolled-up aggregates (current_iter, findings_count,
+    running token totals, last_action / last_tool) so the UI can render
+    progress without re-folding the event stream.
+
+    Reuses the same caller-scoping rule as `get_run`: cross-tenant attempts
+    return 404, not 403, to avoid leaking job existence.
+    """
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid token format")
+    caller_email = extract_email_from_token(authorization[7:])
+    job = _JOBS.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job.get("created_by") and job["created_by"] != caller_email:
+        raise HTTPException(status_code=404, detail="Job not found")
+    live: Optional[LiveEventBuffer] = job.get("live")
+    if live is None:
+        # Run hasn't reached the observer-attach point yet (still waiting on
+        # Azure auth / connection-string), or job pre-dates this feature.
+        return JSONResponse(content={"events": [], "next_cursor": 0, "aggregates": {}})
+    return JSONResponse(content=live.snapshot(since=cursor))
 
 
 @router.get("/runs")

--- a/backend/services/argus_live_events.py
+++ b/backend/services/argus_live_events.py
@@ -1,0 +1,155 @@
+"""Per-job in-memory buffer of structured agent events for live progress polling.
+
+Attached as a third observer alongside StructuredLogObserver + CostTracker on
+each Argus run. Mirrors StructuredLogObserver's event shapes so the frontend
+can render one timeline regardless of source.
+
+Thread-safe: ArgusAgent.run is invoked via run_in_threadpool, so the FastAPI
+request loop reads `snapshot()` from one thread while the worker thread writes
+events from another.
+
+Bounded by a ring buffer so a runaway agent cannot OOM the process; the live
+view is for progress, not the system of record (the persisted AuditReport is).
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Any, Literal
+from uuid import UUID
+
+from queryargus.llm.client import TokenUsage
+from queryargus.models.action import AgentAction
+from queryargus.models.finding import Finding
+from queryargus.models.report import AuditReport
+
+_MAX_EVENTS_PER_JOB = 500
+
+
+def _ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class LiveEventBuffer:
+    def __init__(self) -> None:
+        self._events: deque[dict[str, Any]] = deque(maxlen=_MAX_EVENTS_PER_JOB)
+        self._lock = Lock()
+        self._run_id: str | None = None
+        self.current_iter = 0
+        self.findings_count = 0
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.last_action: str | None = None
+        self.last_tool: str | None = None
+        self.tool_errors = 0
+
+    def _push(self, event: str, /, **extras: object) -> None:
+        with self._lock:
+            self._events.append(
+                {"event": event, "run_id": self._run_id, "ts": _ts(), **extras}
+            )
+
+    def snapshot(self, since: int = 0) -> dict[str, Any]:
+        with self._lock:
+            evs = list(self._events)
+            aggregates = {
+                "current_iter": self.current_iter,
+                "findings_count": self.findings_count,
+                "input_tokens": self.input_tokens,
+                "output_tokens": self.output_tokens,
+                "last_action": self.last_action,
+                "last_tool": self.last_tool,
+                "tool_errors": self.tool_errors,
+            }
+        tail = evs[since:] if since < len(evs) else []
+        return {"events": tail, "next_cursor": len(evs), "aggregates": aggregates}
+
+    # RunObserver protocol -------------------------------------------------
+
+    def on_run_start(self, *, run_id: UUID, collection: str) -> None:
+        self._run_id = str(run_id)
+        self._push("run_start", collection=collection)
+
+    def on_iteration_start(self, *, iter: int) -> None:
+        with self._lock:
+            self.current_iter = iter
+        self._push("iteration_start", iter=iter)
+
+    def on_llm_call(
+        self,
+        *,
+        purpose: Literal["propose_action", "self_eval", "judge"],
+        model: str,
+        usage: TokenUsage,
+        latency_ms: int,
+    ) -> None:
+        with self._lock:
+            self.input_tokens += usage.input_tokens
+            self.output_tokens += usage.output_tokens
+        self._push(
+            "llm_call",
+            purpose=purpose,
+            model=model,
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            latency_ms=latency_ms,
+        )
+
+    def on_tool_call(
+        self,
+        *,
+        name: str,
+        args_summary: str,
+        ok: bool,
+        latency_ms: int,
+        error: str | None,
+    ) -> None:
+        with self._lock:
+            self.last_tool = name
+            if not ok:
+                self.tool_errors += 1
+        self._push(
+            "tool_call",
+            tool=name,
+            args_summary=args_summary,
+            ok=ok,
+            latency_ms=latency_ms,
+            error=error,
+        )
+
+    def on_action(self, *, action: AgentAction) -> None:
+        with self._lock:
+            self.last_action = action.action
+        self._push("action", action=action.action, confidence=action.confidence)
+
+    def on_finding(self, *, finding: Finding) -> None:
+        with self._lock:
+            self.findings_count += 1
+        self._push(
+            "finding",
+            field=finding.field,
+            category=finding.category,
+            severity=str(finding.severity),
+        )
+
+    def on_eval(
+        self,
+        *,
+        target: Literal["action", "finding", "run"],
+        verdict: str,
+        score: float,
+        evaluator: str,
+    ) -> None:
+        self._push(
+            "eval", target=target, verdict=verdict, score=score, evaluator=evaluator
+        )
+
+    def on_run_complete(self, *, report: AuditReport) -> None:
+        self._push(
+            "run_complete",
+            findings_count=len(report.findings),
+            duration_ms=int(report.duration_seconds * 1000),
+            usd_total=(report.cost.usd_total if report.cost is not None else None),
+        )

--- a/frontend/components/AppTopBar.tsx
+++ b/frontend/components/AppTopBar.tsx
@@ -27,7 +27,7 @@ const AppTopBar: React.FC<AppTopBarProps> = ({
   const [showNotifs, setShowNotifs] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const notifsRef = useRef<HTMLDivElement>(null);
-  const { notifications, unreadCount, activeRuns, markAllRead, dismiss, clearAll } = useNotifications();
+  const { notifications, unreadCount, activeRuns, runProgress, markAllRead, dismiss, clearAll } = useNotifications();
 
   const initials = user?.name
     ? user.name.split(' ').map((n) => n[0]).join('').slice(0, 2).toUpperCase()
@@ -246,26 +246,55 @@ const AppTopBar: React.FC<AppTopBarProps> = ({
                     fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em',
                     color: 'var(--muted)', marginBottom: 4, fontFamily: 'var(--font-body)',
                   }}>In progress</div>
-                  {activeRuns.map((r) => (
-                    <div key={r.jobId} style={{
-                      display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0',
-                      fontSize: 12, color: 'var(--fg)', fontFamily: 'var(--font-body)',
-                    }}>
-                      <svg width="11" height="11" viewBox="0 0 16 16" fill="none"
-                           stroke="var(--accent)" strokeWidth="1.5"
-                           style={{ animation: 'qp-spin 0.8s linear infinite', flexShrink: 0 }}>
-                        <circle cx="8" cy="8" r="6" strokeOpacity="0.3" />
-                        <path d="M8 2a6 6 0 0 1 6 6" />
-                      </svg>
-                      <span style={{
-                        fontFamily: 'var(--font-mono)', fontSize: 11.5,
-                        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                      }}>{r.collection}</span>
-                      <span style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--muted)' }}>
-                        {formatRelative(r.startedAt)}
-                      </span>
-                    </div>
-                  ))}
+                  {activeRuns.map((r) => {
+                    const prog = runProgress[r.jobId];
+                    const agg = prog?.aggregates;
+                    const tokens = (agg?.input_tokens ?? 0) + (agg?.output_tokens ?? 0);
+                    const detail = agg
+                      ? [
+                          agg.current_iter ? `iter ${agg.current_iter}` : null,
+                          agg.findings_count ? `${agg.findings_count} finding${agg.findings_count === 1 ? '' : 's'}` : null,
+                          tokens ? `${tokens.toLocaleString()} tok` : null,
+                          agg.last_tool ? `→ ${agg.last_tool}` : (agg.last_action ? `→ ${agg.last_action}` : null),
+                        ].filter(Boolean).join(' · ')
+                      : '';
+                    return (
+                      <div key={r.jobId} style={{ padding: '4px 0' }}>
+                        <div style={{
+                          display: 'flex', alignItems: 'center', gap: 8,
+                          fontSize: 12, color: 'var(--fg)', fontFamily: 'var(--font-body)',
+                        }}>
+                          <svg width="11" height="11" viewBox="0 0 16 16" fill="none"
+                               stroke="var(--accent)" strokeWidth="1.5"
+                               style={{ animation: 'qp-spin 0.8s linear infinite', flexShrink: 0 }}>
+                            <circle cx="8" cy="8" r="6" strokeOpacity="0.3" />
+                            <path d="M8 2a6 6 0 0 1 6 6" />
+                          </svg>
+                          <span style={{
+                            fontFamily: 'var(--font-mono)', fontSize: 11.5,
+                            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                          }}>{r.collection}</span>
+                          <span style={{ marginLeft: 'auto', fontSize: 10.5, color: 'var(--muted)' }}>
+                            {formatRelative(r.startedAt)}
+                          </span>
+                        </div>
+                        {detail && (
+                          <div style={{
+                            marginLeft: 19, marginTop: 2,
+                            fontSize: 10.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)',
+                            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                          }}>
+                            {detail}
+                            {agg && agg.tool_errors && agg.tool_errors > 0 ? (
+                              <span style={{ marginLeft: 6, color: 'var(--status-err)' }}>
+                                · {agg.tool_errors} tool error{agg.tool_errors === 1 ? '' : 's'}
+                              </span>
+                            ) : null}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
                 </div>
               )}
 

--- a/frontend/contexts/NotificationsContext.tsx
+++ b/frontend/contexts/NotificationsContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useRef, useState, useCallback, ReactNode } from 'react';
-import { getArgusJob } from '../services/argusService';
+import { getArgusJob, getArgusJobEvents, ArgusLiveAggregates } from '../services/argusService';
 
 export type NotificationKind = 'argus_done' | 'argus_error';
 
@@ -25,10 +25,17 @@ interface TrackedRun {
   startedAt: number;
 }
 
+export interface RunProgress {
+  aggregates: Partial<ArgusLiveAggregates>;
+  cursor: number;
+  updatedAt: number;
+}
+
 interface NotificationsContextType {
   notifications: AppNotification[];
   unreadCount: number;
   activeRuns: TrackedRun[];
+  runProgress: Record<string, RunProgress>;
   trackArgusRun: (run: TrackedRun) => void;
   markAllRead: () => void;
   markRead: (id: string) => void;
@@ -71,9 +78,11 @@ const makeId = () => `${Date.now().toString(36)}-${Math.random().toString(36).sl
 export const NotificationsProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [notifications, setNotifications] = useState<AppNotification[]>(() => readNotifs());
   const [activeRuns, setActiveRuns] = useState<TrackedRun[]>(() => readRuns());
+  const [runProgress, setRunProgress] = useState<Record<string, RunProgress>>({});
   const runsRef = useRef<TrackedRun[]>(activeRuns);
   runsRef.current = activeRuns;
   const pollingRef = useRef<Set<string>>(new Set());
+  const cursorRef = useRef<Record<string, number>>({});
 
   useEffect(() => { writeNotifs(notifications); }, [notifications]);
   useEffect(() => { writeRuns(activeRuns); }, [activeRuns]);
@@ -87,13 +96,38 @@ export const NotificationsProvider: React.FC<{ children: ReactNode }> = ({ child
 
   const removeRun = useCallback((jobId: string) => {
     setActiveRuns((prev) => prev.filter((r) => r.jobId !== jobId));
+    delete cursorRef.current[jobId];
+    setRunProgress((prev) => {
+      if (!(jobId in prev)) return prev;
+      const next = { ...prev };
+      delete next[jobId];
+      return next;
+    });
   }, []);
 
   const pollOnce = useCallback(async (run: TrackedRun) => {
     if (pollingRef.current.has(run.jobId)) return;
     pollingRef.current.add(run.jobId);
     try {
-      const job = await getArgusJob(run.jobId);
+      // Status + live events fetched in parallel. Events are best-effort:
+      // if the endpoint 404s (old backend, evicted job) we let the status
+      // call drive removal.
+      const cursor = cursorRef.current[run.jobId] ?? 0;
+      const [job, snapshot] = await Promise.all([
+        getArgusJob(run.jobId),
+        getArgusJobEvents(run.jobId, cursor).catch(() => null),
+      ]);
+      if (snapshot) {
+        cursorRef.current[run.jobId] = snapshot.next_cursor;
+        setRunProgress((prev) => ({
+          ...prev,
+          [run.jobId]: {
+            aggregates: snapshot.aggregates,
+            cursor: snapshot.next_cursor,
+            updatedAt: Date.now(),
+          },
+        }));
+      }
       if (job.status === 'done') {
         const findingsCount = job.report?.findings.length ?? 0;
         pushNotification({
@@ -165,7 +199,7 @@ export const NotificationsProvider: React.FC<{ children: ReactNode }> = ({ child
 
   return (
     <NotificationsContext.Provider value={{
-      notifications, unreadCount, activeRuns,
+      notifications, unreadCount, activeRuns, runProgress,
       trackArgusRun, markAllRead, markRead, dismiss, clearAll,
     }}>
       {children}

--- a/frontend/pages/AnalyticsPage.tsx
+++ b/frontend/pages/AnalyticsPage.tsx
@@ -470,6 +470,7 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [selId, setSelId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'findings' | 'history' | 'trends'>('findings');
+  const [costUnit, setCostUnit] = useState<'tokens' | 'usd'>('tokens');
   const [history, setHistory] = useState<ArgusRunSummary[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [openingReportId, setOpeningReportId] = useState<string | null>(null);
@@ -1263,7 +1264,40 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
             {new Date(report.run_at).toLocaleString()} · {report.duration_seconds.toFixed(1)}s
           </span>
           <span>·</span>
-          <span>{report.iterations} iterations · {report.total_tokens.toLocaleString()} tokens</span>
+          <span>{report.iterations} iterations</span>
+          <span>·</span>
+          <button
+            type="button"
+            onClick={() => setCostUnit(u => (u === 'tokens' ? 'usd' : 'tokens'))}
+            title={
+              report.cost
+                ? `Click to switch unit. Pricing v${report.cost.pricing_version}.\n` +
+                  report.cost.by_model
+                    .map(m => `${m.model}: ${(m.input_tokens + m.output_tokens).toLocaleString()} tok · $${m.usd.toFixed(4)}`)
+                    .join('\n')
+                : 'Cost not available — toggle disabled'
+            }
+            disabled={!report.cost}
+            style={{
+              background: 'var(--panel)',
+              border: '1px solid var(--border)',
+              color: 'var(--muted)',
+              fontSize: 11, fontFamily: 'var(--font-body)',
+              padding: '2px 10px', borderRadius: 999,
+              cursor: report.cost ? 'pointer' : 'not-allowed',
+              opacity: report.cost ? 1 : 0.55,
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+            }}
+          >
+            <span>
+              {costUnit === 'usd' && report.cost
+                ? `$${report.cost.usd_total.toFixed(4)}`
+                : `${report.total_tokens.toLocaleString()} tokens`}
+            </span>
+            <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8">
+              <path d="M3 6h8l-2-2M13 10H5l2 2" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
           <span>·</span>
           <span>{report.model} · {report.profile}</span>
           {report.created_by && (
@@ -1449,6 +1483,93 @@ const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
         </div>
       )}
       <style>{`@keyframes qp-spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+};
+
+type TraceEvent = { iter: number; action: string; reason: string; gate?: string };
+
+const TraceView: React.FC<{ raw: string }> = ({ raw }) => {
+  const events = useMemo<TraceEvent[] | null>(() => {
+    if (!raw) return [];
+    const lines = raw.split('\n').filter(Boolean);
+    const parsed: TraceEvent[] = [];
+    for (const line of lines) {
+      try {
+        const obj = JSON.parse(line);
+        if (typeof obj?.iter === 'number' && typeof obj?.action === 'string') {
+          parsed.push(obj as TraceEvent);
+        } else {
+          return null;
+        }
+      } catch {
+        return null;
+      }
+    }
+    return parsed;
+  }, [raw]);
+
+  // Fallback: legacy plain-text trace (or malformed JSONL) — render as-is.
+  if (events === null) {
+    return (
+      <pre style={{
+        margin: 0, fontFamily: 'var(--font-mono)', fontSize: 11, lineHeight: 1.7,
+        background: 'var(--soft)', border: '1px solid var(--border)',
+        borderRadius: 8, padding: '10px 12px',
+        whiteSpace: 'pre-wrap', overflow: 'auto', color: 'var(--muted)',
+      }}>{raw}</pre>
+    );
+  }
+
+  if (events.length === 0) {
+    return (
+      <div style={{
+        fontSize: 11, fontStyle: 'italic', color: 'var(--muted)',
+        background: 'var(--soft)', border: '1px solid var(--border)',
+        borderRadius: 8, padding: '10px 12px',
+      }}>(no trace lines matched this field)</div>
+    );
+  }
+
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', gap: 6,
+      background: 'var(--soft)', border: '1px solid var(--border)',
+      borderRadius: 8, padding: '8px 10px', overflow: 'auto',
+    }}>
+      {events.map((ev, idx) => (
+        <div key={idx} style={{
+          display: 'flex', gap: 8, alignItems: 'flex-start',
+          padding: '6px 8px', background: 'var(--panel)',
+          border: '1px solid var(--border)', borderRadius: 6,
+        }}>
+          <span style={{
+            fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--muted)',
+            background: 'var(--soft)', padding: '1px 6px', borderRadius: 4,
+            border: '1px solid var(--border)', flexShrink: 0, minWidth: 42, textAlign: 'center',
+          }}>iter {ev.iter}</span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{
+              display: 'flex', gap: 6, alignItems: 'center', marginBottom: 2,
+              fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg)',
+            }}>
+              <span style={{ fontWeight: 600 }}>{ev.action}</span>
+              {ev.gate && (
+                <span style={{
+                  fontSize: 9.5, padding: '1px 5px', borderRadius: 3,
+                  background: 'rgba(34,148,94,0.12)', color: '#22945e',
+                  border: '1px solid rgba(34,148,94,0.3)', textTransform: 'uppercase',
+                  letterSpacing: '0.04em',
+                }}>gate {ev.gate}</span>
+              )}
+            </div>
+            <div style={{
+              fontFamily: 'var(--font-body)', fontSize: 11.5, color: 'var(--muted)',
+              lineHeight: 1.55, whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+            }}>{ev.reason}</div>
+          </div>
+        </div>
+      ))}
     </div>
   );
 };
@@ -2007,12 +2128,7 @@ const ReportBody: React.FC<{
                 field was flagged the way it was.
               </InfoPopover>
             </div>
-            <pre style={{
-              margin: 0, fontFamily: 'var(--font-mono)', fontSize: 11, lineHeight: 1.7,
-              background: 'var(--soft)', border: '1px solid var(--border)',
-              borderRadius: 8, padding: '10px 12px',
-              whiteSpace: 'pre-wrap', overflow: 'auto', color: 'var(--muted)',
-            }}>{sel.trace || '(no trace lines matched this field)'}</pre>
+            <TraceView raw={sel.trace} />
           </div>
         </div>
       </aside>

--- a/frontend/services/argusService.ts
+++ b/frontend/services/argusService.ts
@@ -24,6 +24,19 @@ export interface ArgusFinding {
   user_label?: ArgusUserLabel | null;
 }
 
+export interface ArgusModelCost {
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  usd: number;
+}
+
+export interface ArgusRunCost {
+  usd_total: number;
+  by_model: ArgusModelCost[];
+  pricing_version: string;
+}
+
 export interface ArgusReport {
   report_id: string;
   collection: string;
@@ -48,6 +61,7 @@ export interface ArgusReport {
   counts: { critical: number; warning: number; info: number; dismissed: number };
   diff: { new: number; resolved: number; regressed: number };
   findings: ArgusFinding[];
+  cost: ArgusRunCost | null;
   created_by: string | null;
   history: unknown | null;
 }
@@ -284,6 +298,38 @@ export const rateArgusFinding = async (
   if (!response.ok) {
     const err = await response.json().catch(() => ({}));
     throw new Error(err.detail || `Failed to rate finding (${response.status})`);
+  }
+  return response.json();
+};
+
+export interface ArgusLiveAggregates {
+  current_iter: number;
+  findings_count: number;
+  input_tokens: number;
+  output_tokens: number;
+  last_action: string | null;
+  last_tool: string | null;
+  tool_errors: number;
+}
+
+export interface ArgusLiveSnapshot {
+  events: Array<{ event: string; ts: string; run_id?: string | null; [k: string]: unknown }>;
+  next_cursor: number;
+  aggregates: Partial<ArgusLiveAggregates>;
+}
+
+export const getArgusJobEvents = async (
+  jobId: string,
+  cursor: number,
+): Promise<ArgusLiveSnapshot> => {
+  const token = await getToken();
+  const response = await fetch(
+    `${API_BASE_URL}/argus/runs/${encodeURIComponent(jobId)}/events?cursor=${cursor}`,
+    { method: 'GET', headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.detail || `Failed to fetch events (${response.status})`);
   }
   return response.json();
 };


### PR DESCRIPTION
## Summary

Promotes one feature commit from dev to production: **#39 — structured observers + live progress polling for QueryArgus runs**.

This release consumes the observability foundation shipped in QueryArgus PR #2 and wires three observers (`StructuredLogObserver`, `CostTracker`, `LiveEventBuffer`) into QueryPal's Argus run path. Backend gains a new poll endpoint for live event tails; frontend gains a token↔USD cost toggle, a structured (JSONL) ReAct trace renderer, and live progress lines in the notifications dropdown.

## What's shipping

- **#39** — `feat(argus): structured observers + live progress polling` ([squash merge](https://github.com/ChingEnLin/QueryPal/pull/39))
- Submodule bump: `backend/queryargus` → `36edf12` (QueryArgus PR #2 merge)

## Files changed

| Area | Files |
|---|---|
| Backend | `main.py`, `routes/argus.py`, `services/argus_live_events.py` (new), `queryargus` submodule |
| Frontend | `components/AppTopBar.tsx`, `contexts/NotificationsContext.tsx`, `pages/AnalyticsPage.tsx`, `services/argusService.ts` |

## Known merge conflict

`CHANGELOG.md` will conflict — production carries the auto-generated 2.11.0 entries (via semantic-release) that haven't been back-merged to dev. Standard resolution per the prior `dca0412` precedent: keep production's CHANGELOG.md; semantic-release will regenerate it for the new release.

## Test plan

- [ ] Post-merge: confirm semantic-release tags a new version (likely 2.12.0 — one MINOR's worth of `feat:` commits).
- [ ] Smoke-test in production: trigger an Argus audit and confirm the notifications dropdown shows live `iter N · M findings · K tok · → last_tool` progress.
- [ ] Confirm the report header cost toggle flips between tokens and USD with per-model breakdown on hover.
- [ ] Confirm the ReAct trace renders as structured per-step blocks (iter chip, action, optional gate badge).
- [ ] Confirm backend logs emit one JSON line per observer event on the `queryargus.run` logger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)