### PR TITLE
feat(query-gen): clarification gate for vague requests

### DIFF
--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -42,6 +42,9 @@ class QueryPrompt(BaseModel):
         default=3, ge=1, le=10
     )  # Server-enforced agent iteration cap
     model: str = "gemini-2.5-flash"
+    enable_clarification: bool = (
+        True  # Triage gate: ask for detail when the request is too vague
+    )
 
 
 class GeneratedCode(BaseModel):

--- a/backend/routes/query.py
+++ b/backend/routes/query.py
@@ -136,6 +136,7 @@ def nl2query(
         max_iterations=prompt.max_iterations,
         model=prompt.model,
         relationship_context=relationship_context,
+        enable_clarification=prompt.enable_clarification,
     )
 
 

--- a/backend/services/react_agent_service.py
+++ b/backend/services/react_agent_service.py
@@ -68,6 +68,13 @@ class AgentState(TypedDict):
     iterations: int
     max_iterations: int
 
+    # Ambiguity gate: when the request is too vague to answer correctly, the
+    # triage node sets needs_clarification and populates clarifying_questions
+    # instead of generating a (likely wrong) query.
+    enable_clarification: bool
+    needs_clarification: bool
+    clarifying_questions: list[str]
+
 
 # Define LLM clients and prompts
 client = genai.Client()
@@ -186,6 +193,104 @@ Respond in JSON format:
     "critique": "If invalid, explain what went wrong and how to fix it. If valid, briefly explain why."
 }}
 """
+
+TRIAGE_PROMPT = """
+You are a triage assistant for a natural-language-to-MongoDB query generator.
+Your ONLY job is to decide whether the user's request can be turned into a
+correct query right now, or whether a concrete, blocking detail is missing.
+
+User Request: {user_input}
+Database: {database}
+Collections: {collections}
+Schema summary: {schema_context}
+Inferred Relationships: {relationship_context}
+Clarification already provided by the user (if any): {intermediate_context}
+
+DEFAULT TO PROCEEDING. A query generator follows this step; asking unnecessary
+questions is far worse than making a reasonable assumption. Only request
+clarification when you genuinely CANNOT write a correct query without an answer.
+
+Ask for clarification ONLY when one of these concrete, blocking gaps exists:
+- The request references a field or collection that does NOT appear in the
+  schema summary and has no reasonable synonym there.
+- A filter depends on a value with no definable meaning from the schema
+  (e.g. "recent", "active", "important", "top") where no field or threshold
+  makes the intent unambiguous.
+- A time window is implied but the start/end is genuinely undefined and cannot
+  be inferred (e.g. "lately" with no date field to anchor it).
+- The request is so underspecified that multiple fundamentally different
+  queries would all be plausible answers.
+
+Do NOT ask for clarification when:
+- The request is merely long or multi-step but each step is mappable.
+- You could pick a sensible default (e.g. a $limit, a sort order, which date
+  field to use when only one exists).
+- More detail would merely be "nice to have".
+
+If clarification was already provided above, incorporate it and PROCEED unless a
+brand-new blocking gap remains.
+
+Respond in JSON format:
+{{
+    "needs_clarification": true/false,
+    "questions": ["A specific question", "Another specific question"]
+}}
+If needs_clarification is false, "questions" MUST be an empty list.
+Ask at most 3 questions, each targeting a single blocking gap.
+"""
+
+
+def triage_node(state: AgentState):
+    logger.info("--- TRIAGE NODE ---")
+
+    # Gate is opt-out: when disabled, always proceed to generation.
+    if not state.get("enable_clarification", True):
+        logger.info("Clarification gate disabled; proceeding to generation.")
+        return {"needs_clarification": False, "clarifying_questions": []}
+
+    prompt = TRIAGE_PROMPT.format(
+        user_input=state["user_input"],
+        database=state["database"],
+        collections=", ".join(state["collections"]),
+        schema_context=state["schema_context"],
+        relationship_context=state.get("relationship_context")
+        or "None (single collection or no inferred relationships).",
+        intermediate_context=state.get("intermediate_context") or "None.",
+    )
+
+    try:
+        response = client.models.generate_content(
+            model=state.get("model", "gemini-2.5-flash"),
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                response_mime_type="application/json",
+                thinking_config=thinking_config_for(
+                    state.get("model", "gemini-2.5-flash")
+                ),
+            ),
+        )
+
+        if hasattr(response, "parsed") and response.parsed:
+            data = response.parsed
+        else:
+            data = json.loads(response.text)
+
+        needs_clarification = bool(data.get("needs_clarification", False))
+        questions = data.get("questions", []) or []
+        # Defensive: a true verdict with no questions is useless — proceed instead.
+        if needs_clarification and not questions:
+            needs_clarification = False
+    except Exception as e:
+        # Never let triage block generation: fail open and proceed.
+        logger.warning("Triage failed; proceeding to generation: %s", e)
+        needs_clarification = False
+        questions = []
+
+    logger.info(f"Triage result - needs_clarification: {needs_clarification}")
+    return {
+        "needs_clarification": needs_clarification,
+        "clarifying_questions": questions if needs_clarification else [],
+    }
 
 
 def generate_query_node(state: AgentState):
@@ -335,15 +440,25 @@ def should_continue(state: AgentState):
     return "generate_query_node"
 
 
+def after_triage(state: AgentState):
+    # If the request is too vague, stop and return clarifying questions instead
+    # of generating a query.
+    if state.get("needs_clarification"):
+        return END
+    return "generate_query_node"
+
+
 # Build the graph
 workflow = StateGraph(AgentState)
 
+workflow.add_node("triage_node", triage_node)
 workflow.add_node("generate_query_node", generate_query_node)
 workflow.add_node("execute_test_node", execute_test_node)
 workflow.add_node("evaluate_node", evaluate_node)
 
-workflow.set_entry_point("generate_query_node")
+workflow.set_entry_point("triage_node")
 
+workflow.add_conditional_edges("triage_node", after_triage)
 workflow.add_edge("generate_query_node", "execute_test_node")
 workflow.add_edge("execute_test_node", "evaluate_node")
 workflow.add_conditional_edges("evaluate_node", should_continue)
@@ -361,6 +476,7 @@ def run_query_generator(
     max_iterations: int = 3,
     model: str = "gemini-2.5-flash",
     relationship_context: str = "",
+    enable_clarification: bool = True,
 ):
     logger.info(f"Starting ReAct Agent workflow for input: '{user_input}'")
     initial_state = {
@@ -374,6 +490,7 @@ def run_query_generator(
         "model": model,
         "iterations": 0,
         "max_iterations": max_iterations,
+        "enable_clarification": enable_clarification,
     }
 
     # Run the graph
@@ -385,4 +502,6 @@ def run_query_generator(
         "query_result": final_state.get("query_result", None),
         "explanation": final_state.get("evaluation", ""),
         "is_valid": final_state.get("is_valid", False),
+        "needs_clarification": final_state.get("needs_clarification", False),
+        "clarifying_questions": final_state.get("clarifying_questions", []),
     }

--- a/backend/services/react_agent_service.py
+++ b/backend/services/react_agent_service.py
@@ -232,6 +232,10 @@ Do NOT ask for clarification when:
 - The request is merely long or multi-step but each step is mappable.
 - You could pick a sensible default (e.g. a $limit, a sort order, which date
   field to use when only one exists).
+- A vague relative-time term ("recent", "recently", "lately", "latest") is
+  used and a clear date field exists to anchor it — assume a sensible default
+  window (e.g. the last 30 days, or sort descending for "latest") and PROCEED
+  rather than asking. Only ask about time when NO date field can anchor it.
 - More detail would merely be "nice to have".
 
 If clarification was already provided above, incorporate it and PROCEED unless a

--- a/backend/tests/test_react_agent.py
+++ b/backend/tests/test_react_agent.py
@@ -1,0 +1,109 @@
+"""Unit tests for the ReAct agent's clarification (triage) gate.
+
+These tests exercise triage_node / after_triage in isolation by mocking the
+Gemini client, so no real API calls are made (GEMINI_API_KEY is mocked in CI).
+"""
+
+import json
+from unittest.mock import Mock, patch
+
+from langgraph.graph import END
+
+from services.react_agent_service import after_triage, triage_node
+
+
+def _mock_response(payload: dict) -> Mock:
+    """Build a fake Gemini response whose .text is JSON and .parsed is falsy.
+
+    triage_node prefers response.parsed when truthy, otherwise json.loads(text).
+    We force the json.loads path for deterministic, dependency-free tests.
+    """
+    resp = Mock()
+    resp.parsed = None
+    resp.text = json.dumps(payload)
+    return resp
+
+
+BASE_STATE = {
+    "user_input": "show me stuff",
+    "database": "appdb",
+    "collections": ["room", "device"],
+    "schema_context": "Collection: room ...",
+    "relationship_context": "",
+    "intermediate_context": None,
+    "enable_clarification": True,
+    "model": "gemini-2.5-flash",
+}
+
+
+@patch("services.react_agent_service.client")
+def test_triage_flags_vague_request(mock_client):
+    """A vague request yields needs_clarification with concrete questions."""
+    mock_client.models.generate_content.return_value = _mock_response(
+        {
+            "needs_clarification": True,
+            "questions": ["Which collection do you mean by 'stuff'?"],
+        }
+    )
+
+    result = triage_node({**BASE_STATE, "user_input": "show me stuff"})
+
+    assert result["needs_clarification"] is True
+    assert result["clarifying_questions"] == [
+        "Which collection do you mean by 'stuff'?"
+    ]
+
+
+@patch("services.react_agent_service.client")
+def test_triage_passes_clear_request(mock_client):
+    """A clear request proceeds with no questions."""
+    mock_client.models.generate_content.return_value = _mock_response(
+        {"needs_clarification": False, "questions": []}
+    )
+
+    result = triage_node({**BASE_STATE, "user_input": "find all rooms created in 2025"})
+
+    assert result["needs_clarification"] is False
+    assert result["clarifying_questions"] == []
+
+
+@patch("services.react_agent_service.client")
+def test_triage_disabled_skips_llm(mock_client):
+    """When the gate is disabled, no LLM call is made and we proceed."""
+    result = triage_node({**BASE_STATE, "enable_clarification": False})
+
+    assert result["needs_clarification"] is False
+    assert result["clarifying_questions"] == []
+    mock_client.models.generate_content.assert_not_called()
+
+
+@patch("services.react_agent_service.client")
+def test_triage_true_without_questions_proceeds(mock_client):
+    """A 'needs clarification' verdict with no questions is useless → proceed."""
+    mock_client.models.generate_content.return_value = _mock_response(
+        {"needs_clarification": True, "questions": []}
+    )
+
+    result = triage_node(BASE_STATE)
+
+    assert result["needs_clarification"] is False
+    assert result["clarifying_questions"] == []
+
+
+@patch("services.react_agent_service.client")
+def test_triage_fails_open_on_error(mock_client):
+    """Triage must never block generation: an exception fails open."""
+    mock_client.models.generate_content.side_effect = RuntimeError("API down")
+
+    result = triage_node(BASE_STATE)
+
+    assert result["needs_clarification"] is False
+    assert result["clarifying_questions"] == []
+
+
+def test_after_triage_routes_to_end_when_clarifying():
+    assert after_triage({"needs_clarification": True}) == END
+
+
+def test_after_triage_routes_to_generate_when_clear():
+    assert after_triage({"needs_clarification": False}) == "generate_query_node"

--- a/frontend/__tests__/components/ClarificationCard.test.tsx
+++ b/frontend/__tests__/components/ClarificationCard.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+import ClarificationCard from '../../components/ClarificationCard';
+
+describe('ClarificationCard', () => {
+  const questions = [
+    'What defines an "active" record?',
+    'What time frame does "recent" refer to?',
+  ];
+
+  it('renders all clarifying questions', () => {
+    render(<ClarificationCard questions={questions} onSubmit={vi.fn()} />);
+    questions.forEach((q) => {
+      expect(screen.getByText(q)).toBeInTheDocument();
+    });
+  });
+
+  it('disables the submit button until the user types an answer', () => {
+    render(<ClarificationCard questions={questions} onSubmit={vi.fn()} />);
+    const button = screen.getByRole('button', { name: /regenerate with details/i });
+    expect(button).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/additional details/i), {
+      target: { value: 'status === "enabled"; last 30 days' },
+    });
+    expect(button).toBeEnabled();
+  });
+
+  it('calls onSubmit with the trimmed answers on click', () => {
+    const onSubmit = vi.fn();
+    render(<ClarificationCard questions={questions} onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/additional details/i), {
+      target: { value: '  last 7 days  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /regenerate with details/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith('last 7 days');
+  });
+
+  it('submits on Cmd/Ctrl+Enter', () => {
+    const onSubmit = vi.fn();
+    render(<ClarificationCard questions={questions} onSubmit={onSubmit} />);
+
+    const textarea = screen.getByLabelText(/additional details/i);
+    fireEvent.change(textarea, { target: { value: 'enabled devices' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true });
+
+    expect(onSubmit).toHaveBeenCalledWith('enabled devices');
+  });
+
+  it('shows a loading state and blocks submission while regenerating', () => {
+    const onSubmit = vi.fn();
+    render(<ClarificationCard questions={questions} onSubmit={onSubmit} isLoading />);
+
+    const button = screen.getByRole('button', { name: /regenerating/i });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/components/ClarificationCard.tsx
+++ b/frontend/components/ClarificationCard.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+
+interface ClarificationCardProps {
+  /** Questions the agent needs answered before it can write a correct query. */
+  questions: string[];
+  /** Called with the user's free-text answers to re-run generation. */
+  onSubmit: (answers: string) => void;
+  /** True while the follow-up generation is in flight. */
+  isLoading?: boolean;
+}
+
+/**
+ * Rendered when the query generator's triage gate decides the request is too
+ * vague to answer correctly. Instead of a (likely wrong) query, it shows the
+ * blocking questions and lets the user add detail, then regenerates.
+ */
+const ClarificationCard: React.FC<ClarificationCardProps> = ({ questions, onSubmit, isLoading = false }) => {
+  const [answers, setAnswers] = useState('');
+
+  const canSubmit = answers.trim().length > 0 && !isLoading;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    onSubmit(answers.trim());
+  };
+
+  return (
+    <div
+      className="qa-card"
+      style={{ display: 'flex', flexDirection: 'column', gap: 16, padding: 20 }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{ color: 'var(--status-warn)' }}
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+        <span style={{ fontFamily: 'var(--font-display)', fontSize: 15, fontWeight: 600, color: 'var(--fg)' }}>
+          A bit more detail needed
+        </span>
+      </div>
+
+      <p style={{ margin: 0, fontFamily: 'var(--font-body)', fontSize: 13, color: 'var(--muted)' }}>
+        Your request is a little ambiguous. Answer the question{questions.length > 1 ? 's' : ''} below and
+        I&apos;ll generate a more accurate query.
+      </p>
+
+      <ul style={{ margin: 0, paddingLeft: 20, display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {questions.map((q, i) => (
+          <li
+            key={i}
+            style={{ fontFamily: 'var(--font-body)', fontSize: 14, color: 'var(--fg)', lineHeight: 1.5 }}
+          >
+            {q}
+          </li>
+        ))}
+      </ul>
+
+      <textarea
+        value={answers}
+        onChange={(e) => setAnswers(e.target.value)}
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') handleSubmit();
+        }}
+        disabled={isLoading}
+        rows={4}
+        placeholder="Add the missing details here…"
+        aria-label="Additional details"
+        style={{
+          width: '100%',
+          resize: 'vertical',
+          padding: '10px 12px',
+          fontFamily: 'var(--font-body)',
+          fontSize: 14,
+          color: 'var(--fg)',
+          background: 'var(--bg)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-md)',
+          boxSizing: 'border-box',
+        }}
+      />
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <button
+          type="button"
+          className="qa-btn primary"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+        >
+          {isLoading ? 'Regenerating…' : 'Regenerate with details'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ClarificationCard;

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -12,6 +12,7 @@ import { getAuthErrorMessage, isAuthenticationExpiredError } from '../utils/auth
 import QueryDisplay from '../components/QueryDisplay';
 import { useRoles } from '../hooks/useRoles';
 import QueryResult from '../components/QueryResult';
+import ClarificationCard from '../components/ClarificationCard';
 import Loader from '../components/Loader';
 import Tutorial from '../components/Tutorial';
 import JsonDisplay from '../components/JsonDisplay';
@@ -884,6 +885,13 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
         selectedModel
       );
       setQueryResult(result);
+
+      // The agent judged the request too vague — surface its clarifying
+      // questions and stop here, before any history/code/result handling.
+      if (result.needs_clarification) {
+        return;
+      }
+
       setIntermediateContext(null); // Clear context after use
 
       // Add to history
@@ -933,6 +941,14 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     const primaryContext = selectedCollections.length > 0 ? collectionDetailsMap[selectedCollections[0]] : undefined;
     handleGenerateQuery(userInput, primaryContext);
   }, [userInput, intermediateContext, selectedCollections, collectionDetailsMap, handleGenerateQuery]);
+
+  // Re-run generation with the user's clarification answers appended, so the
+  // triage gate can proceed instead of asking again.
+  const handleSubmitClarification = useCallback((answers: string) => {
+    const primaryContext = selectedCollections.length > 0 ? collectionDetailsMap[selectedCollections[0]] : undefined;
+    const combinedPrompt = `${userInput}\n\nAdditional details:\n${answers}`;
+    handleGenerateQuery(combinedPrompt, primaryContext);
+  }, [userInput, selectedCollections, collectionDetailsMap, handleGenerateQuery]);
 
   const executeCode = useCallback(async (code: string) => {
     if (!code.trim() || !connectedDbInfo || !connectedResource) {
@@ -2040,7 +2056,13 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
               {/* Real results */}
               {(!isLoading && !error && !isDemoModeForResultsStep && !isDemoModeForDebugStep && !isDemoModeForContextActiveStep && !isDemoModeForRunStep && !isDemoModeForSaveStep) && (
                 <div className="space-y-8">
-                  {editableCode ? (
+                  {_queryResult?.needs_clarification ? (
+                    <ClarificationCard
+                      questions={_queryResult.clarifying_questions ?? []}
+                      onSubmit={handleSubmitClarification}
+                      isLoading={isLoading}
+                    />
+                  ) : editableCode ? (
                     <>
                       <QueryDisplay
                         code={editableCode}

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -2578,7 +2578,13 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
 
           {/* Real results */}
           {(!isLoading && !error && !isDemoModeForResultsStep && !isDemoModeForDebugStep && !isDemoModeForContextActiveStep && !isDemoModeForRunStep && !isDemoModeForSaveStep) && (
-            editableCode ? (
+            _queryResult?.needs_clarification ? (
+              <ClarificationCard
+                questions={_queryResult.clarifying_questions ?? []}
+                onSubmit={handleSubmitClarification}
+                isLoading={isLoading}
+              />
+            ) : editableCode ? (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
                 <QueryDisplay code={editableCode} onCodeChange={setEditableCode} onRunQuery={handleRunQuery} onSaveQuery={handleOpenSaveDialog} isExecuting={isExecuting} historyCount={codeHistory.length} historyIndex={historyIndex} onNavigateHistory={handleNavigateHistory} isTransferable={!!handover} onOpenInExplorer={handleOpenInExplorer} canWrite={can('data:write')} />
                 <QueryResult isExecuting={isExecuting} executionError={executionError} executionResult={executionResult} onDebug={handleDebugQuery} isDebugging={isDebugging} debuggingResult={debuggingResult} debugError={debugError} sourceCollection={querySourceCollection} onSetIntermediateContext={handleSetIntermediateContext} intermediateContext={intermediateContext} onAnalyze={handleAnalyzeQuery} isAnalyzing={isAnalyzing} analysisResult={analysisResult} analysisError={analysisError} onEvaluateWrite={handleEvaluateWrite} isEvaluatingWrite={isEvaluatingWrite} writeEvaluationResult={writeEvaluationResult} writeEvaluationError={writeEvaluationError} />

--- a/frontend/services/geminiService.ts
+++ b/frontend/services/geminiService.ts
@@ -1,6 +1,6 @@
 import { QueryResultData, DbInfo, CollectionInfo, DebuggingResult, AnalysisResult, SchemaRelationshipsResponse } from '../types';
 import { USE_MSAL_AUTH, API_BASE_URL } from '../app.config';
-import { mockDelay, mockFindUsersQuery, mockUpdateProductsQuery, mockDefaultQuery, mockDebuggingResult, mockAnalysisResult } from './mockData';
+import { mockDelay, mockFindUsersQuery, mockUpdateProductsQuery, mockDefaultQuery, mockClarificationQuery, mockDebuggingResult, mockAnalysisResult } from './mockData';
 import { msalInstance, loginRequest } from '../authConfig';
 import { getAuthErrorMessage } from '../utils/authErrorHandler';
 import { getAuthenticatedToken } from './dbService';
@@ -47,6 +47,14 @@ export const generateMongoQuery = async (
         await mockDelay(1500); // Simulate AI thinking time
 
         const lowerInput = userInput.toLowerCase();
+        // Simulate the clarification gate for vague inputs (unless the user has
+        // already supplied details, which we append under "additional details").
+        if (
+            (lowerInput.includes('stuff') || lowerInput.includes('things') || lowerInput.includes('important')) &&
+            !lowerInput.includes('additional details')
+        ) {
+            return Promise.resolve(mockClarificationQuery);
+        }
         if (lowerInput.includes('user')) {
             return Promise.resolve(mockFindUsersQuery);
         }

--- a/frontend/services/mockData.ts
+++ b/frontend/services/mockData.ts
@@ -131,6 +131,15 @@ export const mockDefaultQuery: QueryResultData = {
     generated_code: 'db[\'your_collection\'].find({})',
 };
 
+export const mockClarificationQuery: QueryResultData = {
+    generated_code: '',
+    needs_clarification: true,
+    clarifying_questions: [
+        'What defines an "active" record — is it based on a status field, and which value indicates active?',
+        'What time frame does "recent" refer to (e.g. the last 7 or 30 days)?',
+    ],
+};
+
 // --- Mock AI Debugging ---
 export const mockDebuggingResult: DebuggingResult = {
     suggestion: `It looks like there's a typo in your query.\n\nThe error message "pymongo.errors.OperationFailure: Message: {\\"Errors\\":[\\"Unknown operator: '$sor'\\"]}" suggests that the operator \`$sor\` is not recognized.\n\nThe correct operator for sorting in MongoDB is \`$sort\`.\n\n**Suggestion:**\nChange \`{ '$sor': { 'name': 1 } }\` to \`{ '$sort': { 'name': 1 } }\` in your query code.`

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -22,6 +22,10 @@ export interface QueryResultData {
     query_result?: any;
     explanation?: string;
     is_valid?: boolean;
+    // Ambiguity gate: when the request is too vague to answer correctly, the
+    // backend returns no query and instead asks for these details.
+    needs_clarification?: boolean;
+    clarifying_questions?: string[];
 }
 
 /**


### PR DESCRIPTION
## Why

The query generator's ReAct loop catches queries that **error out**, but is blind to queries that **run fine yet answer the wrong question**. A vague request → a plausible, runnable query → confidently wrong results the user trusts. This adds an ambiguity gate that asks for the missing detail instead of guessing.

## How

A new `triage_node` runs at the graph entry. Before generating, it judges whether a concrete, *blocking* detail is missing — a field/collection absent from the schema, an undefinable filter value ("important", "active"), an unanchorable time window, or genuine multi-way ambiguity. If blocked, it returns clarifying questions; otherwise the existing `generate → test → evaluate` loop runs unchanged.

Design guardrails (over-asking is the real risk):
- **Conservative by construction** — the prompt defaults to proceeding; only asks on concrete blocking gaps.
- **Vague time words proceed** — "recent"/"latest" with a clear date field assume a default window rather than asking (caught during live calibration).
- **Fails open** — any triage error proceeds to generation.
- **Opt-out** via `QueryPrompt.enable_clarification` (default on) for easy A/B or kill-switch.

Frontend: when the backend returns `needs_clarification`, the generator shows a `ClarificationCard` (questions + answer textarea, ⌘↵ to submit) instead of a query, then re-runs generation with the answers appended so triage can proceed. Wired into both the embedded and standalone layouts.

## Calibration

Verified against 17 live prompts. Representative:

| Prompt | Verdict |
|---|---|
| show me the important rooms | ASK |
| find recent activity for the active devices | ASK (on "active") |
| get me the engagement score per room | ASK (no such field) |
| rooms modified recently | PROCEED (default window) |
| how many devices are there | PROCEED |
| rooms from 2025 with their device name and company | PROCEED |

## Tests

- Backend: triage flags vague vs. clear, disabled path skips the LLM, empty-questions degrades to proceed, errors fail open, routing. **49 passed.**
- Frontend: `ClarificationCard` rendering, enable/disable, submit (click + keyboard), loading. **76 passed.**

## Note for reviewer

The render-layout bug (embedded vs. standalone) is fixed, but please confirm the card renders on a running stack — unit tests can't catch which of the two page layouts is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)