### PR TITLE
feat(ux): hub recents, ⌘K palette, saved-query search, write-op guards

### DIFF
--- a/frontend/components/QueryDisplay.tsx
+++ b/frontend/components/QueryDisplay.tsx
@@ -219,7 +219,7 @@ const QueryDisplay: React.FC<QueryDisplayProps> = ({
           disabled={isRunDisabled}
           className="qa-btn primary"
           aria-label={isExecuting ? 'Running' : 'Run query'}
-          title={writeBlocked ? 'Write operations require Analyst or Admin role' : undefined}
+          title={writeBlocked ? 'Write operations require Analyst or Admin role' : (isWriteOperation && !allowWrite) ? 'Acknowledge the write operation above to enable Run' : undefined}
           style={{ fontSize: 12 }}
         >
           {isExecuting ? 'Running' : 'Run'}

--- a/frontend/components/SavedQueriesPanel.tsx
+++ b/frontend/components/SavedQueriesPanel.tsx
@@ -25,6 +25,8 @@ const timeAgo = (dateString: string) => {
     return `${Math.floor(d / 30)}mo ago`;
 };
 
+const WRITE_OP_RE = /\.(insert_one|insert_many|update_one|update_many|replace_one|delete_one|delete_many|bulk_write|drop|drop_index|drop_indexes|create_index|create_indexes|rename_collection)\s*\(/i;
+
 const PinIcon = () => (
     <svg width="11" height="11" viewBox="0 0 16 16" fill="var(--accent)" stroke="var(--accent)" strokeWidth="1.2">
         <path d="M5 2v6l-2 2v1h4v4h2v-4h4v-1l-2-2V2z"/>
@@ -46,6 +48,7 @@ const SavedQueryCard: React.FC<SavedQueryCardProps> = ({ query, onLoad, onLoadAn
     const handleDelete = () => {
         if (window.confirm(`Delete "${query.name}"? This cannot be undone.`)) onDelete(query.id);
     };
+    const isWrite = WRITE_OP_RE.test(query.code);
     return (
         <div
             className="qa-card"
@@ -59,6 +62,11 @@ const SavedQueryCard: React.FC<SavedQueryCardProps> = ({ query, onLoad, onLoadAn
             {/* Name + tags row */}
             <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6, paddingRight: 20 }}>
                 <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)', lineHeight: 1.3 }}>{query.name}</span>
+                {isWrite && (
+                    <span style={{ fontSize: 10, padding: '2px 7px', borderRadius: 4, background: 'color-mix(in oklch, #c94250 12%, var(--bg))', color: '#c94250', fontFamily: 'var(--font-mono)', flexShrink: 0, marginTop: 1 }}>
+                        write op
+                    </span>
+                )}
             </div>
 
             {/* Prompt quote */}
@@ -86,16 +94,16 @@ const SavedQueryCard: React.FC<SavedQueryCardProps> = ({ query, onLoad, onLoadAn
                     disabled={!dbReady}
                     className="qa-btn"
                     title={!dbReady ? 'Connect to a database first' : 'Load query into editor'}
-                    style={{ fontSize: 12, padding: '4px 12px', opacity: dbReady ? 1 : 0.45, cursor: dbReady ? 'pointer' : 'not-allowed' }}
+                    style={{ fontSize: 12, padding: '4px 12px' }}
                 >
                     Load
                 </button>
                 <button
                     onClick={() => onLoadAndRun(query)}
-                    disabled={!dbReady}
+                    disabled={!dbReady || isWrite}
                     className="qa-btn primary"
-                    title={!dbReady ? 'Connect to a database first' : 'Load query and run it immediately'}
-                    style={{ fontSize: 12, padding: '4px 12px', display: 'flex', alignItems: 'center', gap: 5, opacity: dbReady ? 1 : 0.45, cursor: dbReady ? 'pointer' : 'not-allowed' }}
+                    title={!dbReady ? 'Connect to a database first' : isWrite ? 'Write operations must be reviewed — load the query and acknowledge the toggle to run' : 'Load query and run it immediately'}
+                    style={{ fontSize: 12, padding: '4px 12px', display: 'flex', alignItems: 'center', gap: 5 }}
                 >
                     <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8">
                         <path d="M5 3l9 5-9 5V3z" fill="currentColor" strokeLinejoin="round"/>
@@ -138,6 +146,7 @@ const SavedQueriesPanel: React.FC<SavedQueriesPanelProps> = ({
     onClose, queries, onLoad, onLoadAndRun, onEdit, onDelete, onShare, isLoading, dbReady, currentUserEmail,
 }) => {
     const [activeTab, setActiveTab] = useState<'my_queries' | 'shared_with_me'>('my_queries');
+    const [search, setSearch] = useState('');
 
     const { myQueries, sharedWithMe } = useMemo(() => {
         if (!currentUserEmail) return { myQueries: [], sharedWithMe: [] };
@@ -150,7 +159,14 @@ const SavedQueriesPanel: React.FC<SavedQueriesPanelProps> = ({
         return { myQueries: myq, sharedWithMe: swm };
     }, [queries, currentUserEmail]);
 
-    const queriesToDisplay = activeTab === 'my_queries' ? myQueries : sharedWithMe;
+    const baseList = activeTab === 'my_queries' ? myQueries : sharedWithMe;
+    const queriesToDisplay = useMemo(() => {
+        const term = search.trim().toLowerCase();
+        if (!term) return baseList;
+        return baseList.filter(
+            (q) => q.name.toLowerCase().includes(term) || q.prompt.toLowerCase().includes(term)
+        );
+    }, [baseList, search]);
 
     const renderContent = () => {
         if (isLoading) {
@@ -184,7 +200,12 @@ const SavedQueriesPanel: React.FC<SavedQueriesPanelProps> = ({
                     <path d="M4 2h6l3 3v9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1z"/>
                     <path d="M6 7h5M6 10h3"/>
                 </svg>
-                {activeTab === 'my_queries' ? (
+                {search ? (
+                    <>
+                        <p style={{ fontSize: 13, fontWeight: 500, margin: 0 }}>No matches</p>
+                        <p style={{ fontSize: 12, margin: 0, textAlign: 'center' }}>Try a different name or keyword.</p>
+                    </>
+                ) : activeTab === 'my_queries' ? (
                     <>
                         <p style={{ fontSize: 13, fontWeight: 500, margin: 0 }}>No saved queries yet</p>
                         <p style={{ fontSize: 12, margin: 0, textAlign: 'center' }}>Click Save on a generated query to add it here.</p>
@@ -248,7 +269,7 @@ const SavedQueriesPanel: React.FC<SavedQueriesPanelProps> = ({
                         {(['my_queries', 'shared_with_me'] as const).map((tab) => (
                             <button
                                 key={tab}
-                                onClick={() => setActiveTab(tab)}
+                                onClick={() => { setActiveTab(tab); setSearch(''); }}
                                 style={{
                                     flex: 1, padding: '4px 0', fontSize: 12, fontWeight: activeTab === tab ? 500 : 400,
                                     border: 'none', borderRadius: 4, cursor: 'pointer',
@@ -267,6 +288,35 @@ const SavedQueriesPanel: React.FC<SavedQueriesPanelProps> = ({
                                 )}
                             </button>
                         ))}
+                    </div>
+                </div>
+
+                {/* Search */}
+                <div style={{ padding: '8px 14px', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 7, background: 'var(--soft)', border: '1px solid var(--border)', borderRadius: 7, padding: '5px 10px' }}>
+                        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ color: 'var(--muted)', flexShrink: 0 }}>
+                            <circle cx="7" cy="7" r="4.5"/><path d="M10.5 10.5l3 3"/>
+                        </svg>
+                        <input
+                            type="text"
+                            placeholder="Search by name or prompt…"
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                            style={{
+                                flex: 1, background: 'none', border: 'none', outline: 'none',
+                                fontSize: 12.5, color: 'var(--fg)', fontFamily: 'var(--font-body)',
+                            }}
+                        />
+                        {search && (
+                            <button
+                                onClick={() => setSearch('')}
+                                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex', padding: 0 }}
+                            >
+                                <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8">
+                                    <path d="M3 3l10 10M13 3L3 13"/>
+                                </svg>
+                            </button>
+                        )}
                     </div>
                 </div>
 

--- a/frontend/pages/AuditPage.tsx
+++ b/frontend/pages/AuditPage.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { useNavigate } from 'react-router-dom';
 import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
 import { useRoles } from '../hooks/useRoles';
 import { API_BASE_URL, USE_MSAL_AUTH } from '../app.config';
 import AppLayout from '../components/AppLayout';
 import ChartDisplay, { VisualizationConfig } from '../components/ChartDisplay';
 import { MOCK_AUDIT_EVENTS } from '../services/mockAuditData';
-import { getDatabasesForAccount } from '../services/dbService';
+import { getDatabasesForAccount, getAzureCosmosAccounts } from '../services/dbService';
 import { CosmosDBAccount, DbInfo, CollectionSummary } from '../types';
 
 /* ── session connection (shared shape written by the connect flow) ────────── */
@@ -304,8 +305,25 @@ function ValueCell({ value }: { value: any }) {
     return <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg)', wordBreak: 'break-word' }}>{typeof value === 'string' ? `"${value}"` : String(value)}</span>;
 }
 
-function DiffDrawer({ event, onClose, now }: { event: AuditEvent | null; onClose: () => void; now: number }) {
+function DiffDrawer({ event, onClose, now, availableAccounts }: {
+    event: AuditEvent | null; onClose: () => void; now: number;
+    availableAccounts: CosmosDBAccount[];
+}) {
+    const navigate = useNavigate();
     if (!event) return null;
+
+    // event.database_name is stored as "accountName.databaseName"
+    const dbParts = event.database_name.split('.');
+    const eventAccountName = dbParts[0];
+    const eventDatabaseName = dbParts.slice(1).join('.');
+    const resolvedAccountId = availableAccounts.find((a) => a.name === eventAccountName)?.id;
+
+    const canOpen =
+        event.operation !== 'delete' &&
+        event.document_id !== '—' &&
+        !!event.document_id &&
+        !!resolvedAccountId &&
+        !!eventDatabaseName;
     const o = OP[event.operation];
     const sysFields = ['datetime_creation', 'datetime_last_modified'];
     const diff = event.diff_data && typeof event.diff_data === 'object' ? event.diff_data : {};
@@ -382,7 +400,22 @@ function DiffDrawer({ event, onClose, now }: { event: AuditEvent | null; onClose
                 </div>
 
                 <div style={{ padding: '12px 20px', borderTop: '1px solid var(--border)', display: 'flex', gap: 8 }}>
-                    <button className="qa-btn" style={{ gap: 6 }}>
+                    <button
+                        className="qa-btn"
+                        disabled={!canOpen}
+                        title={
+                            event.operation === 'delete' ? 'Document was deleted' :
+                            (event.document_id === '—' || !event.document_id) ? 'Document ID unknown' :
+                            !resolvedAccountId ? 'Account not found in your connections' :
+                            undefined
+                        }
+                        style={{ gap: 6, opacity: canOpen ? 1 : 0.45, cursor: canOpen ? 'pointer' : 'not-allowed' }}
+                        onClick={() => {
+                            if (!canOpen) return;
+                            navigate(`/data-explorer/${encodeURIComponent(resolvedAccountId!)}/${encodeURIComponent(eventDatabaseName)}/document/${encodeURIComponent(event.document_id)}`);
+                            onClose();
+                        }}
+                    >
                         <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4"><path d="M3 8l3 3 7-7" /></svg>
                         Open document
                     </button>
@@ -663,6 +696,7 @@ const AuditPage: React.FC = () => {
     const isAdmin = can('audit:read');
     const isAnalyst = !isAdmin && can('self:manage');
     const [allEvents, setAllEvents] = useState<AuditEvent[]>([]);
+    const [cosmosAccounts, setCosmosAccounts] = useState<CosmosDBAccount[]>([]);
     const [loading, setLoading] = useState(true);
     const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -697,18 +731,23 @@ const AuditPage: React.FC = () => {
                         : MOCK_AUDIT_EVENTS;
                     const rows = scoped.length ? scoped : MOCK_AUDIT_EVENTS;
                     if (!cancelled) setAllEvents(toEvents(rows));
+                    const accs = await getAzureCosmosAccounts();
+                    if (!cancelled) setCosmosAccounts(accs);
                     return;
                 }
                 const token = await getToken();
                 const params = new URLSearchParams({ days: '90', limit: '1000' });
                 if (scopedAccount) params.set('account', scopedAccount);
                 const endpoint = isAdmin ? 'events' : 'events/mine';
-                const res = await fetch(`${API_BASE_URL}/audit/${endpoint}?${params.toString()}`, {
-                    headers: { Authorization: `Bearer ${token}` },
-                });
+                const [res, accs] = await Promise.all([
+                    fetch(`${API_BASE_URL}/audit/${endpoint}?${params.toString()}`, {
+                        headers: { Authorization: `Bearer ${token}` },
+                    }),
+                    getAzureCosmosAccounts(),
+                ]);
                 if (!res.ok) throw new Error('Failed to load audit events');
                 const raw: RawAuditEvent[] = await res.json();
-                if (!cancelled) setAllEvents(toEvents(raw));
+                if (!cancelled) { setAllEvents(toEvents(raw)); setCosmosAccounts(accs); }
             } catch (err: any) {
                 if (!cancelled) setLoadError(err.message || 'An error occurred');
             } finally {
@@ -934,7 +973,7 @@ const AuditPage: React.FC = () => {
                     </div>
                 )}
 
-                <DiffDrawer event={selected} onClose={() => setSelected(null)} now={now} />
+                <DiffDrawer event={selected} onClose={() => setSelected(null)} now={now} availableAccounts={cosmosAccounts} />
             </div>
         </AppLayout>
     );

--- a/frontend/pages/HubPage.tsx
+++ b/frontend/pages/HubPage.tsx
@@ -1,11 +1,41 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
 import { useTheme } from '../contexts/ThemeContext';
 import UserMenuButton from '../components/UserMenuButton';
+import CommandPalette from '../components/CommandPalette';
 import { getAzureCosmosAccounts } from '../services/dbService';
 import { CosmosDBAccount } from '../types';
 import { API_BASE_URL } from '../app.config';
+
+const RECENT_KEY = 'qp_recent_connections';
+const MAX_RECENTS = 3;
+
+interface RecentConnection {
+  accountId: string;
+  accountName: string;
+  action: 'query' | 'explorer';
+  accessedAt: number;
+}
+
+function loadRecents(): RecentConnection[] {
+  try {
+    return JSON.parse(localStorage.getItem(RECENT_KEY) ?? '[]');
+  } catch {
+    return [];
+  }
+}
+
+function saveRecent(entry: Omit<RecentConnection, 'accessedAt'>) {
+  const existing = loadRecents().filter(
+    (r) => !(r.accountId === entry.accountId && r.action === entry.action)
+  );
+  const next: RecentConnection[] = [
+    { ...entry, accessedAt: Date.now() },
+    ...existing,
+  ].slice(0, MAX_RECENTS);
+  localStorage.setItem(RECENT_KEY, JSON.stringify(next));
+}
 
 interface RecentActivityItem {
   database_name: string;
@@ -149,6 +179,7 @@ const HubPage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [recentActivity, setRecentActivity] = useState<RecentActivityItem[]>([]);
+  const [recents, setRecents] = useState<RecentConnection[]>(loadRecents);
 
   useEffect(() => {
     getAzureCosmosAccounts()
@@ -179,26 +210,42 @@ const HubPage: React.FC = () => {
   const hour = new Date().getHours();
   const greeting = hour < 12 ? 'Good morning' : hour < 17 ? 'Good afternoon' : 'Good evening';
 
+  const [paletteOpen, setPaletteOpen] = useState(false);
   const [busyAccountId, setBusyAccountId] = useState<string | null>(null);
   const [busyAction, setBusyAction] = useState<'open' | 'explorer' | null>(null);
 
-  const handleOpenAccount = (account: CosmosDBAccount) => {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        setPaletteOpen((v) => !v);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const handleOpenAccount = useCallback((account: CosmosDBAccount) => {
     if (busyAccountId) return;
     setBusyAccountId(account.id);
     setBusyAction('open');
+    saveRecent({ accountId: account.id, accountName: account.name, action: 'query' });
+    setRecents(loadRecents());
     navigate('/query-generator', { state: { preselectedAccountId: account.id, preselectedAccountName: account.name } });
-  };
+  }, [busyAccountId, navigate]);
 
-  const handleOpenExplorer = (account: CosmosDBAccount) => {
+  const handleOpenExplorer = useCallback((account: CosmosDBAccount) => {
     if (busyAccountId) return;
     setBusyAccountId(account.id);
     setBusyAction('explorer');
+    saveRecent({ accountId: account.id, accountName: account.name, action: 'explorer' });
+    setRecents(loadRecents());
     // Navigate immediately; the explorer wrapper resolves the first database
     // and shows a blurred connection chip while it loads.
     navigate(`/data-explorer/${encodeURIComponent(account.id)}`, {
       state: { pendingAccountName: account.name },
     });
-  };
+  }, [busyAccountId, navigate]);
 
   return (
     <div style={s.page}>
@@ -209,30 +256,24 @@ const HubPage: React.FC = () => {
           <span style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 14.5 }}>QueryPal</span>
         </Link>
 
-        <nav style={{ display: 'flex', alignItems: 'center', gap: 2, marginLeft: 8 }}>
-          {[
-            { label: 'Home', href: '/hub', active: true },
-            { label: 'Analytics', href: '/analytics', active: false },
-          ].map((item) => (
-            <Link
-              key={item.href}
-              to={item.href}
-              style={{
-                fontSize: 12.5,
-                color: item.active ? 'var(--fg)' : 'var(--muted)',
-                textDecoration: 'none',
-                padding: '6px 9px',
-                borderRadius: 6,
-                fontWeight: item.active ? 500 : 400,
-                background: item.active ? 'var(--soft)' : 'transparent',
-              }}
-            >
-              {item.label}
-            </Link>
-          ))}
-        </nav>
 
         <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <button
+            onClick={() => setPaletteOpen(true)}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 6,
+              padding: '5px 12px', border: '1px solid var(--border)', borderRadius: 7,
+              background: 'var(--soft)', color: 'var(--muted)', fontSize: 12,
+              cursor: 'pointer', fontFamily: 'var(--font-body)',
+            }}
+            title="Command palette (⌘K)"
+          >
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <circle cx="7" cy="7" r="4.5"/>
+              <path d="M10.5 10.5l3 3"/>
+            </svg>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>⌘K</span>
+          </button>
           {/* Theme toggle — shows icon for what you'll switch TO */}
           <button
             onClick={toggleTheme}
@@ -271,6 +312,49 @@ const HubPage: React.FC = () => {
             Pick a connection to start querying.
           </p>
         </div>
+
+        {/* Jump back in */}
+        {recents.length > 0 && (
+          <section>
+            <h2 style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--muted)', margin: '0 0 12px' }}>
+              Jump back in
+            </h2>
+            <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+              {recents.map((r) => {
+                const account = accounts.find((a) => a.id === r.accountId);
+                const inert = !!busyAccountId;
+                return (
+                  <button
+                    key={`${r.accountId}-${r.action}`}
+                    disabled={inert}
+                    onClick={() => {
+                      const acc = account ?? ({ id: r.accountId, name: r.accountName } as CosmosDBAccount);
+                      if (r.action === 'query') handleOpenAccount(acc);
+                      else handleOpenExplorer(acc);
+                    }}
+                    style={{
+                      display: 'inline-flex', alignItems: 'center', gap: 8,
+                      padding: '8px 14px', borderRadius: 10,
+                      border: '1px solid var(--border)', background: 'var(--panel)',
+                      cursor: inert ? 'not-allowed' : 'pointer', opacity: inert ? 0.55 : 1,
+                      fontFamily: 'var(--font-body)', color: 'var(--fg)',
+                      transition: 'border-color 0.12s, background 0.12s',
+                    }}
+                    onMouseEnter={(e) => { if (!inert) { (e.currentTarget as HTMLButtonElement).style.borderColor = 'color-mix(in oklch, var(--accent) 35%, var(--border))'; (e.currentTarget as HTMLButtonElement).style.background = 'var(--soft)'; } }}
+                    onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--border)'; (e.currentTarget as HTMLButtonElement).style.background = 'var(--panel)'; }}
+                  >
+                    <div style={{ width: 22, height: 22, borderRadius: 5, background: '#1a4f8c', color: '#fff', display: 'grid', placeItems: 'center', fontFamily: 'var(--font-display)', fontSize: 12, fontWeight: 600, flexShrink: 0 }}>C</div>
+                    <span style={{ fontSize: 13, fontWeight: 500 }}>{r.accountName}</span>
+                    <span className={`qa-chip${r.action === 'query' ? ' accent' : ''}`} style={{ fontSize: 10 }}>
+                      {r.action === 'query' ? 'Query' : 'Explorer'}
+                    </span>
+                    <span style={{ fontSize: 11, color: 'var(--muted)' }}>{formatRelativeTime(new Date(r.accessedAt).toISOString())}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        )}
 
         {/* Connections */}
         <section>
@@ -391,6 +475,12 @@ const HubPage: React.FC = () => {
           </div>
         </section>
       </div>
+      <CommandPalette
+        open={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        availableAccounts={accounts}
+        onSwitchAccount={(account) => { setPaletteOpen(false); handleOpenAccount(account); }}
+      />
     </div>
   );
 };

--- a/frontend/src/design-tokens.css
+++ b/frontend/src/design-tokens.css
@@ -55,12 +55,14 @@ html.dark {
   white-space: nowrap;
 }
 .qa-btn:hover { background: var(--soft); }
+.qa-btn:disabled { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
 .qa-btn.primary {
   background: var(--accent);
   border-color: var(--accent);
   color: #fff;
 }
 .qa-btn.primary:hover { opacity: 0.9; }
+.qa-btn.primary:disabled { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
 
 .qa-chip {
   display: inline-flex;


### PR DESCRIPTION
## Summary

- **Hub — Jump back in**: Persists last 3 `(account, action)` pairs to `localStorage`; shows a quick-access row above the connections grid so users can re-open a recent connection in one click
- **Hub — ⌘K command palette**: Adds the same command palette used in Workspace/Explorer to the Hub topbar (right-aligned); triggered by button or `⌘K` shortcut. Removes the redundant Analytics nav link from the Hub topbar
- **Saved queries — search**: Adds a search input (filter by name or prompt) between the tabs and the list; clears on tab switch; empty state distinguishes "no matches" from "nothing saved"
- **Saved queries — write-op guard**: Detects write operations in saved query code; disables Load & Run button with explanatory tooltip; shows a "write op" badge on the card
- **Write-op Run button tooltip**: Adds a tooltip on the greyed-out Run button in QueryDisplay explaining the toggle requirement
- **`.qa-btn` disabled styles**: Adds `:disabled` CSS (opacity 0.4, `not-allowed` cursor) which was missing — disabled state was set in HTML but not visually reflected anywhere
- **Audit — Open document**: Resolves account ID via fresh `getAzureCosmosAccounts()` call (cached) instead of stale session storage, fixing "account not found" errors

## Test plan

- [ ] Open Hub → click "Open" or "Explorer" on a connection → navigate back to Hub → verify "Jump back in" row appears with correct account name, action badge, and time-ago
- [ ] Press ⌘K on Hub → palette opens with navigation commands and account list
- [ ] Open Saved Queries panel → type in search box → list filters by name and prompt
- [ ] Save a write-op query → open Saved Queries → verify "write op" badge visible, Load & Run disabled, Load still enabled
- [ ] In QueryDisplay with a write-op query, hover the greyed Run button → tooltip explains toggle requirement
- [ ] Toggle the write acknowledgement → Run button becomes active
- [ ] In Audit page, open a diff drawer for an update/insert entry → "Open document" button resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)