### PR TITLE
fix(query-gen): make datetime queries work in the eval sandbox

### DIFF
--- a/backend/services/mongo_service.py
+++ b/backend/services/mongo_service.py
@@ -1,3 +1,5 @@
+import datetime as _datetime
+
 from bson import ObjectId
 
 SCHEMA_FETCH_FAILED = "Could not fetch schema summary."
@@ -10,12 +12,37 @@ from pymongo.results import (
 )
 
 
+def _iso_date(value: str) -> _datetime.datetime:
+    """mongosh-style ISODate() shim.
+
+    The LLM instinctively reaches for `ISODate("...")` (mongosh/JS syntax). The
+    real executor here is Python `eval()` against PyMongo, so we provide a shim
+    that turns the string into a timezone-aware datetime PyMongo understands.
+    """
+    return _datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _build_query_scope(db):
+    """Globals exposed to the eval'd query string.
+
+    Note: queries are evaluated as a single Python *expression*, so they must
+    not contain `import` statements. `datetime` is provided here so that
+    `datetime.datetime(2025, 1, 1)` resolves without an import.
+    """
+    return {
+        "db": db,
+        "ObjectId": ObjectId,
+        "datetime": _datetime,
+        "ISODate": _iso_date,
+    }
+
+
 def execute_mongo_query(connection_string: str, database: str, query: str):
     client = pymongo.MongoClient(connection_string)
     db = client[database]
     try:
-        # Evaluate the query string in the context of the db variable and ObjectId
-        query_result = eval(query, {"db": db, "ObjectId": ObjectId})
+        # Evaluate the query string in a sandboxed scope. See _build_query_scope.
+        query_result = eval(query, _build_query_scope(db))
     except Exception as e:
         # Return the exception to be handled by the endpoint
         return {"error": str(e), "exception_type": type(e).__name__}

--- a/backend/services/react_agent_service.py
+++ b/backend/services/react_agent_service.py
@@ -157,6 +157,9 @@ Instructions:
 3. Do not include markdown formatting or explanations, just return the code, but you can use ```python if you must.
 4. If the user is asking for a visualization, ensure the query retrieves the necessary data format.
 5. You are allowed to use both find() and aggregate() pipelines. If using aggregate(), be mindful of the resulting data size and include $limit stages if applicable.
+6. EXECUTION CONTEXT: the query is run with PyMongo via Python `eval()` as a SINGLE expression — NOT in mongosh. This has two consequences:
+   - Do NOT write `import` statements (e.g. `import datetime`). `eval()` only accepts one expression and an import is a statement — it will raise `invalid syntax`.
+   - For dates, use Python datetime objects: `datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)`. The `datetime` module is already in scope. Do NOT use mongosh-only syntax like a bare `ISODate("...")` mindset — `datetime.datetime(...)` is the correct, supported form here.
 {cross_collection_guidance}
 """
 
@@ -168,6 +171,10 @@ Generated Query: {generated_query}
 Is Write Action: {is_write_action}
 Query Result / Error: 
 {query_result}
+
+EXECUTION CONTEXT (important): this query is executed with PyMongo via Python `eval()`, NOT in mongosh. The scope already provides `db`, `ObjectId`, `datetime`, and an `ISODate` shim. Therefore:
+  - Python datetime objects such as `datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)` are the CORRECT, supported way to express dates. Do NOT critique them or recommend replacing them with mongosh `ISODate("...")`.
+  - If the error is `name 'datetime' is not defined` or `invalid syntax` caused by an `import` line, the fix is to REMOVE the `import` statement (the query must be a single expression) and rely on the in-scope `datetime` module — NOT to switch to mongosh syntax.
 
 Your task:
 Determine if this query successfully answers the user's request based on the code and the result.

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -6,8 +6,20 @@ def test_app_startup(client):
     # Test that the app is created successfully
     assert client.app is not None
 
-    # Check that all routers are included
-    routes = [route.path for route in client.app.routes]
+    # Check that all routers are included. Newer FastAPI versions wrap
+    # `include_router` results in `_IncludedRouter`, which has no `.path` of
+    # its own — expand those into their prefixed sub-route paths.
+    routes = []
+    for route in client.app.routes:
+        if hasattr(route, "path"):
+            routes.append(route.path)
+        elif hasattr(route, "original_router"):
+            prefix = route.include_context.prefix
+            routes.extend(
+                prefix + sub.path
+                for sub in route.original_router.routes
+                if hasattr(sub, "path")
+            )
 
     # Check that main route prefixes exist
     route_prefixes = ["/query", "/azure", "/system", "/user", "/data"]

--- a/backend/tests/test_mongo_operations.py
+++ b/backend/tests/test_mongo_operations.py
@@ -141,6 +141,61 @@ class TestMongoService:
         assert result == 2
 
     @patch("services.mongo_service.pymongo.MongoClient")
+    def test_execute_mongo_query_with_datetime_in_scope(
+        self, mock_mongo_client, mock_client, sample_documents
+    ):
+        """Regression: `datetime` must be in the eval scope.
+
+        Previously the sandbox scope was only {db, ObjectId}, so a query using
+        `datetime.datetime(...)` failed with `name 'datetime' is not defined`.
+        """
+        # Setup
+        mock_mongo_client.return_value = mock_client
+        db = mock_client["test_db"]
+        collection = db["test_collection"]
+        collection.insert_many(sample_documents)
+
+        # Execute — filter created_at on or after Jan 2 (matches Jane only)
+        query = (
+            'db["test_collection"].find('
+            '{"created_at": {"$gte": datetime.datetime(2023, 1, 2, '
+            "tzinfo=datetime.timezone.utc)}})"
+        )
+        result = execute_mongo_query("mongodb://localhost", "test_db", query)
+
+        # Assert
+        assert "error" not in result
+        assert len(result) == 1
+        assert result[0]["name"] == "Jane Smith"
+
+    @patch("services.mongo_service.pymongo.MongoClient")
+    def test_execute_mongo_query_with_isodate_shim(
+        self, mock_mongo_client, mock_client, sample_documents
+    ):
+        """Regression: the mongosh-style `ISODate("...")` shim must resolve.
+
+        The LLM instinctively reaches for `ISODate(...)`; the shim turns it into
+        a timezone-aware datetime so the query does not blow up.
+        """
+        # Setup
+        mock_mongo_client.return_value = mock_client
+        db = mock_client["test_db"]
+        collection = db["test_collection"]
+        collection.insert_many(sample_documents)
+
+        # Execute
+        query = (
+            'db["test_collection"].find('
+            '{"created_at": {"$gte": ISODate("2023-01-02T00:00:00Z")}})'
+        )
+        result = execute_mongo_query("mongodb://localhost", "test_db", query)
+
+        # Assert
+        assert "error" not in result
+        assert len(result) == 1
+        assert result[0]["name"] == "Jane Smith"
+
+    @patch("services.mongo_service.pymongo.MongoClient")
     def test_execute_mongo_query_invalid_query(self, mock_mongo_client, mock_client):
         """Test execute_mongo_query with invalid query syntax."""
         # Setup


### PR DESCRIPTION
## Problem

The ReAct query generator could not run **any** query that filtered on dates. Real failure from a production log: a multi-step request (year filter + `$lookup` + filters + projection) was decomposed *correctly on the first try* but failed purely on the execution environment, then burned all 3 iterations going in circles.

Root cause was twofold:
1. The sandbox scope passed to `eval()` in `mongo_service` only exposed `db` and `ObjectId`, so `datetime.datetime(...)` raised `name 'datetime' is not defined`.
2. When the agent "fixed" it by prepending `import datetime`, `eval()` rejected it (`invalid syntax`) — it only accepts a single expression.

The evaluator then **misdiagnosed both failures** and repeatedly recommended mongosh `ISODate(...)` syntax (also invalid under PyMongo `eval`), sending the agent in circles until it hit max iterations.

## Changes

- **`mongo_service.py`** — inject `datetime` and an `ISODate(...)` shim into the eval scope; document the single-expression constraint.
- **`react_agent_service.py` GENERATE_PROMPT** — state the executor is PyMongo via Python `eval()`: use `datetime.datetime(...)`, no `import` statements, not mongosh.
- **`react_agent_service.py` EVALUATE_PROMPT** — stop critiquing valid datetime objects and stop recommending `ISODate`/mongosh dead ends.
- **Tests** — regression coverage for `datetime`-in-scope and the `ISODate` shim.

## Verification

```
PYTHONPATH=. python3.12 -m pytest tests/test_mongo_operations.py
31 passed
```

Also confirmed directly: the original failing query now returns results on the first attempt; `import datetime` is still (correctly) rejected. black clean, no new flake8 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)