### PR TITLE
iac: static egress IP + Cloud NAT for Cloud Run

### DIFF
--- a/frontend/components/AnalysisResultDisplay.tsx
+++ b/frontend/components/AnalysisResultDisplay.tsx
@@ -25,6 +25,7 @@ ChartJS.register(
 
 interface AnalysisResultDisplayProps {
   result: AnalysisResult;
+  onFollowup?: (prompt: string) => void;
 }
 
 const SparkleIcon = () => (
@@ -44,7 +45,7 @@ const CHART_TYPE_LABELS: Record<string, string> = {
   bubble: 'Bubble chart',
 };
 
-const AnalysisResultDisplay: React.FC<AnalysisResultDisplayProps> = ({ result }) => {
+const AnalysisResultDisplay: React.FC<AnalysisResultDisplayProps> = ({ result, onFollowup }) => {
   const { theme } = useTheme();
 
   const themedChartOptions = React.useMemo(() => {
@@ -152,6 +153,24 @@ const AnalysisResultDisplay: React.FC<AnalysisResultDisplayProps> = ({ result })
           }}>
             {result.insight}
           </p>
+          {result.followups && result.followups.length > 0 && onFollowup && (
+            <div style={{ marginTop: 'auto', display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <div style={{ fontSize: 10.5, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)' }}>
+                Follow-ups
+              </div>
+              {result.followups.map((f, i) => (
+                <button
+                  key={i}
+                  onClick={() => onFollowup(f)}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', padding: '6px 9px', borderRadius: 7, border: '1px solid var(--border)', background: 'var(--panel)', font: 'inherit', fontSize: 12, color: 'var(--fg)', cursor: 'pointer' }}
+                  onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--soft)'; }}
+                  onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--panel)'; }}
+                >
+                  <span style={{ color: 'var(--accent)', marginRight: 6 }}>→</span>{f}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
 
         {/* Chart panel */}

--- a/frontend/components/QueryResult.tsx
+++ b/frontend/components/QueryResult.tsx
@@ -37,6 +37,7 @@ interface QueryResultProps {
   isAnalyzing: boolean;
   analysisResult: AnalysisResult | null;
   analysisError: string | null;
+  onFollowup?: (prompt: string) => void;
   onEvaluateWrite?: () => void;
   isEvaluatingWrite?: boolean;
   writeEvaluationResult?: { evaluation: string } | null;
@@ -100,7 +101,7 @@ const QueryResult: React.FC<QueryResultProps> = ({
   isExecuting, executionError, executionResult,
   onDebug, isDebugging, debuggingResult, debugError,
   sourceCollection, onSetIntermediateContext, intermediateContext,
-  onAnalyze, isAnalyzing, analysisResult, analysisError,
+  onAnalyze, isAnalyzing, analysisResult, analysisError, onFollowup,
   onEvaluateWrite, isEvaluatingWrite, writeEvaluationResult, writeEvaluationError,
   isTutorialActive, tutorialStepIndex,
 }) => {
@@ -419,7 +420,7 @@ const QueryResult: React.FC<QueryResultProps> = ({
         {analysisError && (
           <div style={{ fontSize: 12, color: '#c94250', padding: '8px 0' }}>Analysis error: {analysisError}</div>
         )}
-        {analysisResult && <AnalysisResultDisplay result={analysisResult} />}
+        {analysisResult && <AnalysisResultDisplay result={analysisResult} onFollowup={onFollowup} />}
 
         {graphDrawer}
 

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -98,6 +98,7 @@ export interface AnalysisResult {
     chartType: ChartJSType;
     chartData: ChartJSData;
     chartOptions?: ChartJSOptions;
+    followups?: string[];
 }
 
 /**

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -20,3 +20,27 @@ resource "google_vpc_access_connector" "querypal" {
 
   depends_on = [google_project_service.vpcaccess]
 }
+
+# Static egress IP so Cloud Run's public traffic (Azure Cosmos/Postgres public
+# endpoints behind IP firewalls) leaves from ONE stable address to allowlist.
+# Requires the Cloud Run service to use vpc-egress=all-traffic (set via gcloud —
+# the services are deployed outside Terraform).
+resource "google_compute_address" "querypal_egress" {
+  name   = "querypal-egress-ip"
+  region = var.region
+}
+
+resource "google_compute_router" "querypal" {
+  name    = "querypal-router"
+  region  = var.region
+  network = var.vpc_network
+}
+
+resource "google_compute_router_nat" "querypal" {
+  name                               = "querypal-nat"
+  router                             = google_compute_router.querypal.name
+  region                             = var.region
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  nat_ips                            = [google_compute_address.querypal_egress.self_link]
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}


### PR DESCRIPTION
## What
Adds a reserved static egress IP + Cloud Router + Cloud NAT (`terraform/network.tf`) so all Cloud Run egress leaves from **one stable IP**.

## Why
Azure locked down Cosmos (dev/staging) behind private endpoints; an empty IP-firewall now means *deny* instead of *allow-all*. Cloud Run's default egress uses Google's ephemeral IP pool, so there was no stable address to allowlist. This pins egress to a single NAT IP.

## Applied
- `terraform apply`: 3 add, 0 change, 0 destroy (state is local).
- `gcloud run services update querypal-backend --vpc-egress all-traffic` (services deployed outside Terraform).

## Follow-up (manual, in Azure portal)
Allowlist on:
- dev Cosmos `v-patients-saas-development2`
- staging Cosmos `vpatient-staging`
- prod Postgres `database-patient-server` (if QueryPal queries it)

## Notes
- Frontend WIP in the working tree is intentionally excluded.
- TF state is local; enable the GCS backend before a teammate applies.