### PR TITLE
Release: PostgreSQL data explorer, audit & access management

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -80,7 +80,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["*"],
 )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ from routes import (
     audit,
     argus,
     admin,
+    postgres,
 )
 
 
@@ -101,6 +102,7 @@ app.include_router(data_documents.router, prefix="/data", tags=["Data Documents"
 app.include_router(audit.router, prefix="/audit", tags=["Audit"])
 app.include_router(argus.router, prefix="/argus", tags=["Argus"])
 app.include_router(admin.router, prefix="/admin", tags=["Admin"])
+app.include_router(postgres.router, prefix="/postgres", tags=["PostgreSQL"])
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/models/analyze.py
+++ b/backend/models/analyze.py
@@ -12,3 +12,4 @@ class AnalyzeResponse(BaseModel):
     chartType: str
     chartData: Dict[str, Any]
     chartOptions: Dict[str, Any]
+    followups: List[str] = []

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -64,6 +64,15 @@ class DebugSuggestionResponse(BaseModel):
     suggestion: str
 
 
+class ExplainQueryRequest(BaseModel):
+    query: str
+    model: str = "gemini-2.5-flash"
+
+
+class ExplainQueryResponse(BaseModel):
+    explanation: str
+
+
 class SchemaRelationshipsRequest(BaseModel):
     account_id: str
     database_name: str

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -174,3 +174,39 @@ class PgRevokeRequest(BaseModel):
 
 class PgAccessListRequest(BaseModel):
     server_id: str
+
+
+class PgRowsRequest(BaseModel):
+    server_id: str
+    database: str
+    schema_name: str
+    table: str
+    filters: list[dict] = Field(default_factory=list)
+    sort: dict | None = None
+    limit: int = Field(default=50, ge=1, le=500)
+    offset: int = Field(default=0, ge=0)
+
+
+class PgRowInsertRequest(BaseModel):
+    server_id: str
+    database: str
+    schema_name: str
+    table: str
+    values: dict
+
+
+class PgRowUpdateRequest(BaseModel):
+    server_id: str
+    database: str
+    schema_name: str
+    table: str
+    pk: dict
+    values: dict
+
+
+class PgRowDeleteRequest(BaseModel):
+    server_id: str
+    database: str
+    schema_name: str
+    table: str
+    pk: dict

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -113,3 +113,34 @@ class UserWithRoles(BaseModel):
 
 class AssignRoleRequest(BaseModel):
     role: Literal["Admin", "Analyst", "Viewer"]
+
+
+class PgDatabasesRequest(BaseModel):
+    server_id: str
+
+
+class PgSchemaRequest(BaseModel):
+    server_id: str
+    database: str
+
+
+class PgTableInfoRequest(BaseModel):
+    server_id: str
+    database: str
+    schema_name: str
+    table: str
+
+
+class PgNl2SqlRequest(BaseModel):
+    server_id: str
+    database: str
+    schema_context: str
+    user_input: str
+    model: str = "gemini-2.5-flash"
+    max_iterations: int = Field(default=3, ge=1, le=10)
+
+
+class PgExecuteRequest(BaseModel):
+    server_id: str
+    database: str
+    sql: str

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -146,6 +146,13 @@ class PgExecuteRequest(BaseModel):
     sql: str
 
 
+class PgAnalyzeRequest(BaseModel):
+    columns: list[str]
+    rows: list[list]
+    user_input: str = ""
+    model: str = "gemini-2.5-flash"
+
+
 class PgGrantRequest(BaseModel):
     server_id: str
     user_email: str

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -144,3 +144,17 @@ class PgExecuteRequest(BaseModel):
     server_id: str
     database: str
     sql: str
+
+
+class PgGrantRequest(BaseModel):
+    server_id: str
+    user_email: str
+
+
+class PgRevokeRequest(BaseModel):
+    server_id: str
+    user_email: str
+
+
+class PgAccessListRequest(BaseModel):
+    server_id: str

--- a/backend/models/user_queries.py
+++ b/backend/models/user_queries.py
@@ -7,6 +7,7 @@ class SavedQuery(BaseModel):
     name: str
     prompt: str
     code: str
+    engine: str = "cosmos"  # "cosmos" | "pg"
     ownerEmail: str
     sharedWith: List[str]
     lastModifiedBy: str
@@ -17,12 +18,14 @@ class SavedQueryCreate(BaseModel):
     name: str
     prompt: str
     code: str
+    engine: str = "cosmos"
 
 
 class SavedQueryUpdate(BaseModel):
     name: str
     prompt: str
     code: str
+    engine: str = "cosmos"
     ownerEmail: str
     sharedWith: List[str]
     lastModifiedBy: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,7 @@ python-dotenv
 psycopg2-binary
 requests
 pymongo
+sqlparse
 msal
 PyJWT[crypto]
 langgraph

--- a/backend/routes/audit.py
+++ b/backend/routes/audit.py
@@ -28,7 +28,7 @@ class RecentActivityItem(BaseModel):
     database_name: str
     collection_name: str
     operation: str
-    document_id: str
+    document_id: Optional[str] = None  # inserts have no doc/row id
     user_email: str
     timestamp_utc: str
 

--- a/backend/routes/postgres.py
+++ b/backend/routes/postgres.py
@@ -1,0 +1,124 @@
+from fastapi import APIRouter, Body, Depends, Header, HTTPException
+
+from models.schemas import (
+    PgDatabasesRequest,
+    PgExecuteRequest,
+    PgNl2SqlRequest,
+    PgSchemaRequest,
+    PgTableInfoRequest,
+)
+from services.azure_auth import exchange_token_obo
+from services.azure_postgres_resources import (
+    get_schema_overview,
+    get_server_fqdn,
+    get_table_info,
+    list_databases,
+    list_postgres_servers,
+)
+from services.pg_connection_obo import get_pg_connection
+from services.pg_query_service import OSSRDBMS_SCOPE, execute_sql
+from services.pg_react_agent_service import run_sql_generator
+from services.rbac import Caller, require
+
+router = APIRouter()
+
+
+def _connect(authorization: str, server_id: str, database: str, caller: Caller):
+    """Resolve server FQDN and open an Entra-OBO PG connection. 404 on unknown
+    server id (do not leak existence of servers the caller can't enumerate)."""
+    user_token = authorization.replace("Bearer ", "")
+    arm_token = exchange_token_obo(user_token)
+    servers = list_postgres_servers(arm_token)
+    try:
+        fqdn = get_server_fqdn(server_id, servers)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="PostgreSQL server not found")
+    pg_token = exchange_token_obo(user_token, scope=OSSRDBMS_SCOPE)
+    try:
+        return get_pg_connection(fqdn, database, caller.email, pg_token)
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"PostgreSQL connection failed: {e}")
+
+
+@router.get("/servers")
+def servers(
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("query:read")),
+):
+    arm_token = exchange_token_obo(authorization.replace("Bearer ", ""))
+    return list_postgres_servers(arm_token)
+
+
+@router.post("/databases")
+def databases(
+    data: PgDatabasesRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("query:read")),
+):
+    conn = _connect(authorization, data.server_id, "postgres", caller)
+    try:
+        return list_databases(conn)
+    finally:
+        conn.close()
+
+
+@router.post("/schema")
+def schema(
+    data: PgSchemaRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("query:read")),
+):
+    conn = _connect(authorization, data.server_id, data.database, caller)
+    try:
+        return get_schema_overview(conn)
+    finally:
+        conn.close()
+
+
+@router.post("/table_info")
+def table_info(
+    data: PgTableInfoRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("query:read")),
+):
+    conn = _connect(authorization, data.server_id, data.database, caller)
+    try:
+        return get_table_info(conn, data.schema_name, data.table)
+    finally:
+        conn.close()
+
+
+@router.post("/nl2sql")
+def nl2sql(
+    data: PgNl2SqlRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("query:read")),
+):
+    conn = _connect(authorization, data.server_id, data.database, caller)
+    try:
+        return run_sql_generator(
+            user_input=data.user_input,
+            database=data.database,
+            schema_context=data.schema_context,
+            conn=conn,
+            max_iterations=data.max_iterations,
+            model=data.model,
+        )
+    finally:
+        conn.close()
+
+
+@router.post("/execute")
+def execute(
+    data: PgExecuteRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("query:read")),
+):
+    conn = _connect(authorization, data.server_id, data.database, caller)
+    try:
+        result = execute_sql(conn, data.sql)
+    finally:
+        conn.close()
+    if isinstance(result, dict) and "error" in result:
+        raise HTTPException(status_code=500, detail=f"SQL error: {result['error']}")
+    return result

--- a/backend/routes/postgres.py
+++ b/backend/routes/postgres.py
@@ -266,7 +266,9 @@ def update_row(
         user_email=caller.email, operation="update",
         database_name=data.server_id,
         collection_name=f"{data.schema_name}.{data.table}",
-        document_id=str(data.pk), after_data=_row_dict(result) or data.values,
+        document_id=str(data.pk),
+        before_data=result.get("before"),
+        after_data=_row_dict(result) or data.values,
     )
     return result
 

--- a/backend/routes/postgres.py
+++ b/backend/routes/postgres.py
@@ -8,6 +8,10 @@ from models.schemas import (
     PgGrantRequest,
     PgNl2SqlRequest,
     PgRevokeRequest,
+    PgRowDeleteRequest,
+    PgRowInsertRequest,
+    PgRowsRequest,
+    PgRowUpdateRequest,
     PgSchemaRequest,
     PgTableInfoRequest,
 )
@@ -27,8 +31,10 @@ from services.pg_admin_service import (
     list_access,
     revoke_access,
 )
+from services import pg_row_service
 from services.pg_connection_obo import get_pg_connection
 from services.pg_query_service import OSSRDBMS_SCOPE, execute_sql
+from services.pg_row_service import NoPrimaryKey, RowError
 from services.pg_react_agent_service import run_sql_generator
 from services.rbac import Caller, require
 
@@ -71,6 +77,17 @@ def _admin_connect(authorization: str, server_id: str):
         raise HTTPException(
             status_code=502, detail=f"PostgreSQL connection failed: {e}"
         )
+
+
+def _row_meta(conn, schema_name: str, table: str):
+    """Whitelist source: the target table's real columns + primary-key columns.
+    Raises 404 if the table is not visible (empty columns list from catalog)."""
+    info = get_table_info(conn, schema_name, table)
+    if not info["columns"]:
+        raise HTTPException(status_code=404, detail="Table not found")
+    allowed = {c["name"] for c in info["columns"]}
+    pk_cols = [c["name"] for c in info["columns"] if c.get("pk")]
+    return allowed, pk_cols
 
 
 @router.get("/servers")
@@ -171,6 +188,104 @@ def analyze(
         user_input=data.user_input,
         model=data.model,
     )
+
+
+@router.post("/rows")
+def rows(
+    data: PgRowsRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("query:read")),
+):
+    conn = _connect(authorization, data.server_id, data.database, caller)
+    try:
+        allowed, pk_cols = _row_meta(conn, data.schema_name, data.table)
+        return pg_row_service.browse(
+            conn, data.schema_name, data.table, allowed, pk_cols,
+            data.filters, data.sort, data.limit, data.offset,
+        )
+    except RowError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        conn.close()
+
+
+@router.post("/row")
+def insert_row(
+    data: PgRowInsertRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("data:write")),
+):
+    conn = _connect(authorization, data.server_id, data.database, caller)
+    try:
+        allowed, _ = _row_meta(conn, data.schema_name, data.table)
+        result = pg_row_service.insert_row(
+            conn, data.schema_name, data.table, allowed, data.values,
+        )
+    except RowError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        conn.close()
+    log_write_operation(
+        user_email=caller.email, operation="insert",
+        database_name=data.server_id,
+        collection_name=f"{data.schema_name}.{data.table}",
+        after_data=data.values,
+    )
+    return result
+
+
+@router.patch("/row")
+def update_row(
+    data: PgRowUpdateRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("data:write")),
+):
+    conn = _connect(authorization, data.server_id, data.database, caller)
+    try:
+        allowed, pk_cols = _row_meta(conn, data.schema_name, data.table)
+        result = pg_row_service.update_row(
+            conn, data.schema_name, data.table, allowed, pk_cols, data.pk, data.values,
+        )
+    except NoPrimaryKey as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except RowError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        conn.close()
+    log_write_operation(
+        user_email=caller.email, operation="update",
+        database_name=data.server_id,
+        collection_name=f"{data.schema_name}.{data.table}",
+        document_id=str(data.pk), after_data=data.values,
+    )
+    return result
+
+
+@router.delete("/row")
+def delete_row(
+    data: PgRowDeleteRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("data:write")),
+):
+    conn = _connect(authorization, data.server_id, data.database, caller)
+    try:
+        _, pk_cols = _row_meta(conn, data.schema_name, data.table)
+        result = pg_row_service.delete_row(
+            conn, data.schema_name, data.table, pk_cols, data.pk,
+        )
+    except NoPrimaryKey as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except RowError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        conn.close()
+    log_write_operation(
+        user_email=caller.email, operation="delete",
+        database_name=data.server_id,
+        collection_name=f"{data.schema_name}.{data.table}",
+        document_id=str(data.pk),
+    )
+    return result
 
 
 # --- Access provisioning (admin only) ------------------------------------

--- a/backend/routes/postgres.py
+++ b/backend/routes/postgres.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Body, Depends, Header, HTTPException
 
 from models.schemas import (
     PgAccessListRequest,
+    PgAnalyzeRequest,
     PgDatabasesRequest,
     PgExecuteRequest,
     PgGrantRequest,
@@ -19,6 +20,7 @@ from services.azure_postgres_resources import (
     list_postgres_servers,
 )
 from services.data_documents_service import log_write_operation
+from services.gemini_service import analyze_pg_result
 from services.pg_admin_service import (
     get_pg_admin_connection,
     grant_access,
@@ -47,7 +49,9 @@ def _connect(authorization: str, server_id: str, database: str, caller: Caller):
     try:
         return get_pg_connection(fqdn, database, caller.email, pg_token)
     except Exception as e:
-        raise HTTPException(status_code=502, detail=f"PostgreSQL connection failed: {e}")
+        raise HTTPException(
+            status_code=502, detail=f"PostgreSQL connection failed: {e}"
+        )
 
 
 def _admin_connect(authorization: str, server_id: str):
@@ -64,7 +68,9 @@ def _admin_connect(authorization: str, server_id: str):
     try:
         return get_pg_admin_connection(fqdn)
     except Exception as e:
-        raise HTTPException(status_code=502, detail=f"PostgreSQL connection failed: {e}")
+        raise HTTPException(
+            status_code=502, detail=f"PostgreSQL connection failed: {e}"
+        )
 
 
 @router.get("/servers")
@@ -149,6 +155,22 @@ def execute(
     if isinstance(result, dict) and "error" in result:
         raise HTTPException(status_code=500, detail=f"SQL error: {result['error']}")
     return result
+
+
+@router.post("/analyze")
+def analyze(
+    data: PgAnalyzeRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("query:read")),
+):
+    """AI insight over a result set the caller already fetched. No DB access —
+    operates purely on the provided rows, so no server connection is opened."""
+    return analyze_pg_result(
+        columns=data.columns,
+        rows=data.rows,
+        user_input=data.user_input,
+        model=data.model,
+    )
 
 
 # --- Access provisioning (admin only) ------------------------------------

--- a/backend/routes/postgres.py
+++ b/backend/routes/postgres.py
@@ -1,9 +1,12 @@
 from fastapi import APIRouter, Body, Depends, Header, HTTPException
 
 from models.schemas import (
+    PgAccessListRequest,
     PgDatabasesRequest,
     PgExecuteRequest,
+    PgGrantRequest,
     PgNl2SqlRequest,
+    PgRevokeRequest,
     PgSchemaRequest,
     PgTableInfoRequest,
 )
@@ -14,6 +17,13 @@ from services.azure_postgres_resources import (
     get_table_info,
     list_databases,
     list_postgres_servers,
+)
+from services.data_documents_service import log_write_operation
+from services.pg_admin_service import (
+    get_pg_admin_connection,
+    grant_access,
+    list_access,
+    revoke_access,
 )
 from services.pg_connection_obo import get_pg_connection
 from services.pg_query_service import OSSRDBMS_SCOPE, execute_sql
@@ -36,6 +46,23 @@ def _connect(authorization: str, server_id: str, database: str, caller: Caller):
     pg_token = exchange_token_obo(user_token, scope=OSSRDBMS_SCOPE)
     try:
         return get_pg_connection(fqdn, database, caller.email, pg_token)
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"PostgreSQL connection failed: {e}")
+
+
+def _admin_connect(authorization: str, server_id: str):
+    """Resolve FQDN (via the caller's OBO ARM discovery, 404 on unknown) and open
+    a PG connection as the backend SP admin — used by grant/revoke/list, which
+    must run as a PG admin regardless of the caller's own PG access."""
+    user_token = authorization.replace("Bearer ", "")
+    arm_token = exchange_token_obo(user_token)
+    servers = list_postgres_servers(arm_token)
+    try:
+        fqdn = get_server_fqdn(server_id, servers)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="PostgreSQL server not found")
+    try:
+        return get_pg_admin_connection(fqdn)
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"PostgreSQL connection failed: {e}")
 
@@ -122,3 +149,63 @@ def execute(
     if isinstance(result, dict) and "error" in result:
         raise HTTPException(status_code=500, detail=f"SQL error: {result['error']}")
     return result
+
+
+# --- Access provisioning (admin only) ------------------------------------
+
+
+@router.post("/grant")
+def grant(
+    data: PgGrantRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("system:admin")),
+):
+    conn = _admin_connect(authorization, data.server_id)
+    try:
+        result = grant_access(conn, data.user_email)
+    finally:
+        conn.close()
+    log_write_operation(
+        user_email=caller.email,
+        operation="grant",
+        database_name=data.server_id,
+        collection_name="pg_access",
+        document_id=data.user_email,
+    )
+    return result
+
+
+@router.post("/revoke")
+def revoke(
+    data: PgRevokeRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("system:admin")),
+):
+    conn = _admin_connect(authorization, data.server_id)
+    try:
+        result = revoke_access(conn, data.user_email)
+    except Exception as e:
+        raise HTTPException(status_code=409, detail=f"Cannot revoke: {e}")
+    finally:
+        conn.close()
+    log_write_operation(
+        user_email=caller.email,
+        operation="revoke",
+        database_name=data.server_id,
+        collection_name="pg_access",
+        document_id=data.user_email,
+    )
+    return result
+
+
+@router.post("/access")
+def access(
+    data: PgAccessListRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("system:admin")),
+):
+    conn = _admin_connect(authorization, data.server_id)
+    try:
+        return list_access(conn)
+    finally:
+        conn.close()

--- a/backend/routes/postgres.py
+++ b/backend/routes/postgres.py
@@ -209,6 +209,14 @@ def rows(
         conn.close()
 
 
+def _row_dict(result: dict):
+    """The single affected row (from RETURNING *) as a dict, for the audit log."""
+    rows = result.get("rows") or []
+    if not rows:
+        return None
+    return dict(zip(result.get("columns", []), rows[0]))
+
+
 @router.post("/row")
 def insert_row(
     data: PgRowInsertRequest = Body(...),
@@ -229,7 +237,7 @@ def insert_row(
         user_email=caller.email, operation="insert",
         database_name=data.server_id,
         collection_name=f"{data.schema_name}.{data.table}",
-        after_data=data.values,
+        after_data=_row_dict(result) or data.values,
     )
     return result
 
@@ -256,7 +264,7 @@ def update_row(
         user_email=caller.email, operation="update",
         database_name=data.server_id,
         collection_name=f"{data.schema_name}.{data.table}",
-        document_id=str(data.pk), after_data=data.values,
+        document_id=str(data.pk), after_data=_row_dict(result) or data.values,
     )
     return result
 
@@ -283,7 +291,7 @@ def delete_row(
         user_email=caller.email, operation="delete",
         database_name=data.server_id,
         collection_name=f"{data.schema_name}.{data.table}",
-        document_id=str(data.pk),
+        document_id=str(data.pk), before_data=_row_dict(result),
     )
     return result
 

--- a/backend/routes/postgres.py
+++ b/backend/routes/postgres.py
@@ -28,8 +28,10 @@ from services.gemini_service import analyze_pg_result
 from services.pg_admin_service import (
     get_pg_admin_connection,
     grant_access,
+    grant_write_access,
     list_access,
     revoke_access,
+    revoke_write_access,
 )
 from services import pg_row_service
 from services.pg_connection_obo import get_pg_connection
@@ -336,6 +338,52 @@ def revoke(
     log_write_operation(
         user_email=caller.email,
         operation="revoke",
+        database_name=data.server_id,
+        collection_name="pg_access",
+        document_id=data.user_email,
+    )
+    return result
+
+
+@router.post("/grant_write")
+def grant_write(
+    data: PgGrantRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("system:admin")),
+):
+    conn = _admin_connect(authorization, data.server_id)
+    try:
+        result = grant_write_access(conn, data.user_email)
+    except Exception as e:
+        raise HTTPException(status_code=409, detail=f"Cannot grant write: {e}")
+    finally:
+        conn.close()
+    log_write_operation(
+        user_email=caller.email,
+        operation="grant_write",
+        database_name=data.server_id,
+        collection_name="pg_access",
+        document_id=data.user_email,
+    )
+    return result
+
+
+@router.post("/revoke_write")
+def revoke_write(
+    data: PgRevokeRequest = Body(...),
+    authorization: str = Header(...),
+    caller: Caller = Depends(require("system:admin")),
+):
+    conn = _admin_connect(authorization, data.server_id)
+    try:
+        result = revoke_write_access(conn, data.user_email)
+    except Exception as e:
+        raise HTTPException(status_code=409, detail=f"Cannot revoke write: {e}")
+    finally:
+        conn.close()
+    log_write_operation(
+        user_email=caller.email,
+        operation="revoke_write",
         database_name=data.server_id,
         collection_name="pg_access",
         document_id=data.user_email,

--- a/backend/routes/postgres.py
+++ b/backend/routes/postgres.py
@@ -84,7 +84,9 @@ def _admin_connect(authorization: str, server_id: str):
     except Exception as e:
         logging.getLogger("querypal.postgres").warning(
             "SP-admin PG connect failed for %s (login=%s): %r",
-            fqdn, os.environ.get("PG_ADMIN_LOGIN"), e
+            fqdn,
+            os.environ.get("PG_ADMIN_LOGIN"),
+            e,
         )
         raise HTTPException(
             status_code=502, detail=f"PostgreSQL connection failed: {e}"
@@ -212,8 +214,15 @@ def rows(
     try:
         allowed, pk_cols = _row_meta(conn, data.schema_name, data.table)
         return pg_row_service.browse(
-            conn, data.schema_name, data.table, allowed, pk_cols,
-            data.filters, data.sort, data.limit, data.offset,
+            conn,
+            data.schema_name,
+            data.table,
+            allowed,
+            pk_cols,
+            data.filters,
+            data.sort,
+            data.limit,
+            data.offset,
         )
     except RowError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -239,14 +248,19 @@ def insert_row(
     try:
         allowed, _ = _row_meta(conn, data.schema_name, data.table)
         result = pg_row_service.insert_row(
-            conn, data.schema_name, data.table, allowed, data.values,
+            conn,
+            data.schema_name,
+            data.table,
+            allowed,
+            data.values,
         )
     except RowError as e:
         raise HTTPException(status_code=400, detail=str(e))
     finally:
         conn.close()
     log_write_operation(
-        user_email=caller.email, operation="insert",
+        user_email=caller.email,
+        operation="insert",
         database_name=data.server_id,
         collection_name=f"{data.schema_name}.{data.table}",
         after_data=_row_dict(result) or data.values,
@@ -264,7 +278,13 @@ def update_row(
     try:
         allowed, pk_cols = _row_meta(conn, data.schema_name, data.table)
         result = pg_row_service.update_row(
-            conn, data.schema_name, data.table, allowed, pk_cols, data.pk, data.values,
+            conn,
+            data.schema_name,
+            data.table,
+            allowed,
+            pk_cols,
+            data.pk,
+            data.values,
         )
     except NoPrimaryKey as e:
         raise HTTPException(status_code=409, detail=str(e))
@@ -273,7 +293,8 @@ def update_row(
     finally:
         conn.close()
     log_write_operation(
-        user_email=caller.email, operation="update",
+        user_email=caller.email,
+        operation="update",
         database_name=data.server_id,
         collection_name=f"{data.schema_name}.{data.table}",
         document_id=str(data.pk),
@@ -293,7 +314,11 @@ def delete_row(
     try:
         _, pk_cols = _row_meta(conn, data.schema_name, data.table)
         result = pg_row_service.delete_row(
-            conn, data.schema_name, data.table, pk_cols, data.pk,
+            conn,
+            data.schema_name,
+            data.table,
+            pk_cols,
+            data.pk,
         )
     except NoPrimaryKey as e:
         raise HTTPException(status_code=409, detail=str(e))
@@ -302,10 +327,12 @@ def delete_row(
     finally:
         conn.close()
     log_write_operation(
-        user_email=caller.email, operation="delete",
+        user_email=caller.email,
+        operation="delete",
         database_name=data.server_id,
         collection_name=f"{data.schema_name}.{data.table}",
-        document_id=str(data.pk), before_data=_row_dict(result),
+        document_id=str(data.pk),
+        before_data=_row_dict(result),
     )
     return result
 

--- a/backend/routes/postgres.py
+++ b/backend/routes/postgres.py
@@ -1,3 +1,6 @@
+import logging
+import os
+
 from fastapi import APIRouter, Body, Depends, Header, HTTPException
 
 from models.schemas import (
@@ -57,6 +60,9 @@ def _connect(authorization: str, server_id: str, database: str, caller: Caller):
     try:
         return get_pg_connection(fqdn, database, caller.email, pg_token)
     except Exception as e:
+        logging.getLogger("querypal.postgres").warning(
+            "OBO PG connect failed for %s: %r", fqdn, e
+        )
         raise HTTPException(
             status_code=502, detail=f"PostgreSQL connection failed: {e}"
         )
@@ -76,6 +82,10 @@ def _admin_connect(authorization: str, server_id: str):
     try:
         return get_pg_admin_connection(fqdn)
     except Exception as e:
+        logging.getLogger("querypal.postgres").warning(
+            "SP-admin PG connect failed for %s (login=%s): %r",
+            fqdn, os.environ.get("PG_ADMIN_LOGIN"), e
+        )
         raise HTTPException(
             status_code=502, detail=f"PostgreSQL connection failed: {e}"
         )

--- a/backend/routes/query.py
+++ b/backend/routes/query.py
@@ -9,6 +9,8 @@ from models.schemas import (
     ExecuteInput,
     DebugQueryRequest,
     DebugSuggestionResponse,
+    ExplainQueryRequest,
+    ExplainQueryResponse,
     SchemaRelationshipsRequest,
     SchemaRelationshipsResponse,
     EvaluateWriteRequest,
@@ -18,6 +20,7 @@ from services.react_agent_service import run_query_generator
 from services.gemini_service import (
     generate_suggestion_from_query_error,
     generate_schema_relationships,
+    explain_mongo_query,
 )
 from services.mongo_service import (
     execute_mongo_query,
@@ -236,6 +239,15 @@ def debug(
     return generate_suggestion_from_query_error(
         body.query, body.error_message, model=body.model
     )
+
+
+@router.post("/explain", response_model=ExplainQueryResponse)
+def explain(
+    body: ExplainQueryRequest = Body(...),
+    caller: Caller = Depends(require("query:read")),
+):
+    """Return a plain-English description of a generated Mongo query."""
+    return explain_mongo_query(body.query, model=body.model)
 
 
 @router.post("/analyze", response_model=AnalyzeResponse)

--- a/backend/routes/user_queries.py
+++ b/backend/routes/user_queries.py
@@ -12,8 +12,11 @@ router = APIRouter()
 
 
 @router.get("/queries", response_model=list[SavedQuery])
-def list_saved_queries(caller: Caller = Depends(require("self:manage"))):
-    return get_saved_queries(caller.email)
+def list_saved_queries(
+    engine: str | None = None,
+    caller: Caller = Depends(require("self:manage")),
+):
+    return get_saved_queries(caller.email, engine)
 
 
 @router.post("/queries", response_model=SavedQuery, status_code=201)

--- a/backend/services/analyze_service.py
+++ b/backend/services/analyze_service.py
@@ -13,12 +13,13 @@ You are a data analyst assistant. Given the following MongoDB query result, prov
 1. A concise textual insight or summary of the data.
 2. A recommended chart type (bar, line, pie, etc.) for visualization.
 3. Chart.js compatible data and options objects for the recommended chart.
-4. Two or three short natural-language follow-up questions the user could ask next, grounded only in this data.
+4. Exactly three follow-up prompts the user could run next as new queries. Each must be a short, actionable natural-language request phrased so it can be handed straight to a query generator (e.g. "show the 10 most recent orders", "count documents grouped by status"), grounded in this data or the collection it came from. This field is REQUIRED and must always contain three non-empty strings — never return an empty list.
 
 Query result (JSON array):
 {query_result}
 
 Respond in JSON with keys: insight, chartType, chartData, chartOptions, followups.
+The followups value must be a JSON array of exactly three non-empty strings.
 """
     client = genai.Client()
     response = client.models.generate_content(

--- a/backend/services/analyze_service.py
+++ b/backend/services/analyze_service.py
@@ -13,11 +13,12 @@ You are a data analyst assistant. Given the following MongoDB query result, prov
 1. A concise textual insight or summary of the data.
 2. A recommended chart type (bar, line, pie, etc.) for visualization.
 3. Chart.js compatible data and options objects for the recommended chart.
+4. Two or three short natural-language follow-up questions the user could ask next, grounded only in this data.
 
 Query result (JSON array):
 {query_result}
 
-Respond in JSON with keys: insight, chartType, chartData, chartOptions.
+Respond in JSON with keys: insight, chartType, chartData, chartOptions, followups.
 """
     client = genai.Client()
     response = client.models.generate_content(

--- a/backend/services/azure_auth.py
+++ b/backend/services/azure_auth.py
@@ -97,11 +97,15 @@ def _get_msal_app() -> msal.ConfidentialClientApplication:
     return _app
 
 
-def exchange_token_obo(user_token: str) -> str:
-    """Exchange user token for access token using On-Behalf-Of flow."""
+def exchange_token_obo(user_token: str, scope: Optional[str] = None) -> str:
+    """Exchange user token for an access token via the On-Behalf-Of flow.
+
+    Defaults to ARM_SCOPE (Cosmos/ARM discovery). Pass an explicit scope (e.g.
+    the OSS-RDBMS scope for PostgreSQL) to target another resource.
+    """
     app = _get_msal_app()
     result = app.acquire_token_on_behalf_of(
-        user_assertion=user_token, scopes=[ARM_SCOPE]
+        user_assertion=user_token, scopes=[scope or ARM_SCOPE]
     )
     if "access_token" not in result:
         raise Exception(f"OBO token exchange failed: {result}")

--- a/backend/services/azure_auth.py
+++ b/backend/services/azure_auth.py
@@ -112,6 +112,20 @@ def exchange_token_obo(user_token: str, scope: Optional[str] = None) -> str:
     return result["access_token"]
 
 
+def get_app_token(scope: str) -> str:
+    """Acquire an app-only (client-credentials) token for `scope`.
+
+    Used for actions QueryPal performs as itself (the backend service principal)
+    rather than on behalf of a user — e.g. running PostgreSQL grant/revoke as the
+    SP that is a permanent PG Entra admin.
+    """
+    app = _get_msal_app()
+    result = app.acquire_token_for_client(scopes=[scope])
+    if "access_token" not in result:
+        raise Exception(f"App token acquisition failed: {result}")
+    return result["access_token"]
+
+
 @dataclass
 class TokenClaims:
     email: Optional[str] = None

--- a/backend/services/azure_postgres_resources.py
+++ b/backend/services/azure_postgres_resources.py
@@ -4,6 +4,7 @@ Mirrors azure_cosmos_resources.py. Discovery uses the ARM access token;
 introspection runs against an already-open psycopg2 connection (opened by the
 route via pg_connection_obo) so the catalog queries stay unit-testable.
 """
+
 from cachetools import TTLCache, cached
 import psycopg2.sql as _sql  # noqa: F401  (reserved for future identifier quoting)
 import requests
@@ -61,8 +62,7 @@ def list_databases(conn) -> list:
 def get_schema_overview(conn) -> list:
     """Schemas -> tables with a fast row estimate from pg_class.reltuples."""
     with conn.cursor() as cur:
-        cur.execute(
-            """
+        cur.execute("""
             SELECT n.nspname AS schema,
                    c.relname AS table,
                    c.reltuples::bigint AS row_estimate
@@ -72,8 +72,7 @@ def get_schema_overview(conn) -> list:
               AND n.nspname NOT IN ('pg_catalog', 'information_schema')
               AND n.nspname NOT LIKE 'pg_toast%'
             ORDER BY n.nspname, c.relname
-            """
-        )
+            """)
         rows = cur.fetchall()
 
     by_schema: dict = {}
@@ -88,6 +87,17 @@ def get_schema_overview(conn) -> list:
 
 def get_table_info(conn, schema: str, table: str, sample_limit: int = 20) -> dict:
     with conn.cursor() as cur:
+        # Resolve the table oid once; the pk/fk/index catalog queries key off it.
+        # (These read pg_catalog, which is world-readable, so they succeed even
+        # when the caller lacks table-level read on the data itself.)
+        cur.execute(
+            "SELECT c.oid FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname = %s AND c.relname = %s",
+            (schema, table),
+        )
+        row = cur.fetchone()
+        relid = row[0] if row else None
+
         cur.execute(
             """
             SELECT column_name, data_type, is_nullable
@@ -97,17 +107,71 @@ def get_table_info(conn, schema: str, table: str, sample_limit: int = 20) -> dic
             """,
             (schema, table),
         )
-        columns = [
-            {"name": name, "type": dtype, "nullable": (nullable == "YES")}
-            for name, dtype, nullable in cur.fetchall()
-        ]
+        col_rows = cur.fetchall()
 
-        cur.execute(
-            "SELECT indexname FROM pg_indexes "
-            "WHERE schemaname = %s AND tablename = %s ORDER BY indexname",
-            (schema, table),
-        )
-        indexes = [r[0] for r in cur.fetchall()]
+        pk_cols: set = set()
+        fk_map: dict = {}
+        indexes: list = []
+        if relid is not None:
+            cur.execute(
+                "SELECT a.attname FROM pg_index i "
+                "JOIN pg_attribute a ON a.attrelid = i.indrelid "
+                "AND a.attnum = ANY(i.indkey) "
+                "WHERE i.indrelid = %s AND i.indisprimary",
+                (relid,),
+            )
+            pk_cols = {r[0] for r in cur.fetchall()}
+
+            # Outbound foreign keys: local column -> "reftable.refcol".
+            cur.execute(
+                """
+                SELECT att.attname, cl.relname, refatt.attname
+                FROM pg_constraint con
+                JOIN LATERAL unnest(con.conkey, con.confkey)
+                     WITH ORDINALITY AS cols(conkey, confkey, ord) ON true
+                JOIN pg_attribute att
+                     ON att.attrelid = con.conrelid AND att.attnum = cols.conkey
+                JOIN pg_class cl ON cl.oid = con.confrelid
+                JOIN pg_attribute refatt
+                     ON refatt.attrelid = con.confrelid AND refatt.attnum = cols.confkey
+                WHERE con.conrelid = %s AND con.contype = 'f'
+                """,
+                (relid,),
+            )
+            for col, reftable, refcol in cur.fetchall():
+                fk_map[col] = f"{reftable}.{refcol}"
+
+            # Indexes with column list + kind (uniq / gin / index) for badges.
+            cur.execute(
+                """
+                SELECT i.relname, am.amname, ix.indisunique,
+                       array_to_string(array_agg(a.attname ORDER BY k.ord), ', ')
+                FROM pg_index ix
+                JOIN pg_class i ON i.oid = ix.indexrelid
+                JOIN pg_am am ON am.oid = i.relam
+                JOIN unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ord) ON true
+                LEFT JOIN pg_attribute a
+                     ON a.attrelid = ix.indrelid AND a.attnum = k.attnum
+                WHERE ix.indrelid = %s
+                GROUP BY i.relname, am.amname, ix.indisunique
+                ORDER BY i.relname
+                """,
+                (relid,),
+            )
+            for name, method, is_unique, cols in cur.fetchall():
+                kind = "gin" if method == "gin" else "uniq" if is_unique else "index"
+                indexes.append({"name": name, "cols": cols or "", "kind": kind})
+
+        columns = [
+            {
+                "name": name,
+                "type": dtype,
+                "nullable": (nullable == "YES"),
+                "pk": name in pk_cols,
+                "fk": fk_map.get(name),
+            }
+            for name, dtype, nullable in col_rows
+        ]
 
         # Sample data is best-effort: the caller may lack table-level read
         # privileges (e.g. no pg_read_all_data) even though catalog metadata

--- a/backend/services/azure_postgres_resources.py
+++ b/backend/services/azure_postgres_resources.py
@@ -1,0 +1,129 @@
+"""Discover Azure PostgreSQL Flexible Servers (ARM) and introspect schema/data.
+
+Mirrors azure_cosmos_resources.py. Discovery uses the ARM access token;
+introspection runs against an already-open psycopg2 connection (opened by the
+route via pg_connection_obo) so the catalog queries stay unit-testable.
+"""
+from cachetools import TTLCache, cached
+import psycopg2.sql as _sql  # noqa: F401  (reserved for future identifier quoting)
+import requests
+
+from services.pg_query_service import _json_safe
+
+_pg_list_cache = TTLCache(maxsize=5, ttl=3600)
+ALL_CACHES = [_pg_list_cache]
+
+
+@cached(_pg_list_cache)
+def list_postgres_servers(access_token: str):
+    headers = {"Authorization": f"Bearer {access_token}"}
+    subs = requests.get(
+        "https://management.azure.com/subscriptions?api-version=2020-01-01",
+        headers=headers,
+    ).json()
+
+    results = []
+    for sub in subs.get("value", []):
+        sub_id = sub["subscriptionId"]
+        url = (
+            f"https://management.azure.com/subscriptions/{sub_id}/resources"
+            "?api-version=2021-04-01&$filter=resourceType eq "
+            "'Microsoft.DBforPostgreSQL/flexibleServers'"
+        )
+        servers = requests.get(url, headers=headers).json()
+        for srv in servers.get("value", []):
+            results.append(
+                {
+                    "name": srv["name"],
+                    "id": srv["id"],
+                    "fqdn": f"{srv['name']}.postgres.database.azure.com",
+                }
+            )
+    return results
+
+
+def get_server_fqdn(server_id: str, servers: list) -> str:
+    for srv in servers:
+        if srv["id"] == server_id:
+            return srv["fqdn"]
+    raise KeyError(f"Unknown PostgreSQL server id: {server_id}")
+
+
+def list_databases(conn) -> list:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT datname FROM pg_database "
+            "WHERE NOT datistemplate ORDER BY datname"
+        )
+        return [r[0] for r in cur.fetchall()]
+
+
+def get_schema_overview(conn) -> list:
+    """Schemas -> tables with a fast row estimate from pg_class.reltuples."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT n.nspname AS schema,
+                   c.relname AS table,
+                   c.reltuples::bigint AS row_estimate
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relkind IN ('r', 'p')
+              AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+              AND n.nspname NOT LIKE 'pg_toast%'
+            ORDER BY n.nspname, c.relname
+            """
+        )
+        rows = cur.fetchall()
+
+    by_schema: dict = {}
+    order: list = []
+    for schema, table, estimate in rows:
+        if schema not in by_schema:
+            by_schema[schema] = []
+            order.append(schema)
+        by_schema[schema].append({"name": table, "rowEstimate": int(estimate)})
+    return [{"schema": s, "tables": by_schema[s]} for s in order]
+
+
+def get_table_info(conn, schema: str, table: str, sample_limit: int = 20) -> dict:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT column_name, data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = %s AND table_name = %s
+            ORDER BY ordinal_position
+            """,
+            (schema, table),
+        )
+        columns = [
+            {"name": name, "type": dtype, "nullable": (nullable == "YES")}
+            for name, dtype, nullable in cur.fetchall()
+        ]
+
+        cur.execute(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE schemaname = %s AND tablename = %s ORDER BY indexname",
+            (schema, table),
+        )
+        indexes = [r[0] for r in cur.fetchall()]
+
+        # Identifiers can't be parameterized; quote with format() on validated
+        # catalog names (schema/table came from get_schema_overview).
+        cur.execute(
+            'SELECT * FROM "{}"."{}" LIMIT %s'.format(
+                schema.replace('"', '""'), table.replace('"', '""')
+            ),
+            (sample_limit,),
+        )
+        sample_cols = [d[0] for d in (cur.description or [])]
+        sample_rows = [[_json_safe(v) for v in row] for row in cur.fetchall()]
+
+    return {
+        "schema": schema,
+        "table": table,
+        "columns": columns,
+        "indexes": indexes,
+        "sample": {"columns": sample_cols, "rows": sample_rows},
+    }

--- a/backend/services/azure_postgres_resources.py
+++ b/backend/services/azure_postgres_resources.py
@@ -109,21 +109,31 @@ def get_table_info(conn, schema: str, table: str, sample_limit: int = 20) -> dic
         )
         indexes = [r[0] for r in cur.fetchall()]
 
-        # Identifiers can't be parameterized; quote with format() on validated
-        # catalog names (schema/table came from get_schema_overview).
-        cur.execute(
-            'SELECT * FROM "{}"."{}" LIMIT %s'.format(
-                schema.replace('"', '""'), table.replace('"', '""')
-            ),
-            (sample_limit,),
-        )
-        sample_cols = [d[0] for d in (cur.description or [])]
-        sample_rows = [[_json_safe(v) for v in row] for row in cur.fetchall()]
+        # Sample data is best-effort: the caller may lack table-level read
+        # privileges (e.g. no pg_read_all_data) even though catalog metadata
+        # above is readable. Don't fail the whole request — return columns/
+        # indexes with an empty sample and a reason the UI can surface.
+        # Identifiers can't be parameterized; quote on validated catalog names.
+        sample = {"columns": [], "rows": []}
+        try:
+            cur.execute(
+                'SELECT * FROM "{}"."{}" LIMIT %s'.format(
+                    schema.replace('"', '""'), table.replace('"', '""')
+                ),
+                (sample_limit,),
+            )
+            sample = {
+                "columns": [d[0] for d in (cur.description or [])],
+                "rows": [[_json_safe(v) for v in row] for row in cur.fetchall()],
+            }
+        except Exception as e:
+            conn.rollback()  # clear the aborted transaction
+            sample = {"columns": [], "rows": [], "error": str(e).strip()}
 
     return {
         "schema": schema,
         "table": table,
         "columns": columns,
         "indexes": indexes,
-        "sample": {"columns": sample_cols, "rows": sample_rows},
+        "sample": sample,
     }

--- a/backend/services/gemini_service.py
+++ b/backend/services/gemini_service.py
@@ -377,3 +377,30 @@ def analyze_pg_result(
         return PgInsight(
             summary="Could not analyze the result.", points=[], followups=[]
         )
+
+
+PROMPT_TEMPLATE_EXPLAIN = """
+You are a MongoDB expert. Explain, in one or two plain-English sentences, exactly what the following PyMongo query does — the collection, filters, sorting, limits, and any aggregation stages. Do not restate the code or add caveats.
+
+Query:
+{query}
+"""
+
+
+def explain_mongo_query(code: str, model: str = "gemini-2.5-flash"):
+    from models.schemas import ExplainQueryResponse
+
+    prompt = PROMPT_TEMPLATE_EXPLAIN.format(query=code)
+    try:
+        client = genai.Client()
+        response = client.models.generate_content(
+            model=model,
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                thinking_config=thinking_config_for(model)
+            ),
+        )
+        text = (response.text or "").strip()
+    except Exception as e:
+        text = f"Could not generate an explanation: {e}"
+    return ExplainQueryResponse(explanation=text or "No explanation available.")

--- a/backend/services/gemini_service.py
+++ b/backend/services/gemini_service.py
@@ -64,11 +64,12 @@ Respond ONLY with a suggestion for how to fix the query. Do not repeat the error
 
 def extract_python_code(text: str) -> str:
     """
-    Extracts code from a string wrapped in triple backticks (```python ... ```), or returns the original if not wrapped.
+    Extracts code from a string wrapped in triple backticks (```python ... ```,
+    ```sql ... ```, or an untagged ``` ... ```), or returns the original if not wrapped.
     """
     import re
 
-    match = re.search(r"```python\s*([\s\S]+?)\s*```", text)
+    match = re.search(r"```[a-zA-Z]*\s*([\s\S]+?)\s*```", text)
     if match:
         return match.group(1).strip()
     return text.strip()

--- a/backend/services/gemini_service.py
+++ b/backend/services/gemini_service.py
@@ -325,3 +325,55 @@ def generate_schema_relationships(
     except Exception as e:
         print(f"Error parsing Gemini relationship response: {e}")
         return SchemaRelationshipsResponse(relationships=[])
+
+
+class PgInsight(BaseModel):
+    summary: str
+    points: List[str] = Field(default_factory=list)
+    followups: List[str] = Field(default_factory=list)
+
+
+PROMPT_TEMPLATE_PG_INSIGHT = """You are a data analyst reviewing a PostgreSQL query result.
+
+User's request (if any): {user_input}
+Columns: {columns}
+Rows (sample, may be truncated):
+{rows}
+
+Return a JSON object:
+- "summary": one or two sentences describing what the result shows.
+- "points": up to 4 short bullet strings — notable patterns, anomalies, or distributions.
+- "followups": up to 3 short natural-language follow-up questions the user could ask next.
+Base everything only on the data shown. Do not invent columns or values.
+"""
+
+
+def analyze_pg_result(
+    columns: list, rows: list, user_input: str = "", model: str = "gemini-2.5-flash"
+) -> PgInsight:
+    """Summarize a SQL result set into {summary, points, followups}."""
+    rows_str = str(rows)[:8000]
+    full_prompt = PROMPT_TEMPLATE_PG_INSIGHT.format(
+        user_input=user_input or "(none)", columns=columns, rows=rows_str
+    )
+    client = genai.Client()
+    response = client.models.generate_content(
+        model=model,
+        contents=full_prompt,
+        config=types.GenerateContentConfig(
+            response_mime_type="application/json",
+            response_schema=PgInsight,
+            thinking_config=thinking_config_for(model),
+        ),
+    )
+    if hasattr(response, "parsed") and response.parsed:
+        return response.parsed
+    import json
+
+    try:
+        return PgInsight(**json.loads(response.text))
+    except Exception as e:
+        print(f"Error parsing Gemini insight response: {e}")
+        return PgInsight(
+            summary="Could not analyze the result.", points=[], followups=[]
+        )

--- a/backend/services/pg_admin_service.py
+++ b/backend/services/pg_admin_service.py
@@ -67,10 +67,20 @@ def revoke_access(conn, user_email: str) -> dict:
 
 
 def list_access(conn) -> list:
-    """Emails of individual Entra user principals that currently have access."""
+    """Emails of Entra user principals that actually have read access.
+
+    "Has access" = member of pg_read_all_data (what grant_access confers), NOT
+    merely having a login principal — otherwise a created-but-ungranted user
+    would show as granted yet fail every query with permission denied.
+    """
     with conn.cursor() as cur:
         cur.execute(
-            "SELECT rolname FROM pgaadauth_list_principals(false) "
-            "WHERE principaltype = 'user'"
+            """
+            SELECT p.rolname
+            FROM pgaadauth_list_principals(false) p
+            JOIN pg_roles u ON u.rolname = p.rolname
+            WHERE p.principaltype = 'user'
+              AND pg_has_role(u.oid, 'pg_read_all_data', 'member')
+            """
         )
         return [r[0] for r in cur.fetchall()]

--- a/backend/services/pg_admin_service.py
+++ b/backend/services/pg_admin_service.py
@@ -10,6 +10,7 @@ Grant creates an Entra LOGIN principal AND grants pg_read_all_data — the
 principal alone has no table privileges, so reads would otherwise fail. Read-only
 tool: no write/DDL privileges are ever granted.
 """
+
 from os import environ as env
 
 import psycopg2
@@ -101,14 +102,12 @@ def list_access(conn) -> list:
     Returns [{"email": str, "write": bool}].
     """
     with conn.cursor() as cur:
-        cur.execute(
-            """
+        cur.execute("""
             SELECT p.rolname,
                    pg_has_role(u.oid, 'pg_write_all_data', 'member')
             FROM pgaadauth_list_principals(false) p
             JOIN pg_roles u ON u.rolname = p.rolname
             WHERE p.principaltype = 'user'
               AND pg_has_role(u.oid, 'pg_read_all_data', 'member')
-            """
-        )
+            """)
         return [{"email": r[0], "write": bool(r[1])} for r in cur.fetchall()]

--- a/backend/services/pg_admin_service.py
+++ b/backend/services/pg_admin_service.py
@@ -1,0 +1,76 @@
+"""Provision Azure PostgreSQL access for QueryPal users (grant / revoke / list).
+
+Runs as the backend service principal, which is a permanent PG Entra admin
+(member of azure_pg_admin). The SP authenticates app-only and logs into PG with
+its Entra DISPLAY NAME (set via PG_ADMIN_LOGIN) — not its appId/objectId. This
+lets a QueryPal admin grant DB access to any user without themselves being a PG
+admin (and without az/psql).
+
+Grant creates an Entra LOGIN principal AND grants pg_read_all_data — the
+principal alone has no table privileges, so reads would otherwise fail. Read-only
+tool: no write/DDL privileges are ever granted.
+"""
+from os import environ as env
+
+import psycopg2
+from psycopg2 import sql
+
+from services.azure_auth import get_app_token
+from services.pg_query_service import OSSRDBMS_SCOPE
+
+
+def get_pg_admin_connection(fqdn: str, dbname: str = "postgres"):
+    """Open a PG connection as the backend SP admin (app-only token)."""
+    login = env["PG_ADMIN_LOGIN"]
+    token = get_app_token(OSSRDBMS_SCOPE)
+    conn = psycopg2.connect(
+        host=fqdn,
+        dbname=dbname,
+        user=login,
+        password=token,
+        sslmode="require",
+        connect_timeout=10,
+    )
+    conn.autocommit = True
+    return conn
+
+
+def grant_access(conn, user_email: str) -> dict:
+    """Idempotently grant `user_email` read-only PG access.
+
+    Creates the Entra login principal if absent, then ensures pg_read_all_data.
+    """
+    with conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (user_email,))
+        existed = cur.fetchone() is not None
+        if not existed:
+            cur.execute(
+                "SELECT pgaadauth_create_principal(%s, false, false)", (user_email,)
+            )
+        cur.execute(
+            sql.SQL("GRANT pg_read_all_data TO {}").format(sql.Identifier(user_email))
+        )
+    return {"granted": user_email, "created": not existed}
+
+
+def revoke_access(conn, user_email: str) -> dict:
+    """Revoke `user_email` PG access by dropping the role.
+
+    Read-only principals own nothing, so DROP ROLE suffices. If a role owns
+    objects this raises (we never silently DROP OWNED) — surface as a 409.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("DROP ROLE IF EXISTS {}").format(sql.Identifier(user_email))
+        )
+    return {"revoked": user_email}
+
+
+def list_access(conn) -> list:
+    """Emails of individual Entra user principals that currently have access."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT rolname FROM pgaadauth_list_principals(false) "
+            "WHERE principaltype = 'user'"
+        )
+        return [r[0] for r in cur.fetchall()]

--- a/backend/services/pg_admin_service.py
+++ b/backend/services/pg_admin_service.py
@@ -53,6 +53,31 @@ def grant_access(conn, user_email: str) -> dict:
     return {"granted": user_email, "created": not existed}
 
 
+def grant_write_access(conn, user_email: str) -> dict:
+    """Add write privileges (INSERT/UPDATE/DELETE on all tables) on top of the
+    caller's existing read access, via the built-in pg_write_all_data role.
+
+    Opt-in and separate from grant_access, which stays read-only. Assumes the
+    user already has a login principal + read (granted from the same admin UI).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("GRANT pg_write_all_data TO {}").format(sql.Identifier(user_email))
+        )
+    return {"granted_write": user_email}
+
+
+def revoke_write_access(conn, user_email: str) -> dict:
+    """Drop write privileges while leaving read access intact."""
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("REVOKE pg_write_all_data FROM {}").format(
+                sql.Identifier(user_email)
+            )
+        )
+    return {"revoked_write": user_email}
+
+
 def revoke_access(conn, user_email: str) -> dict:
     """Revoke `user_email` PG access by dropping the role.
 
@@ -67,20 +92,23 @@ def revoke_access(conn, user_email: str) -> dict:
 
 
 def list_access(conn) -> list:
-    """Emails of Entra user principals that actually have read access.
+    """Entra user principals with read access + whether they also have write.
 
     "Has access" = member of pg_read_all_data (what grant_access confers), NOT
     merely having a login principal — otherwise a created-but-ungranted user
-    would show as granted yet fail every query with permission denied.
+    would show as granted yet fail every query with permission denied. The
+    `write` flag reflects membership in pg_write_all_data (grant_write_access).
+    Returns [{"email": str, "write": bool}].
     """
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT p.rolname
+            SELECT p.rolname,
+                   pg_has_role(u.oid, 'pg_write_all_data', 'member')
             FROM pgaadauth_list_principals(false) p
             JOIN pg_roles u ON u.rolname = p.rolname
             WHERE p.principaltype = 'user'
               AND pg_has_role(u.oid, 'pg_read_all_data', 'member')
             """
         )
-        return [r[0] for r in cur.fetchall()]
+        return [{"email": r[0], "write": bool(r[1])} for r in cur.fetchall()]

--- a/backend/services/pg_connection_obo.py
+++ b/backend/services/pg_connection_obo.py
@@ -14,4 +14,7 @@ def get_pg_connection(fqdn: str, dbname: str, email: str, pg_token: str):
         user=email,
         password=pg_token,
         sslmode="require",
+        # Fail fast instead of hanging on the OS default (~minutes) when the
+        # server is unreachable — almost always a firewall/network issue.
+        connect_timeout=10,
     )

--- a/backend/services/pg_connection_obo.py
+++ b/backend/services/pg_connection_obo.py
@@ -4,6 +4,7 @@ caller's Entra identity (OBO token as password). No stored secrets.
 Distinct from services/pg_connection.py, which connects to QueryPal's own
 metadata store on GCP Cloud SQL.
 """
+
 import psycopg2
 
 

--- a/backend/services/pg_connection_obo.py
+++ b/backend/services/pg_connection_obo.py
@@ -1,0 +1,17 @@
+"""Open a psycopg2 connection to an Azure PostgreSQL Flexible Server using the
+caller's Entra identity (OBO token as password). No stored secrets.
+
+Distinct from services/pg_connection.py, which connects to QueryPal's own
+metadata store on GCP Cloud SQL.
+"""
+import psycopg2
+
+
+def get_pg_connection(fqdn: str, dbname: str, email: str, pg_token: str):
+    return psycopg2.connect(
+        host=fqdn,
+        dbname=dbname,
+        user=email,
+        password=pg_token,
+        sslmode="require",
+    )

--- a/backend/services/pg_query_service.py
+++ b/backend/services/pg_query_service.py
@@ -5,6 +5,7 @@ READ ONLY, so PostgreSQL itself rejects any write — no custom sandbox. Write
 and DDL statements are detected up front and returned for manual review
 instead of being executed (parity with the Cosmos Mongo write-guard).
 """
+
 import datetime
 import decimal
 import uuid

--- a/backend/services/pg_query_service.py
+++ b/backend/services/pg_query_service.py
@@ -1,0 +1,59 @@
+"""Read-only SQL execution + write/DDL detection for Azure PostgreSQL.
+
+Safety model: every statement runs inside a transaction explicitly set
+READ ONLY, so PostgreSQL itself rejects any write — no custom sandbox. Write
+and DDL statements are detected up front and returned for manual review
+instead of being executed (parity with the Cosmos Mongo write-guard).
+"""
+import datetime
+import decimal
+import uuid
+
+import sqlparse
+
+OSSRDBMS_SCOPE = "https://ossrdbms-aad.database.windows.net/.default"
+
+# Leading keyword of statements we consider safe to execute.
+_READ_KEYWORDS = {"SELECT", "WITH", "SHOW", "EXPLAIN"}
+
+
+def is_write_sql(sql: str) -> bool:
+    """True if `sql` is a write/DDL statement (or cannot be parsed).
+
+    Fails safe: anything we can't confidently classify as a read is a write.
+    """
+    statements = [s for s in sqlparse.parse(sql or "") if str(s).strip()]
+    if not statements:
+        return True
+    for stmt in statements:
+        keyword = stmt.token_first(skip_cm=True)
+        if keyword is None:
+            return True
+        if keyword.normalized.upper() not in _READ_KEYWORDS:
+            return True
+    return False
+
+
+def _json_safe(value):
+    if isinstance(value, (datetime.datetime, datetime.date, datetime.time)):
+        return value.isoformat()
+    if isinstance(value, decimal.Decimal):
+        return str(value)
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    if isinstance(value, (bytes, memoryview)):
+        return bytes(value).hex()
+    return value
+
+
+def execute_sql(conn, sql: str) -> dict:
+    """Run `sql` read-only. Returns {"columns", "rows"} or {"error"}."""
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SET TRANSACTION READ ONLY")
+            cur.execute(sql)
+            columns = [d[0] for d in (cur.description or [])]
+            rows = [[_json_safe(v) for v in row] for row in cur.fetchall()]
+        return {"columns": columns, "rows": rows}
+    except Exception as e:
+        return {"error": str(e)}

--- a/backend/services/pg_react_agent_service.py
+++ b/backend/services/pg_react_agent_service.py
@@ -15,7 +15,17 @@ from langgraph.graph import StateGraph, END
 from services.gemini_service import extract_python_code, thinking_config_for
 from services.pg_query_service import execute_sql, is_write_sql
 
+# Configure logger
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
 client = genai.Client()
 
 GENERATE_PROMPT = """You are an expert PostgreSQL engineer.

--- a/backend/services/pg_react_agent_service.py
+++ b/backend/services/pg_react_agent_service.py
@@ -4,6 +4,7 @@ Same generate -> execute -> evaluate -> loop shape as react_agent_service.py
 (Cosmos), with SQL-specific prompts. Reads are test-executed inside a READ ONLY
 transaction; writes/DDL skip execution and are returned for manual review.
 """
+
 import json
 import logging
 from typing import Any, TypedDict

--- a/backend/services/pg_react_agent_service.py
+++ b/backend/services/pg_react_agent_service.py
@@ -1,0 +1,183 @@
+"""LangGraph ReAct agent that generates read-only SQL for Azure PostgreSQL.
+
+Same generate -> execute -> evaluate -> loop shape as react_agent_service.py
+(Cosmos), with SQL-specific prompts. Reads are test-executed inside a READ ONLY
+transaction; writes/DDL skip execution and are returned for manual review.
+"""
+import json
+import logging
+from typing import Any, TypedDict
+
+from google import genai
+from google.genai import types
+from langgraph.graph import StateGraph, END
+
+from services.gemini_service import extract_python_code, thinking_config_for
+from services.pg_query_service import execute_sql, is_write_sql
+
+logger = logging.getLogger(__name__)
+client = genai.Client()
+
+GENERATE_PROMPT = """You are an expert PostgreSQL engineer.
+Generate a single SQL statement answering the user's request.
+
+User Request: {user_input}
+Database: {database}
+Schema (tables and columns):
+{schema_context}
+
+Previous Attempt (if a retry — do NOT repeat it verbatim):
+{previous_query}
+Previous Evaluation Feedback (if a retry):
+{evaluation}
+
+Rules:
+1. Return ONLY the SQL. No prose. A ```sql fenced block is acceptable.
+2. Prefer a SELECT. Include a LIMIT (<= 50) unless the user asks for all rows.
+3. Use only schema-listed tables/columns; never invent names.
+4. Standard PostgreSQL syntax. Use schema-qualified names when given.
+"""
+
+EVALUATE_PROMPT = """You are a database QA reviewer for a generated PostgreSQL query.
+
+User's Original Request: {user_input}
+Generated SQL: {generated_query}
+Is Write Action: {is_write_action}
+Query Result / Error:
+{query_result}
+
+If a write/DDL action, you cannot see a result — judge whether the SQL is
+correct for the intent. Otherwise judge whether the result answers the request;
+any error means it is NOT valid.
+
+Respond in JSON:
+{{"is_valid": true/false, "critique": "what went wrong and how to fix, or why it is valid"}}
+"""
+
+
+class _State(TypedDict, total=False):
+    user_input: str
+    database: str
+    schema_context: str
+    conn: Any
+    model: str
+    generated_query: str
+    is_write_action: bool
+    query_result: Any
+    evaluation: str
+    is_valid: bool
+    iterations: int
+    max_iterations: int
+
+
+def _generate(state: _State):
+    prompt = GENERATE_PROMPT.format(
+        user_input=state["user_input"],
+        database=state["database"],
+        schema_context=state["schema_context"],
+        previous_query=state.get("generated_query") or "None (first attempt).",
+        evaluation=state.get("evaluation", "None"),
+    )
+    try:
+        resp = client.models.generate_content(
+            model=state.get("model", "gemini-2.5-flash"),
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                thinking_config=thinking_config_for(
+                    state.get("model", "gemini-2.5-flash")
+                )
+            ),
+        )
+        sql = extract_python_code(resp.text).strip()
+    except Exception as e:
+        sql = f"-- Error generating query: {e}"
+    return {
+        "generated_query": sql,
+        "is_write_action": is_write_sql(sql),
+        "iterations": state.get("iterations", 0) + 1,
+    }
+
+
+def _execute(state: _State):
+    if state["is_write_action"]:
+        return {
+            "query_result": "Write/DDL operation detected. Execution skipped — "
+            "returned for manual review."
+        }
+    return {"query_result": execute_sql(state["conn"], state["generated_query"])}
+
+
+def _evaluate(state: _State):
+    raw = state.get("query_result")
+    result_str = str(raw)[:2000]
+    prompt = EVALUATE_PROMPT.format(
+        user_input=state["user_input"],
+        generated_query=state["generated_query"],
+        is_write_action=state["is_write_action"],
+        query_result=result_str,
+    )
+    try:
+        resp = client.models.generate_content(
+            model=state.get("model", "gemini-2.5-flash"),
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                response_mime_type="application/json",
+                thinking_config=thinking_config_for(
+                    state.get("model", "gemini-2.5-flash")
+                ),
+            ),
+        )
+        data = resp.parsed if getattr(resp, "parsed", None) else json.loads(resp.text)
+        return {
+            "is_valid": data.get("is_valid", False),
+            "evaluation": data.get("critique", "No critique provided."),
+        }
+    except Exception as e:
+        return {"is_valid": False, "evaluation": f"Failed to evaluate: {e}"}
+
+
+def _should_continue(state: _State):
+    if state.get("is_valid"):
+        return END
+    if state.get("iterations", 0) >= min(state.get("max_iterations", 3), 10):
+        return END
+    return "generate"
+
+
+_workflow = StateGraph(_State)
+_workflow.add_node("generate", _generate)
+_workflow.add_node("execute", _execute)
+_workflow.add_node("evaluate", _evaluate)
+_workflow.set_entry_point("generate")
+_workflow.add_edge("generate", "execute")
+_workflow.add_edge("execute", "evaluate")
+_workflow.add_conditional_edges("evaluate", _should_continue)
+_sql_generator = _workflow.compile()
+
+
+def run_sql_generator(
+    user_input: str,
+    database: str,
+    schema_context: str,
+    conn,
+    max_iterations: int = 3,
+    model: str = "gemini-2.5-flash",
+) -> dict:
+    final = _sql_generator.invoke(
+        {
+            "user_input": user_input,
+            "database": database,
+            "schema_context": schema_context,
+            "conn": conn,
+            "model": model,
+            "iterations": 0,
+            "max_iterations": max_iterations,
+        }
+    )
+    return {
+        "generated_code": final.get("generated_query", ""),
+        "is_write_action": final.get("is_write_action", False),
+        "query_result": final.get("query_result", None),
+        "explanation": final.get("evaluation", ""),
+        "is_valid": final.get("is_valid", False),
+    }

--- a/backend/services/pg_row_service.py
+++ b/backend/services/pg_row_service.py
@@ -1,0 +1,154 @@
+"""Parameterized, whitelist-validated row CRUD for Azure PostgreSQL.
+
+Distinct from pg_query_service (arbitrary read-only SQL): here every identifier
+is validated against the target table's real catalog columns and every value is
+bound as a parameter, closing both the identifier and value injection paths.
+Writes require a primary key so UPDATE/DELETE target exactly one row.
+"""
+from typing import Iterable, List, Tuple
+
+from services.pg_query_service import _json_safe
+
+
+class RowError(Exception):
+    """Bad request against a row endpoint (unknown column, bad operator, etc.)."""
+
+
+class NoPrimaryKey(RowError):
+    """Table has no primary key, so row-scoped writes are unsupported."""
+
+
+_OPS = {
+    "=": "=", "!=": "<>", "<": "<", ">": ">", "<=": "<=", ">=": ">=",
+    "like": "LIKE", "ilike": "ILIKE",
+}
+_NULLARY = {"isnull": "IS NULL", "isnotnull": "IS NOT NULL"}
+
+
+def _qi(name: str) -> str:
+    # Safe only after `name` is whitelisted against real catalog columns; the
+    # doubling handles legitimate special characters in an identifier.
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _qt(schema: str, table: str) -> str:
+    return f"{_qi(schema)}.{_qi(table)}"
+
+
+def _check(cols: Iterable[str], allowed: set) -> None:
+    unknown = [c for c in cols if c not in allowed]
+    if unknown:
+        raise RowError(f"Unknown column(s): {', '.join(unknown)}")
+
+
+def _where(filters: list, allowed: set) -> Tuple[str, List]:
+    if not filters:
+        return "", []
+    clauses, params = [], []
+    for f in filters:
+        col = f.get("column")
+        op = (f.get("op") or "=").lower()
+        _check([col], allowed)
+        if op in _NULLARY:
+            clauses.append(f"{_qi(col)} {_NULLARY[op]}")
+        elif op in _OPS:
+            clauses.append(f"{_qi(col)} {_OPS[op]} %s")
+            params.append(f.get("value"))
+        else:
+            raise RowError(f"Unsupported operator: {op}")
+    return " WHERE " + " AND ".join(clauses), params
+
+
+def build_browse(schema, table, allowed, filters, sort, limit, offset):
+    where, params = _where(filters or [], allowed)
+    order = ""
+    if sort and sort.get("column"):
+        _check([sort["column"]], allowed)
+        direction = "DESC" if str(sort.get("dir", "asc")).lower() == "desc" else "ASC"
+        order = f" ORDER BY {_qi(sort['column'])} {direction}"
+    q = f"SELECT * FROM {_qt(schema, table)}{where}{order} LIMIT %s OFFSET %s"
+    return q, params + [limit, offset]
+
+
+def build_count(schema, table, allowed, filters):
+    where, params = _where(filters or [], allowed)
+    return f"SELECT count(*) FROM {_qt(schema, table)}{where}", params
+
+
+def build_insert(schema, table, allowed, values):
+    if not values:
+        raise RowError("No values to insert.")
+    _check(values.keys(), allowed)
+    cols = list(values)
+    placeholders = ", ".join(["%s"] * len(cols))
+    collist = ", ".join(_qi(c) for c in cols)
+    q = f"INSERT INTO {_qt(schema, table)} ({collist}) VALUES ({placeholders}) RETURNING *"
+    return q, [values[c] for c in cols]
+
+
+def _pk_where(pk, pk_cols):
+    if not pk_cols:
+        raise NoPrimaryKey("Table has no primary key; row edits are unsupported.")
+    if set(pk) != set(pk_cols):
+        raise RowError("Primary key columns do not match the table's key.")
+    clause = " AND ".join(f"{_qi(c)} = %s" for c in pk_cols)
+    return clause, [pk[c] for c in pk_cols]
+
+
+def build_update(schema, table, allowed, pk_cols, pk, values):
+    if not values:
+        raise RowError("No values to update.")
+    where, wparams = _pk_where(pk, pk_cols)
+    _check(values.keys(), allowed)
+    cols = list(values)
+    setlist = ", ".join(f"{_qi(c)} = %s" for c in cols)
+    q = f"UPDATE {_qt(schema, table)} SET {setlist} WHERE {where} RETURNING *"
+    return q, [values[c] for c in cols] + wparams
+
+
+def build_delete(schema, table, pk_cols, pk):
+    where, wparams = _pk_where(pk, pk_cols)
+    q = f"DELETE FROM {_qt(schema, table)} WHERE {where} RETURNING *"
+    return q, wparams
+
+
+def _fetch(cur) -> dict:
+    columns = [d[0] for d in (cur.description or [])]
+    rows = [[_json_safe(v) for v in row] for row in cur.fetchall()]
+    return {"columns": columns, "rows": rows}
+
+
+def browse(conn, schema, table, allowed, pk_cols, filters, sort, limit, offset):
+    dq, dp = build_browse(schema, table, allowed, filters, sort, limit, offset)
+    cq, cp = build_count(schema, table, allowed, filters)
+    with conn.cursor() as cur:
+        cur.execute("SET TRANSACTION READ ONLY")
+        cur.execute(dq, dp)
+        result = _fetch(cur)
+        cur.execute(cq, cp)
+        result["total"] = cur.fetchone()[0]
+    result["pk"] = sorted(pk_cols)
+    return result
+
+
+def _write(conn, query, params) -> dict:
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        result = _fetch(cur)
+    conn.commit()
+    return result
+
+
+def insert_row(conn, schema, table, allowed, values):
+    q, params = build_insert(schema, table, allowed, values)
+    return _write(conn, q, params)
+
+
+def update_row(conn, schema, table, allowed, pk_cols, pk, values):
+    q, params = build_update(schema, table, allowed, pk_cols, pk, values)
+    return _write(conn, q, params)
+
+
+def delete_row(conn, schema, table, pk_cols, pk):
+    q, params = build_delete(schema, table, pk_cols, pk)
+    return _write(conn, q, params)

--- a/backend/services/pg_row_service.py
+++ b/backend/services/pg_row_service.py
@@ -5,6 +5,7 @@ is validated against the target table's real catalog columns and every value is
 bound as a parameter, closing both the identifier and value injection paths.
 Writes require a primary key so UPDATE/DELETE target exactly one row.
 """
+
 from typing import Iterable, List, Tuple
 
 import psycopg2
@@ -21,8 +22,14 @@ class NoPrimaryKey(RowError):
 
 
 _OPS = {
-    "=": "=", "!=": "<>", "<": "<", ">": ">", "<=": "<=", ">=": ">=",
-    "like": "LIKE", "ilike": "ILIKE",
+    "=": "=",
+    "!=": "<>",
+    "<": "<",
+    ">": ">",
+    "<=": "<=",
+    ">=": ">=",
+    "like": "LIKE",
+    "ilike": "ILIKE",
 }
 _NULLARY = {"isnull": "IS NULL", "isnotnull": "IS NOT NULL"}
 

--- a/backend/services/pg_row_service.py
+++ b/backend/services/pg_row_service.py
@@ -7,6 +7,8 @@ Writes require a primary key so UPDATE/DELETE target exactly one row.
 """
 from typing import Iterable, List, Tuple
 
+import psycopg2
+
 from services.pg_query_service import _json_safe
 
 
@@ -124,22 +126,28 @@ def _fetch(cur) -> dict:
 def browse(conn, schema, table, allowed, pk_cols, filters, sort, limit, offset):
     dq, dp = build_browse(schema, table, allowed, filters, sort, limit, offset)
     cq, cp = build_count(schema, table, allowed, filters)
-    with conn.cursor() as cur:
-        cur.execute("SET TRANSACTION READ ONLY")
-        cur.execute(dq, dp)
-        result = _fetch(cur)
-        cur.execute(cq, cp)
-        result["total"] = cur.fetchone()[0]
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SET TRANSACTION READ ONLY")
+            cur.execute(dq, dp)
+            result = _fetch(cur)
+            cur.execute(cq, cp)
+            result["total"] = cur.fetchone()[0]
+    except psycopg2.Error as e:
+        raise RowError(str(e).strip())
     result["pk"] = sorted(pk_cols)
     return result
 
 
 def _write(conn, query, params) -> dict:
-    with conn.cursor() as cur:
-        cur.execute(query, params)
-        result = _fetch(cur)
-    conn.commit()
-    return result
+    try:
+        with conn.cursor() as cur:
+            cur.execute(query, params)
+            result = _fetch(cur)
+        conn.commit()
+        return result
+    except psycopg2.Error as e:
+        raise RowError(str(e).strip())
 
 
 def insert_row(conn, schema, table, allowed, values):

--- a/backend/services/pg_row_service.py
+++ b/backend/services/pg_row_service.py
@@ -123,6 +123,18 @@ def _fetch(cur) -> dict:
     return {"columns": columns, "rows": rows}
 
 
+def _select_by_pk(conn, schema, table, pk_cols, pk) -> dict | None:
+    """The current row keyed by pk, as a dict — the pre-image for an update's
+    audit diff. None if the row doesn't exist."""
+    where, params = _pk_where(pk, pk_cols)
+    q = f"SELECT * FROM {_qt(schema, table)} WHERE {where}"
+    with conn.cursor() as cur:
+        cur.execute(q, params)
+        columns = [d[0] for d in (cur.description or [])]
+        row = cur.fetchone()
+    return dict(zip(columns, [_json_safe(v) for v in row])) if row else None
+
+
 def browse(conn, schema, table, allowed, pk_cols, filters, sort, limit, offset):
     dq, dp = build_browse(schema, table, allowed, filters, sort, limit, offset)
     cq, cp = build_count(schema, table, allowed, filters)
@@ -157,7 +169,12 @@ def insert_row(conn, schema, table, allowed, values):
 
 def update_row(conn, schema, table, allowed, pk_cols, pk, values):
     q, params = build_update(schema, table, allowed, pk_cols, pk, values)
-    return _write(conn, q, params)
+    # Capture the pre-image (same txn, before the write) so the audit records a
+    # real before/after diff instead of the whole new row.
+    before = _select_by_pk(conn, schema, table, pk_cols, pk)
+    result = _write(conn, q, params)
+    result["before"] = before
+    return result
 
 
 def delete_row(conn, schema, table, pk_cols, pk):

--- a/backend/services/pg_row_service.py
+++ b/backend/services/pg_row_service.py
@@ -32,6 +32,9 @@ def _qi(name: str) -> str:
 
 
 def _qt(schema: str, table: str) -> str:
+    # Contract: schema/table are quote-escaped here (injection-safe) but NOT
+    # allowlisted — the caller must resolve them against the real catalog first
+    # (the route does this via get_table_info, which 404s an unknown table).
     return f"{_qi(schema)}.{_qi(table)}"
 
 

--- a/backend/services/user_queries_service.py
+++ b/backend/services/user_queries_service.py
@@ -1,9 +1,42 @@
 import base64
 import json
 import uuid
-from typing import List
+from typing import List, Optional
 from models.user_queries import SavedQuery, SavedQueryCreate, SavedQueryUpdate
 from services.pg_connection import get_connection
+
+_COLS = "id, name, prompt, code, engine, owner_email, shared_with, last_modified_by, updated_at"
+
+# Additive migration: existing deployments created saved_queries without an
+# engine column. Add it once per process (ALTER ... IF NOT EXISTS is idempotent).
+_engine_col_ready = False
+
+
+def _ensure_engine_column(conn):
+    global _engine_col_ready
+    if _engine_col_ready:
+        return
+    c = conn.cursor()
+    c.execute(
+        "ALTER TABLE saved_queries "
+        "ADD COLUMN IF NOT EXISTS engine TEXT NOT NULL DEFAULT 'cosmos'"
+    )
+    _engine_col_ready = True
+
+
+def _row_to_query(row) -> SavedQuery:
+    shared_with = row[6].split(",") if row[6] else []
+    return SavedQuery(
+        id=row[0],
+        name=row[1],
+        prompt=row[2],
+        code=row[3],
+        engine=row[4] or "cosmos",
+        ownerEmail=row[5],
+        sharedWith=shared_with,
+        lastModifiedBy=row[7],
+        updatedAt=row[8],
+    )
 
 
 def get_user_id_from_token(token: str) -> str:
@@ -23,32 +56,23 @@ def get_user_id_from_token(token: str) -> str:
         return token
 
 
-def get_saved_queries(user_id: str) -> List[SavedQuery]:
+def get_saved_queries(user_id: str, engine: Optional[str] = None) -> List[SavedQuery]:
     conn = get_connection()
+    _ensure_engine_column(conn)
     c = conn.cursor()
-    # Return queries owned by or shared with user
-    c.execute(
-        "SELECT id, name, prompt, code, owner_email, shared_with, last_modified_by, updated_at FROM saved_queries WHERE owner_email = %s OR position(%s in shared_with) > 0",
-        (user_id, user_id),
+    # Return queries owned by or shared with user, optionally filtered by engine.
+    sql = (
+        f"SELECT {_COLS} FROM saved_queries "
+        "WHERE (owner_email = %s OR position(%s in shared_with) > 0)"
     )
+    params = [user_id, user_id]
+    if engine:
+        sql += " AND engine = %s"
+        params.append(engine)
+    c.execute(sql, tuple(params))
     rows = c.fetchall()
     conn.close()
-    result = []
-    for row in rows:
-        shared_with = row[5].split(",") if row[5] else []
-        result.append(
-            SavedQuery(
-                id=row[0],
-                name=row[1],
-                prompt=row[2],
-                code=row[3],
-                ownerEmail=row[4],
-                sharedWith=shared_with,
-                lastModifiedBy=row[6],
-                updatedAt=row[7],
-            )
-        )
-    return result
+    return [_row_to_query(row) for row in rows]
 
 
 def create_saved_query(user_id: str, data: SavedQueryCreate) -> SavedQuery:
@@ -57,10 +81,24 @@ def create_saved_query(user_id: str, data: SavedQueryCreate) -> SavedQuery:
     query_id = str(uuid.uuid4())
     now = datetime.datetime.utcnow().isoformat() + "Z"
     conn = get_connection()
+    _ensure_engine_column(conn)
     c = conn.cursor()
     c.execute(
-        "INSERT INTO saved_queries (id, name, prompt, code, owner_email, shared_with, last_modified_by, updated_at) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
-        (query_id, data.name, data.prompt, data.code, user_id, "", user_id, now),
+        "INSERT INTO saved_queries "
+        "(id, name, prompt, code, engine, owner_email, shared_with, "
+        "last_modified_by, updated_at) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
+        (
+            query_id,
+            data.name,
+            data.prompt,
+            data.code,
+            data.engine,
+            user_id,
+            "",
+            user_id,
+            now,
+        ),
     )
     conn.close()
     return SavedQuery(
@@ -68,6 +106,7 @@ def create_saved_query(user_id: str, data: SavedQueryCreate) -> SavedQuery:
         name=data.name,
         prompt=data.prompt,
         code=data.code,
+        engine=data.engine,
         ownerEmail=user_id,
         sharedWith=[],
         lastModifiedBy=user_id,
@@ -82,6 +121,7 @@ def update_saved_query(
 
     # Only owner or shared user can update
     conn = get_connection()
+    _ensure_engine_column(conn)
     c = conn.cursor()
     c.execute(
         "SELECT owner_email, shared_with FROM saved_queries WHERE id = %s", (query_id,)
@@ -96,8 +136,10 @@ def update_saved_query(
         conn.close()
         raise PermissionError("Not allowed to update this query")
     now = datetime.datetime.utcnow().isoformat() + "Z"
+    # engine is immutable after creation; not updated here.
     c.execute(
-        "UPDATE saved_queries SET name = %s, prompt = %s, code = %s, shared_with = %s, last_modified_by = %s, updated_at = %s WHERE id = %s",
+        "UPDATE saved_queries SET name = %s, prompt = %s, code = %s, shared_with = %s, "
+        "last_modified_by = %s, updated_at = %s WHERE id = %s",
         (
             data.name,
             data.prompt,
@@ -108,23 +150,10 @@ def update_saved_query(
             query_id,
         ),
     )
-    c.execute(
-        "SELECT id, name, prompt, code, owner_email, shared_with, last_modified_by, updated_at FROM saved_queries WHERE id = %s",
-        (query_id,),
-    )
+    c.execute(f"SELECT {_COLS} FROM saved_queries WHERE id = %s", (query_id,))
     row = c.fetchone()
     conn.close()
-    shared_with = row[5].split(",") if row[5] else []
-    return SavedQuery(
-        id=row[0],
-        name=row[1],
-        prompt=row[2],
-        code=row[3],
-        ownerEmail=row[4],
-        sharedWith=shared_with,
-        lastModifiedBy=row[6],
-        updatedAt=row[7],
-    )
+    return _row_to_query(row)
 
 
 def delete_saved_query(user_id: str, query_id: str):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,29 +8,35 @@ import pytest
 # Python 3.7 compatibility: add .args/.kwargs properties to _Call class
 from unittest.mock import _Call
 
+
 class _ArgsDescriptor:
     """Descriptor to provide .args attribute for Python 3.7 compatibility."""
+
     def __get__(self, obj, objtype=None):
         if obj is None:
             return self
         return obj[0]
 
+
 class _KwargsDescriptor:
     """Descriptor to provide .kwargs attribute for Python 3.7 compatibility."""
+
     def __get__(self, obj, objtype=None):
         if obj is None:
             return self
         return obj[1]
 
-if not hasattr(_Call, 'args'):
+
+if not hasattr(_Call, "args"):
     _Call.args = _ArgsDescriptor()
-if not hasattr(_Call, 'kwargs'):
+if not hasattr(_Call, "kwargs"):
     _Call.kwargs = _KwargsDescriptor()
 
 try:
     from fastapi.testclient import TestClient
     from main import app
     import services.azure_auth as _azure_auth
+
     _main_loaded = True
 except (ImportError, ModuleNotFoundError):
     _main_loaded = False
@@ -39,6 +45,7 @@ except (ImportError, ModuleNotFoundError):
 
 
 if _main_loaded:
+
     @pytest.fixture
     def client():
         """Create a test client for the FastAPI app."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,39 +4,67 @@ import base64
 import json
 
 import pytest
-from fastapi.testclient import TestClient
-from main import app
-import services.azure_auth as _azure_auth
+
+# Python 3.7 compatibility: add .args/.kwargs properties to _Call class
+from unittest.mock import _Call
+
+class _ArgsDescriptor:
+    """Descriptor to provide .args attribute for Python 3.7 compatibility."""
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return obj[0]
+
+class _KwargsDescriptor:
+    """Descriptor to provide .kwargs attribute for Python 3.7 compatibility."""
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return obj[1]
+
+if not hasattr(_Call, 'args'):
+    _Call.args = _ArgsDescriptor()
+if not hasattr(_Call, 'kwargs'):
+    _Call.kwargs = _KwargsDescriptor()
+
+try:
+    from fastapi.testclient import TestClient
+    from main import app
+    import services.azure_auth as _azure_auth
+    _main_loaded = True
+except (ImportError, ModuleNotFoundError):
+    _main_loaded = False
+    app = None
+    _azure_auth = None
 
 
-@pytest.fixture
-def client():
-    """Create a test client for the FastAPI app."""
-    return TestClient(app)
+if _main_loaded:
+    @pytest.fixture
+    def client():
+        """Create a test client for the FastAPI app."""
+        return TestClient(app)
 
-
-@pytest.fixture
-def mock_auth_header():
-    """Mock authorization header — structurally valid unsigned JWT for tests."""
-    payload = (
-        base64.urlsafe_b64encode(
-            json.dumps(
-                {"preferred_username": "test@example.com", "roles": ["Analyst"]}
-            ).encode()
+    @pytest.fixture
+    def mock_auth_header():
+        """Mock authorization header — structurally valid unsigned JWT for tests."""
+        payload = (
+            base64.urlsafe_b64encode(
+                json.dumps(
+                    {"preferred_username": "test@example.com", "roles": ["Analyst"]}
+                ).encode()
+            )
+            .rstrip(b"=")
+            .decode()
         )
-        .rstrip(b"=")
-        .decode()
-    )
-    return {"authorization": f"Bearer header.{payload}.sig"}
+        return {"authorization": f"Bearer header.{payload}.sig"}
 
-
-@pytest.fixture(autouse=True, scope="session")
-def _skip_jwt_verification_in_tests():
-    """Disable JWKS network calls for all tests. Patched per-test when needed."""
-    original_flag = _azure_auth.SKIP_JWT_VERIFICATION
-    original_client = _azure_auth._jwks_client
-    _azure_auth.SKIP_JWT_VERIFICATION = True
-    _azure_auth._jwks_client = None
-    yield
-    _azure_auth.SKIP_JWT_VERIFICATION = original_flag
-    _azure_auth._jwks_client = original_client
+    @pytest.fixture(autouse=True, scope="session")
+    def _skip_jwt_verification_in_tests():
+        """Disable JWKS network calls for all tests. Patched per-test when needed."""
+        original_flag = _azure_auth.SKIP_JWT_VERIFICATION
+        original_client = _azure_auth._jwks_client
+        _azure_auth.SKIP_JWT_VERIFICATION = True
+        _azure_auth._jwks_client = None
+        yield
+        _azure_auth.SKIP_JWT_VERIFICATION = original_flag
+        _azure_auth._jwks_client = original_client

--- a/backend/tests/test_audit_routes.py
+++ b/backend/tests/test_audit_routes.py
@@ -1,0 +1,21 @@
+def test_recent_allows_null_document_id(client, mock_auth_header, monkeypatch):
+    """Inserts log a null document_id — /recent must still validate (not 500)."""
+    import routes.audit as r
+
+    monkeypatch.setattr(
+        r,
+        "get_recent_activity",
+        lambda **k: [
+            {
+                "database_name": "srv",
+                "collection_name": "public.orders",
+                "operation": "insert",
+                "document_id": None,
+                "user_email": "u@x.io",
+                "timestamp_utc": "2026-07-12T00:00:00Z",
+            }
+        ],
+    )
+    resp = client.get("/audit/recent?limit=8", headers=mock_auth_header)
+    assert resp.status_code == 200
+    assert resp.json()[0]["document_id"] is None

--- a/backend/tests/test_azure_auth_obo.py
+++ b/backend/tests/test_azure_auth_obo.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock, patch
+import services.azure_auth as auth
+
+
+def test_obo_uses_arm_scope_by_default():
+    fake_app = MagicMock()
+    fake_app.acquire_token_on_behalf_of.return_value = {"access_token": "tok"}
+    with patch.object(auth, "_get_msal_app", return_value=fake_app):
+        with patch.object(auth, "ARM_SCOPE", "arm/.default"):
+            assert auth.exchange_token_obo("user-jwt") == "tok"
+    _, kwargs = fake_app.acquire_token_on_behalf_of.call_args
+    assert kwargs["scopes"] == ["arm/.default"]
+
+
+def test_obo_uses_explicit_scope_when_given():
+    fake_app = MagicMock()
+    fake_app.acquire_token_on_behalf_of.return_value = {"access_token": "pgtok"}
+    with patch.object(auth, "_get_msal_app", return_value=fake_app):
+        result = auth.exchange_token_obo(
+            "user-jwt", scope="https://ossrdbms-aad.database.windows.net/.default"
+        )
+    assert result == "pgtok"
+    _, kwargs = fake_app.acquire_token_on_behalf_of.call_args
+    assert kwargs["scopes"] == [
+        "https://ossrdbms-aad.database.windows.net/.default"
+    ]
+
+
+def test_obo_raises_when_no_access_token():
+    fake_app = MagicMock()
+    fake_app.acquire_token_on_behalf_of.return_value = {"error": "bad"}
+    with patch.object(auth, "_get_msal_app", return_value=fake_app):
+        try:
+            auth.exchange_token_obo("user-jwt")
+            assert False, "expected exception"
+        except Exception as e:
+            assert "OBO token exchange failed" in str(e)

--- a/backend/tests/test_azure_auth_obo.py
+++ b/backend/tests/test_azure_auth_obo.py
@@ -35,3 +35,23 @@ def test_obo_raises_when_no_access_token():
             assert False, "expected exception"
         except Exception as e:
             assert "OBO token exchange failed" in str(e)
+
+
+def test_get_app_token_uses_client_credentials():
+    fake_app = MagicMock()
+    fake_app.acquire_token_for_client.return_value = {"access_token": "apptok"}
+    with patch.object(auth, "_get_msal_app", return_value=fake_app):
+        assert auth.get_app_token("oss/.default") == "apptok"
+    _, kwargs = fake_app.acquire_token_for_client.call_args
+    assert kwargs["scopes"] == ["oss/.default"]
+
+
+def test_get_app_token_raises_when_no_access_token():
+    fake_app = MagicMock()
+    fake_app.acquire_token_for_client.return_value = {"error": "nope"}
+    with patch.object(auth, "_get_msal_app", return_value=fake_app):
+        try:
+            auth.get_app_token("oss/.default")
+            assert False, "expected exception"
+        except Exception as e:
+            assert "App token acquisition failed" in str(e)

--- a/backend/tests/test_azure_auth_obo.py
+++ b/backend/tests/test_azure_auth_obo.py
@@ -21,9 +21,7 @@ def test_obo_uses_explicit_scope_when_given():
         )
     assert result == "pgtok"
     _, kwargs = fake_app.acquire_token_on_behalf_of.call_args
-    assert kwargs["scopes"] == [
-        "https://ossrdbms-aad.database.windows.net/.default"
-    ]
+    assert kwargs["scopes"] == ["https://ossrdbms-aad.database.windows.net/.default"]
 
 
 def test_obo_raises_when_no_access_token():

--- a/backend/tests/test_azure_postgres_resources.py
+++ b/backend/tests/test_azure_postgres_resources.py
@@ -64,20 +64,37 @@ def test_get_schema_overview_groups_tables_by_schema():
 
 def test_get_table_info_returns_columns_indexes_sample():
     cur = MagicMock()
-    # 1) columns query  2) indexes query  3) sample query
+    cur.fetchone.return_value = (16384,)  # relid lookup
+    # fetchall order: columns, pk, fk, indexes, sample
     cur.fetchall.side_effect = [
-        [("id", "integer", "NO"), ("name", "text", "YES")],
-        [("patients_pkey",)],
-        [(1, "Ann"), (2, "Bob")],
+        [
+            ("id", "integer", "NO"),
+            ("name", "text", "YES"),
+            ("study_id", "integer", "YES"),
+        ],
+        [("id",)],  # primary key columns
+        [("study_id", "studies", "id")],  # foreign keys
+        [("patients_pkey", "btree", True, "id"), ("idx_name", "gin", False, "name")],
+        [(1, "Ann", 7), (2, "Bob", 7)],  # sample
     ]
-    cur.description = [("id",), ("name",)]
+    cur.description = [("id",), ("name",), ("study_id",)]
     conn = MagicMock()
     conn.cursor.return_value.__enter__.return_value = cur
     out = pg.get_table_info(conn, "public", "patients", sample_limit=20)
     assert out["columns"] == [
-        {"name": "id", "type": "integer", "nullable": False},
-        {"name": "name", "type": "text", "nullable": True},
+        {"name": "id", "type": "integer", "nullable": False, "pk": True, "fk": None},
+        {"name": "name", "type": "text", "nullable": True, "pk": False, "fk": None},
+        {
+            "name": "study_id",
+            "type": "integer",
+            "nullable": True,
+            "pk": False,
+            "fk": "studies.id",
+        },
     ]
-    assert out["indexes"] == ["patients_pkey"]
-    assert out["sample"]["columns"] == ["id", "name"]
-    assert out["sample"]["rows"] == [[1, "Ann"], [2, "Bob"]]
+    assert out["indexes"] == [
+        {"name": "patients_pkey", "cols": "id", "kind": "uniq"},
+        {"name": "idx_name", "cols": "name", "kind": "gin"},
+    ]
+    assert out["sample"]["columns"] == ["id", "name", "study_id"]
+    assert out["sample"]["rows"] == [[1, "Ann", 7], [2, "Bob", 7]]

--- a/backend/tests/test_azure_postgres_resources.py
+++ b/backend/tests/test_azure_postgres_resources.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock, patch
+
+import services.azure_postgres_resources as pg
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.json.return_value = json_body
+    r.status_code = 200
+    return r
+
+
+def test_list_postgres_servers_filters_flexible_servers():
+    pg._pg_list_cache.clear()
+    subs = _resp({"value": [{"subscriptionId": "sub1"}]})
+    servers = _resp(
+        {
+            "value": [
+                {
+                    "name": "database-patient-server",
+                    "id": "/subscriptions/sub1/.../flexibleServers/database-patient-server",
+                }
+            ]
+        }
+    )
+    with patch.object(pg.requests, "get", side_effect=[subs, servers]):
+        out = pg.list_postgres_servers("arm-token")
+    assert out == [
+        {
+            "name": "database-patient-server",
+            "id": "/subscriptions/sub1/.../flexibleServers/database-patient-server",
+            "fqdn": "database-patient-server.postgres.database.azure.com",
+        }
+    ]
+
+
+def test_list_databases_excludes_templates():
+    cur = MagicMock()
+    cur.fetchall.return_value = [("appdb",), ("postgres",)]
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+    assert pg.list_databases(conn) == ["appdb", "postgres"]
+
+
+def test_get_schema_overview_groups_tables_by_schema():
+    cur = MagicMock()
+    cur.fetchall.return_value = [
+        ("public", "patients", 1200),
+        ("public", "visits", 50),
+    ]
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+    out = pg.get_schema_overview(conn)
+    assert out == [
+        {
+            "schema": "public",
+            "tables": [
+                {"name": "patients", "rowEstimate": 1200},
+                {"name": "visits", "rowEstimate": 50},
+            ],
+        }
+    ]
+
+
+def test_get_table_info_returns_columns_indexes_sample():
+    cur = MagicMock()
+    # 1) columns query  2) indexes query  3) sample query
+    cur.fetchall.side_effect = [
+        [("id", "integer", "NO"), ("name", "text", "YES")],
+        [("patients_pkey",)],
+        [(1, "Ann"), (2, "Bob")],
+    ]
+    cur.description = [("id",), ("name",)]
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+    out = pg.get_table_info(conn, "public", "patients", sample_limit=20)
+    assert out["columns"] == [
+        {"name": "id", "type": "integer", "nullable": False},
+        {"name": "name", "type": "text", "nullable": True},
+    ]
+    assert out["indexes"] == ["patients_pkey"]
+    assert out["sample"]["columns"] == ["id", "name"]
+    assert out["sample"]["rows"] == [[1, "Ann"], [2, "Bob"]]

--- a/backend/tests/test_pg_admin_service.py
+++ b/backend/tests/test_pg_admin_service.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+
+from services.pg_admin_service import grant_access, revoke_access, list_access
+
+
+def _conn_with_cursor():
+    cur = MagicMock()
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+    return conn, cur
+
+
+def _executed_sql(cur):
+    return " || ".join(str(c.args[0]) for c in cur.execute.call_args_list)
+
+
+def test_grant_creates_principal_and_grants_read_when_absent():
+    conn, cur = _conn_with_cursor()
+    cur.fetchone.return_value = None  # role does not exist yet
+    out = grant_access(conn, "new@virtonomy.io")
+    assert out == {"granted": "new@virtonomy.io", "created": True}
+    blob = _executed_sql(cur)
+    assert "pgaadauth_create_principal" in blob
+    assert "pg_read_all_data" in blob
+    # email passed as a parameter to create_principal (not interpolated)
+    params = [c.args[1] for c in cur.execute.call_args_list if len(c.args) > 1]
+    assert ("new@virtonomy.io",) in params
+    # GRANT quotes the identifier
+    assert "new@virtonomy.io" in blob
+
+
+def test_grant_skips_create_when_role_exists():
+    conn, cur = _conn_with_cursor()
+    cur.fetchone.return_value = (1,)  # role already exists
+    out = grant_access(conn, "lin@virtonomy.io")
+    assert out == {"granted": "lin@virtonomy.io", "created": False}
+    blob = _executed_sql(cur)
+    assert "pgaadauth_create_principal" not in blob
+    assert "pg_read_all_data" in blob  # membership still ensured
+
+
+def test_revoke_drops_role():
+    conn, cur = _conn_with_cursor()
+    out = revoke_access(conn, "lin@virtonomy.io")
+    assert out == {"revoked": "lin@virtonomy.io"}
+    blob = _executed_sql(cur)
+    assert "DROP ROLE IF EXISTS" in blob
+    assert "lin@virtonomy.io" in blob
+
+
+def test_list_access_returns_user_emails():
+    conn, cur = _conn_with_cursor()
+    cur.fetchall.return_value = [("a@x.io",), ("b@x.io",)]
+    assert list_access(conn) == ["a@x.io", "b@x.io"]
+    assert "pgaadauth_list_principals" in _executed_sql(cur)

--- a/backend/tests/test_pg_admin_service.py
+++ b/backend/tests/test_pg_admin_service.py
@@ -1,6 +1,12 @@
 from unittest.mock import MagicMock
 
-from services.pg_admin_service import grant_access, revoke_access, list_access
+from services.pg_admin_service import (
+    grant_access,
+    grant_write_access,
+    list_access,
+    revoke_access,
+    revoke_write_access,
+)
 
 
 def _conn_with_cursor():
@@ -48,8 +54,31 @@ def test_revoke_drops_role():
     assert "lin@virtonomy.io" in blob
 
 
-def test_list_access_returns_user_emails():
+def test_list_access_returns_emails_with_write_flag():
     conn, cur = _conn_with_cursor()
-    cur.fetchall.return_value = [("a@x.io",), ("b@x.io",)]
-    assert list_access(conn) == ["a@x.io", "b@x.io"]
-    assert "pgaadauth_list_principals" in _executed_sql(cur)
+    cur.fetchall.return_value = [("a@x.io", True), ("b@x.io", False)]
+    assert list_access(conn) == [
+        {"email": "a@x.io", "write": True},
+        {"email": "b@x.io", "write": False},
+    ]
+    blob = _executed_sql(cur)
+    assert "pgaadauth_list_principals" in blob
+    assert "pg_write_all_data" in blob
+
+
+def test_grant_write_grants_write_role():
+    conn, cur = _conn_with_cursor()
+    out = grant_write_access(conn, "lin@virtonomy.io")
+    assert out == {"granted_write": "lin@virtonomy.io"}
+    blob = _executed_sql(cur)
+    assert "GRANT pg_write_all_data" in blob
+    assert "lin@virtonomy.io" in blob
+
+
+def test_revoke_write_revokes_write_role():
+    conn, cur = _conn_with_cursor()
+    out = revoke_write_access(conn, "lin@virtonomy.io")
+    assert out == {"revoked_write": "lin@virtonomy.io"}
+    blob = _executed_sql(cur)
+    assert "REVOKE pg_write_all_data" in blob
+    assert "lin@virtonomy.io" in blob

--- a/backend/tests/test_pg_connection_obo.py
+++ b/backend/tests/test_pg_connection_obo.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+import services.pg_connection_obo as mod
+
+
+def test_get_pg_connection_passes_entra_credentials():
+    with patch.object(mod.psycopg2, "connect") as connect:
+        connect.return_value = object()
+        mod.get_pg_connection(
+            fqdn="srv.postgres.database.azure.com",
+            dbname="appdb",
+            email="user@example.com",
+            pg_token="the-obo-token",
+        )
+    _, kwargs = connect.call_args
+    assert kwargs["host"] == "srv.postgres.database.azure.com"
+    assert kwargs["dbname"] == "appdb"
+    assert kwargs["user"] == "user@example.com"
+    assert kwargs["password"] == "the-obo-token"
+    assert kwargs["sslmode"] == "require"

--- a/backend/tests/test_pg_query_service.py
+++ b/backend/tests/test_pg_query_service.py
@@ -1,0 +1,64 @@
+import datetime
+import decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.pg_query_service import is_write_sql, execute_sql
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT * FROM patients",
+        "  select 1",
+        "WITH t AS (SELECT 1) SELECT * FROM t",
+    ],
+)
+def test_read_sql_is_not_write(sql):
+    assert is_write_sql(sql) is False
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "UPDATE patients SET name='x'",
+        "INSERT INTO patients (id) VALUES (1)",
+        "DELETE FROM patients",
+        "DROP TABLE patients",
+        "CREATE TABLE t (id int)",
+        "TRUNCATE patients",
+        "not valid sql ;;;",
+    ],
+)
+def test_write_or_ddl_or_unparseable_is_write(sql):
+    assert is_write_sql(sql) is True
+
+
+def test_execute_sql_returns_columns_and_json_safe_rows():
+    cur = MagicMock()
+    cur.description = [("id",), ("created",), ("amount",)]
+    cur.fetchall.return_value = [
+        (1, datetime.datetime(2026, 1, 1), decimal.Decimal("9.50")),
+    ]
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+
+    out = execute_sql(conn, "SELECT id, created, amount FROM t")
+
+    assert out["columns"] == ["id", "created", "amount"]
+    assert out["rows"] == [[1, "2026-01-01T00:00:00", "9.50"]]
+    # read-only transaction was set before running the query
+    executed = " ".join(str(c.args[0]) for c in cur.execute.call_args_list)
+    assert "READ ONLY" in executed.upper()
+
+
+def test_execute_sql_returns_error_dict_on_failure():
+    cur = MagicMock()
+    cur.execute.side_effect = Exception("relation does not exist")
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+
+    out = execute_sql(conn, "SELECT * FROM nope")
+    assert "error" in out
+    assert "relation does not exist" in out["error"]

--- a/backend/tests/test_pg_react_agent_service.py
+++ b/backend/tests/test_pg_react_agent_service.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock, patch
+
+import services.pg_react_agent_service as agent
+
+
+def _gen_response(text):
+    r = MagicMock()
+    r.text = text
+    r.parsed = None
+    return r
+
+
+def test_read_query_runs_and_validates():
+    conn = MagicMock()
+    gen = _gen_response("```sql\nSELECT id FROM patients\n```")
+    eval_resp = _gen_response('{"is_valid": true, "critique": "looks good"}')
+    with patch.object(
+        agent.client.models, "generate_content", side_effect=[gen, eval_resp]
+    ), patch.object(
+        agent, "execute_sql", return_value={"columns": ["id"], "rows": [[1]]}
+    ):
+        out = agent.run_sql_generator(
+            user_input="list patient ids",
+            database="appdb",
+            schema_context="public.patients(id int)",
+            conn=conn,
+            max_iterations=1,
+        )
+    assert out["generated_code"] == "SELECT id FROM patients"
+    assert out["is_write_action"] is False
+    assert out["is_valid"] is True
+    assert out["query_result"] == {"columns": ["id"], "rows": [[1]]}
+
+
+def test_write_sql_is_not_executed():
+    conn = MagicMock()
+    gen = _gen_response("UPDATE patients SET name='x'")
+    eval_resp = _gen_response('{"is_valid": true, "critique": "write looks correct"}')
+    with patch.object(
+        agent.client.models, "generate_content", side_effect=[gen, eval_resp]
+    ), patch.object(agent, "execute_sql") as exec_sql:
+        out = agent.run_sql_generator(
+            user_input="rename patient",
+            database="appdb",
+            schema_context="public.patients(id int, name text)",
+            conn=conn,
+            max_iterations=1,
+        )
+    exec_sql.assert_not_called()
+    assert out["is_write_action"] is True
+    assert "review" in str(out["query_result"]).lower()

--- a/backend/tests/test_pg_react_agent_service.py
+++ b/backend/tests/test_pg_react_agent_service.py
@@ -14,10 +14,13 @@ def test_read_query_runs_and_validates():
     conn = MagicMock()
     gen = _gen_response("```sql\nSELECT id FROM patients\n```")
     eval_resp = _gen_response('{"is_valid": true, "critique": "looks good"}')
-    with patch.object(
-        agent.client.models, "generate_content", side_effect=[gen, eval_resp]
-    ), patch.object(
-        agent, "execute_sql", return_value={"columns": ["id"], "rows": [[1]]}
+    with (
+        patch.object(
+            agent.client.models, "generate_content", side_effect=[gen, eval_resp]
+        ),
+        patch.object(
+            agent, "execute_sql", return_value={"columns": ["id"], "rows": [[1]]}
+        ),
     ):
         out = agent.run_sql_generator(
             user_input="list patient ids",
@@ -36,9 +39,12 @@ def test_write_sql_is_not_executed():
     conn = MagicMock()
     gen = _gen_response("UPDATE patients SET name='x'")
     eval_resp = _gen_response('{"is_valid": true, "critique": "write looks correct"}')
-    with patch.object(
-        agent.client.models, "generate_content", side_effect=[gen, eval_resp]
-    ), patch.object(agent, "execute_sql") as exec_sql:
+    with (
+        patch.object(
+            agent.client.models, "generate_content", side_effect=[gen, eval_resp]
+        ),
+        patch.object(agent, "execute_sql") as exec_sql,
+    ):
         out = agent.run_sql_generator(
             user_input="rename patient",
             database="appdb",

--- a/backend/tests/test_pg_row_service.py
+++ b/backend/tests/test_pg_row_service.py
@@ -5,9 +5,13 @@ from services import pg_row_service as s
 
 def test_browse_builds_where_order_limit_offset():
     q, params = s.build_browse(
-        "public", "orders", {"id", "status", "total"},
+        "public",
+        "orders",
+        {"id", "status", "total"},
         [{"column": "status", "op": "=", "value": "paid"}],
-        {"column": "total", "dir": "desc"}, 50, 100,
+        {"column": "total", "dir": "desc"},
+        50,
+        100,
     )
     assert q == (
         'SELECT * FROM "public"."orders" WHERE "status" = %s '
@@ -18,8 +22,13 @@ def test_browse_builds_where_order_limit_offset():
 
 def test_browse_nullary_operator_binds_no_value():
     q, params = s.build_browse(
-        "public", "orders", {"id", "note"},
-        [{"column": "note", "op": "isnull"}], None, 50, 0,
+        "public",
+        "orders",
+        {"id", "note"},
+        [{"column": "note", "op": "isnull"}],
+        None,
+        50,
+        0,
     )
     assert '"note" IS NULL' in q
     assert params == [50, 0]
@@ -27,36 +36,58 @@ def test_browse_nullary_operator_binds_no_value():
 
 def test_unknown_column_is_rejected():
     with pytest.raises(s.RowError):
-        s.build_browse("public", "orders", {"id"},
-                       [{"column": "secret", "op": "=", "value": 1}], None, 50, 0)
+        s.build_browse(
+            "public",
+            "orders",
+            {"id"},
+            [{"column": "secret", "op": "=", "value": 1}],
+            None,
+            50,
+            0,
+        )
 
 
 def test_unsupported_operator_is_rejected():
     with pytest.raises(s.RowError):
-        s.build_browse("public", "orders", {"id"},
-                       [{"column": "id", "op": "; drop", "value": 1}], None, 50, 0)
+        s.build_browse(
+            "public",
+            "orders",
+            {"id"},
+            [{"column": "id", "op": "; drop", "value": 1}],
+            None,
+            50,
+            0,
+        )
 
 
 def test_count_builds_matching_where():
-    q, params = s.build_count("public", "orders", {"status"},
-                              [{"column": "status", "op": "=", "value": "x"}])
+    q, params = s.build_count(
+        "public", "orders", {"status"}, [{"column": "status", "op": "=", "value": "x"}]
+    )
     assert q == 'SELECT count(*) FROM "public"."orders" WHERE "status" = %s'
     assert params == ["x"]
 
 
 def test_insert_builds_columns_and_params_in_order():
-    q, params = s.build_insert("public", "orders", {"status", "total"},
-                               {"status": "paid", "total": 9.5})
+    q, params = s.build_insert(
+        "public", "orders", {"status", "total"}, {"status": "paid", "total": 9.5}
+    )
     assert q == (
         'INSERT INTO "public"."orders" ("status", "total") '
-        'VALUES (%s, %s) RETURNING *'
+        "VALUES (%s, %s) RETURNING *"
     )
     assert params == ["paid", 9.5]
 
 
 def test_update_binds_set_then_pk():
-    q, params = s.build_update("public", "orders", {"status", "total"},
-                               ["id"], {"id": 7}, {"status": "refunded"})
+    q, params = s.build_update(
+        "public",
+        "orders",
+        {"status", "total"},
+        ["id"],
+        {"id": 7},
+        {"status": "refunded"},
+    )
     assert q == (
         'UPDATE "public"."orders" SET "status" = %s WHERE "id" = %s RETURNING *'
     )
@@ -78,13 +109,15 @@ def test_write_without_primary_key_raises():
 
 def test_update_pk_mismatch_raises():
     with pytest.raises(s.RowError):
-        s.build_update("public", "orders", {"status"}, ["id"],
-                       {"wrong": 1}, {"status": "x"})
+        s.build_update(
+            "public", "orders", {"status"}, ["id"], {"wrong": 1}, {"status": "x"}
+        )
 
 
 def test_write_wraps_db_error_as_rowerror():
     from unittest.mock import MagicMock
     import psycopg2
+
     cur = MagicMock()
     cur.__enter__ = lambda self=cur: cur
     cur.__exit__ = lambda *a: False
@@ -98,6 +131,7 @@ def test_write_wraps_db_error_as_rowerror():
 def test_browse_wraps_db_error_as_rowerror():
     from unittest.mock import MagicMock
     import psycopg2
+
     cur = MagicMock()
     cur.__enter__ = lambda self=cur: cur
     cur.__exit__ = lambda *a: False
@@ -110,14 +144,17 @@ def test_browse_wraps_db_error_as_rowerror():
 
 def test_update_row_captures_before_image_for_diff():
     from unittest.mock import MagicMock
+
     cur = MagicMock()
     cur.__enter__ = lambda self=cur: cur
     cur.__exit__ = lambda *a: False
     cur.description = [("id",), ("status",)]
-    cur.fetchone.return_value = (7, "old")     # SELECT pre-image
-    cur.fetchall.return_value = [(7, "new")]   # UPDATE ... RETURNING *
+    cur.fetchone.return_value = (7, "old")  # SELECT pre-image
+    cur.fetchall.return_value = [(7, "new")]  # UPDATE ... RETURNING *
     conn = MagicMock()
     conn.cursor.return_value = cur
-    result = s.update_row(conn, "public", "orders", {"status"}, ["id"], {"id": 7}, {"status": "new"})
+    result = s.update_row(
+        conn, "public", "orders", {"status"}, ["id"], {"id": 7}, {"status": "new"}
+    )
     assert result["before"] == {"id": 7, "status": "old"}
     assert result["rows"] == [[7, "new"]]

--- a/backend/tests/test_pg_row_service.py
+++ b/backend/tests/test_pg_row_service.py
@@ -106,3 +106,18 @@ def test_browse_wraps_db_error_as_rowerror():
     conn.cursor.return_value = cur
     with pytest.raises(s.RowError):
         s.browse(conn, "public", "orders", {"status"}, ["id"], [], None, 50, 0)
+
+
+def test_update_row_captures_before_image_for_diff():
+    from unittest.mock import MagicMock
+    cur = MagicMock()
+    cur.__enter__ = lambda self=cur: cur
+    cur.__exit__ = lambda *a: False
+    cur.description = [("id",), ("status",)]
+    cur.fetchone.return_value = (7, "old")     # SELECT pre-image
+    cur.fetchall.return_value = [(7, "new")]   # UPDATE ... RETURNING *
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    result = s.update_row(conn, "public", "orders", {"status"}, ["id"], {"id": 7}, {"status": "new"})
+    assert result["before"] == {"id": 7, "status": "old"}
+    assert result["rows"] == [[7, "new"]]

--- a/backend/tests/test_pg_row_service.py
+++ b/backend/tests/test_pg_row_service.py
@@ -80,3 +80,29 @@ def test_update_pk_mismatch_raises():
     with pytest.raises(s.RowError):
         s.build_update("public", "orders", {"status"}, ["id"],
                        {"wrong": 1}, {"status": "x"})
+
+
+def test_write_wraps_db_error_as_rowerror():
+    from unittest.mock import MagicMock
+    import psycopg2
+    cur = MagicMock()
+    cur.__enter__ = lambda self=cur: cur
+    cur.__exit__ = lambda *a: False
+    cur.execute.side_effect = psycopg2.Error("null value violates not-null constraint")
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    with pytest.raises(s.RowError):
+        s.insert_row(conn, "public", "orders", {"status"}, {"status": "x"})
+
+
+def test_browse_wraps_db_error_as_rowerror():
+    from unittest.mock import MagicMock
+    import psycopg2
+    cur = MagicMock()
+    cur.__enter__ = lambda self=cur: cur
+    cur.__exit__ = lambda *a: False
+    cur.execute.side_effect = psycopg2.Error("permission denied for table orders")
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    with pytest.raises(s.RowError):
+        s.browse(conn, "public", "orders", {"status"}, ["id"], [], None, 50, 0)

--- a/backend/tests/test_pg_row_service.py
+++ b/backend/tests/test_pg_row_service.py
@@ -1,0 +1,82 @@
+import pytest
+
+from services import pg_row_service as s
+
+
+def test_browse_builds_where_order_limit_offset():
+    q, params = s.build_browse(
+        "public", "orders", {"id", "status", "total"},
+        [{"column": "status", "op": "=", "value": "paid"}],
+        {"column": "total", "dir": "desc"}, 50, 100,
+    )
+    assert q == (
+        'SELECT * FROM "public"."orders" WHERE "status" = %s '
+        'ORDER BY "total" DESC LIMIT %s OFFSET %s'
+    )
+    assert params == ["paid", 50, 100]
+
+
+def test_browse_nullary_operator_binds_no_value():
+    q, params = s.build_browse(
+        "public", "orders", {"id", "note"},
+        [{"column": "note", "op": "isnull"}], None, 50, 0,
+    )
+    assert '"note" IS NULL' in q
+    assert params == [50, 0]
+
+
+def test_unknown_column_is_rejected():
+    with pytest.raises(s.RowError):
+        s.build_browse("public", "orders", {"id"},
+                       [{"column": "secret", "op": "=", "value": 1}], None, 50, 0)
+
+
+def test_unsupported_operator_is_rejected():
+    with pytest.raises(s.RowError):
+        s.build_browse("public", "orders", {"id"},
+                       [{"column": "id", "op": "; drop", "value": 1}], None, 50, 0)
+
+
+def test_count_builds_matching_where():
+    q, params = s.build_count("public", "orders", {"status"},
+                              [{"column": "status", "op": "=", "value": "x"}])
+    assert q == 'SELECT count(*) FROM "public"."orders" WHERE "status" = %s'
+    assert params == ["x"]
+
+
+def test_insert_builds_columns_and_params_in_order():
+    q, params = s.build_insert("public", "orders", {"status", "total"},
+                               {"status": "paid", "total": 9.5})
+    assert q == (
+        'INSERT INTO "public"."orders" ("status", "total") '
+        'VALUES (%s, %s) RETURNING *'
+    )
+    assert params == ["paid", 9.5]
+
+
+def test_update_binds_set_then_pk():
+    q, params = s.build_update("public", "orders", {"status", "total"},
+                               ["id"], {"id": 7}, {"status": "refunded"})
+    assert q == (
+        'UPDATE "public"."orders" SET "status" = %s WHERE "id" = %s RETURNING *'
+    )
+    assert params == ["refunded", 7]
+
+
+def test_delete_binds_pk():
+    q, params = s.build_delete("public", "orders", ["id"], {"id": 7})
+    assert q == 'DELETE FROM "public"."orders" WHERE "id" = %s RETURNING *'
+    assert params == [7]
+
+
+def test_write_without_primary_key_raises():
+    with pytest.raises(s.NoPrimaryKey):
+        s.build_delete("public", "logs", [], {"id": 1})
+    with pytest.raises(s.NoPrimaryKey):
+        s.build_update("public", "logs", {"id"}, [], {"id": 1}, {"x": 1})
+
+
+def test_update_pk_mismatch_raises():
+    with pytest.raises(s.RowError):
+        s.build_update("public", "orders", {"status"}, ["id"],
+                       {"wrong": 1}, {"status": "x"})

--- a/backend/tests/test_postgres_routes.py
+++ b/backend/tests/test_postgres_routes.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+SERVERS = [
+    {
+        "name": "database-patient-server",
+        "id": "/subscriptions/sub1/.../flexibleServers/database-patient-server",
+        "fqdn": "database-patient-server.postgres.database.azure.com",
+    }
+]
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    import routes.postgres as r
+
+    monkeypatch.setattr(r, "exchange_token_obo", lambda *a, **k: "tok")
+    monkeypatch.setattr(r, "list_postgres_servers", lambda token: SERVERS)
+    monkeypatch.setattr(r, "get_pg_connection", lambda *a, **k: MagicMock())
+    return r
+
+
+def test_list_servers(client, mock_auth_header, patched):
+    resp = client.get("/postgres/servers", headers=mock_auth_header)
+    assert resp.status_code == 200
+    assert resp.json()[0]["name"] == "database-patient-server"
+
+
+def test_schema_overview(client, mock_auth_header, patched, monkeypatch):
+    monkeypatch.setattr(
+        patched,
+        "get_schema_overview",
+        lambda conn: [
+            {"schema": "public", "tables": [{"name": "patients", "rowEstimate": 5}]}
+        ],
+    )
+    resp = client.post(
+        "/postgres/schema",
+        headers=mock_auth_header,
+        json={"server_id": SERVERS[0]["id"], "database": "appdb"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()[0]["schema"] == "public"
+
+
+def test_execute_runs_readonly(client, mock_auth_header, patched, monkeypatch):
+    monkeypatch.setattr(
+        patched, "execute_sql", lambda conn, sql: {"columns": ["id"], "rows": [[1]]}
+    )
+    resp = client.post(
+        "/postgres/execute",
+        headers=mock_auth_header,
+        json={
+            "server_id": SERVERS[0]["id"],
+            "database": "appdb",
+            "sql": "SELECT id FROM patients",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"columns": ["id"], "rows": [[1]]}
+
+
+def test_execute_rejects_unknown_server(client, mock_auth_header, patched):
+    resp = client.post(
+        "/postgres/execute",
+        headers=mock_auth_header,
+        json={"server_id": "/bogus/id", "database": "appdb", "sql": "SELECT 1"},
+    )
+    assert resp.status_code == 404

--- a/backend/tests/test_postgres_routes.py
+++ b/backend/tests/test_postgres_routes.py
@@ -68,3 +68,98 @@ def test_execute_rejects_unknown_server(client, mock_auth_header, patched):
         json={"server_id": "/bogus/id", "database": "appdb", "sql": "SELECT 1"},
     )
     assert resp.status_code == 404
+
+
+# --- Access provisioning (admin) routes ---------------------------------
+
+import base64 as _b64
+import json as _json
+
+
+def _admin_header():
+    payload = (
+        _b64.urlsafe_b64encode(
+            _json.dumps({"preferred_username": "admin@example.com", "roles": ["Admin"]}).encode()
+        ).rstrip(b"=").decode()
+    )
+    return {"authorization": f"Bearer header.{payload}.sig"}
+
+
+@pytest.fixture
+def patched_admin(monkeypatch):
+    import routes.postgres as r
+
+    monkeypatch.setattr(r, "exchange_token_obo", lambda *a, **k: "tok")
+    monkeypatch.setattr(r, "list_postgres_servers", lambda token: SERVERS)
+    monkeypatch.setattr(r, "get_pg_admin_connection", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(r, "log_write_operation", lambda *a, **k: None)
+    return r
+
+
+def test_grant_requires_admin(client, mock_auth_header, patched_admin):
+    # default mock_auth_header is an Analyst -> no system:admin
+    resp = client.post(
+        "/postgres/grant",
+        headers=mock_auth_header,
+        json={"server_id": SERVERS[0]["id"], "user_email": "u@x.io"},
+    )
+    assert resp.status_code == 403
+
+
+def test_grant_ok_for_admin(client, patched_admin, monkeypatch):
+    monkeypatch.setattr(
+        patched_admin, "grant_access", lambda conn, email: {"granted": email, "created": True}
+    )
+    resp = client.post(
+        "/postgres/grant",
+        headers=_admin_header(),
+        json={"server_id": SERVERS[0]["id"], "user_email": "u@x.io"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"granted": "u@x.io", "created": True}
+
+
+def test_revoke_ok_for_admin(client, patched_admin, monkeypatch):
+    monkeypatch.setattr(
+        patched_admin, "revoke_access", lambda conn, email: {"revoked": email}
+    )
+    resp = client.post(
+        "/postgres/revoke",
+        headers=_admin_header(),
+        json={"server_id": SERVERS[0]["id"], "user_email": "u@x.io"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"revoked": "u@x.io"}
+
+
+def test_revoke_conflict_on_dependency_error(client, patched_admin, monkeypatch):
+    def _boom(conn, email):
+        raise Exception("role has dependent objects")
+
+    monkeypatch.setattr(patched_admin, "revoke_access", _boom)
+    resp = client.post(
+        "/postgres/revoke",
+        headers=_admin_header(),
+        json={"server_id": SERVERS[0]["id"], "user_email": "u@x.io"},
+    )
+    assert resp.status_code == 409
+
+
+def test_access_list_for_admin(client, patched_admin, monkeypatch):
+    monkeypatch.setattr(patched_admin, "list_access", lambda conn: ["a@x.io", "b@x.io"])
+    resp = client.post(
+        "/postgres/access",
+        headers=_admin_header(),
+        json={"server_id": SERVERS[0]["id"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == ["a@x.io", "b@x.io"]
+
+
+def test_access_rejects_unknown_server(client, patched_admin):
+    resp = client.post(
+        "/postgres/access",
+        headers=_admin_header(),
+        json={"server_id": "/bogus/id"},
+    )
+    assert resp.status_code == 404

--- a/backend/tests/test_postgres_routes.py
+++ b/backend/tests/test_postgres_routes.py
@@ -195,13 +195,27 @@ def _fake_conn_with_rows(monkeypatch, patched, rows, columns, total=None):
     """Patch get_table_info + a cursor that returns `rows`/`columns`, and for
     browse a trailing count fetchone()."""
     monkeypatch.setattr(
-        patched, "get_table_info",
+        patched,
+        "get_table_info",
         lambda conn, schema, table: {
             "columns": [
-                {"name": "id", "type": "integer", "nullable": False, "pk": True, "fk": None},
-                {"name": "status", "type": "text", "nullable": True, "pk": False, "fk": None},
+                {
+                    "name": "id",
+                    "type": "integer",
+                    "nullable": False,
+                    "pk": True,
+                    "fk": None,
+                },
+                {
+                    "name": "status",
+                    "type": "text",
+                    "nullable": True,
+                    "pk": False,
+                    "fk": None,
+                },
             ],
-            "indexes": [], "sample": {"columns": [], "rows": []},
+            "indexes": [],
+            "sample": {"columns": [], "rows": []},
         },
     )
     cur = MagicMock()
@@ -218,10 +232,19 @@ def _fake_conn_with_rows(monkeypatch, patched, rows, columns, total=None):
 
 def test_rows_browse(client, mock_auth_header, patched, monkeypatch):
     _fake_conn_with_rows(monkeypatch, patched, [[1, "paid"]], ["id", "status"], total=1)
-    resp = client.post("/postgres/rows", headers=mock_auth_header, json={
-        "server_id": SERVERS[0]["id"], "database": "app", "schema_name": "public",
-        "table": "orders", "filters": [], "limit": 50, "offset": 0,
-    })
+    resp = client.post(
+        "/postgres/rows",
+        headers=mock_auth_header,
+        json={
+            "server_id": SERVERS[0]["id"],
+            "database": "app",
+            "schema_name": "public",
+            "table": "orders",
+            "filters": [],
+            "limit": 50,
+            "offset": 0,
+        },
+    )
     assert resp.status_code == 200
     body = resp.json()
     assert body["columns"] == ["id", "status"]
@@ -232,64 +255,117 @@ def test_rows_browse(client, mock_auth_header, patched, monkeypatch):
 def test_insert_row(client, mock_auth_header, patched, monkeypatch):
     _fake_conn_with_rows(monkeypatch, patched, [[2, "new"]], ["id", "status"])
     monkeypatch.setattr(patched, "log_write_operation", lambda **k: None)
-    resp = client.post("/postgres/row", headers=mock_auth_header, json={
-        "server_id": SERVERS[0]["id"], "database": "app", "schema_name": "public",
-        "table": "orders", "values": {"status": "new"},
-    })
+    resp = client.post(
+        "/postgres/row",
+        headers=mock_auth_header,
+        json={
+            "server_id": SERVERS[0]["id"],
+            "database": "app",
+            "schema_name": "public",
+            "table": "orders",
+            "values": {"status": "new"},
+        },
+    )
     assert resp.status_code == 200
     assert resp.json()["rows"] == [[2, "new"]]
 
 
 def test_delete_row_without_pk_is_409(client, mock_auth_header, patched, monkeypatch):
     monkeypatch.setattr(
-        patched, "get_table_info",
+        patched,
+        "get_table_info",
         lambda conn, schema, table: {
-            "columns": [{"name": "id", "type": "integer", "nullable": True,
-                         "pk": False, "fk": None}],
-            "indexes": [], "sample": {"columns": [], "rows": []},
+            "columns": [
+                {
+                    "name": "id",
+                    "type": "integer",
+                    "nullable": True,
+                    "pk": False,
+                    "fk": None,
+                }
+            ],
+            "indexes": [],
+            "sample": {"columns": [], "rows": []},
         },
     )
     monkeypatch.setattr(patched, "get_pg_connection", lambda *a, **k: MagicMock())
-    resp = client.request("DELETE", "/postgres/row", headers=mock_auth_header, json={
-        "server_id": SERVERS[0]["id"], "database": "app", "schema_name": "public",
-        "table": "logs", "pk": {"id": 1},
-    })
+    resp = client.request(
+        "DELETE",
+        "/postgres/row",
+        headers=mock_auth_header,
+        json={
+            "server_id": SERVERS[0]["id"],
+            "database": "app",
+            "schema_name": "public",
+            "table": "logs",
+            "pk": {"id": 1},
+        },
+    )
     assert resp.status_code == 409
 
 
 def test_rows_unknown_table_is_404(client, mock_auth_header, patched, monkeypatch):
     monkeypatch.setattr(
-        patched, "get_table_info",
+        patched,
+        "get_table_info",
         lambda conn, schema, table: {
-            "columns": [], "indexes": [], "sample": {"columns": [], "rows": []},
+            "columns": [],
+            "indexes": [],
+            "sample": {"columns": [], "rows": []},
         },
     )
     monkeypatch.setattr(patched, "get_pg_connection", lambda *a, **k: MagicMock())
-    resp = client.post("/postgres/rows", headers=mock_auth_header, json={
-        "server_id": SERVERS[0]["id"], "database": "app", "schema_name": "public",
-        "table": "nonexistent", "filters": [], "limit": 50, "offset": 0,
-    })
+    resp = client.post(
+        "/postgres/rows",
+        headers=mock_auth_header,
+        json={
+            "server_id": SERVERS[0]["id"],
+            "database": "app",
+            "schema_name": "public",
+            "table": "nonexistent",
+            "filters": [],
+            "limit": 50,
+            "offset": 0,
+        },
+    )
     assert resp.status_code == 404
 
 
-def test_writes_are_audited_with_row_data(client, mock_auth_header, patched, monkeypatch):
+def test_writes_are_audited_with_row_data(
+    client, mock_auth_header, patched, monkeypatch
+):
     calls = []
     monkeypatch.setattr(patched, "log_write_operation", lambda **k: calls.append(k))
 
     # insert -> records the RETURNING row as after_data
     _fake_conn_with_rows(monkeypatch, patched, [[2, "new"]], ["id", "status"])
-    r = client.post("/postgres/row", headers=mock_auth_header, json={
-        "server_id": SERVERS[0]["id"], "database": "app", "schema_name": "public",
-        "table": "orders", "values": {"status": "new"},
-    })
+    r = client.post(
+        "/postgres/row",
+        headers=mock_auth_header,
+        json={
+            "server_id": SERVERS[0]["id"],
+            "database": "app",
+            "schema_name": "public",
+            "table": "orders",
+            "values": {"status": "new"},
+        },
+    )
     assert r.status_code == 200
 
     # delete -> records the deleted row as before_data
     _fake_conn_with_rows(monkeypatch, patched, [[7, "old"]], ["id", "status"])
-    r = client.request("DELETE", "/postgres/row", headers=mock_auth_header, json={
-        "server_id": SERVERS[0]["id"], "database": "app", "schema_name": "public",
-        "table": "orders", "pk": {"id": 7},
-    })
+    r = client.request(
+        "DELETE",
+        "/postgres/row",
+        headers=mock_auth_header,
+        json={
+            "server_id": SERVERS[0]["id"],
+            "database": "app",
+            "schema_name": "public",
+            "table": "orders",
+            "pk": {"id": 7},
+        },
+    )
     assert r.status_code == 200
 
     ops = {c["operation"]: c for c in calls}

--- a/backend/tests/test_postgres_routes.py
+++ b/backend/tests/test_postgres_routes.py
@@ -270,3 +270,28 @@ def test_rows_unknown_table_is_404(client, mock_auth_header, patched, monkeypatc
         "table": "nonexistent", "filters": [], "limit": 50, "offset": 0,
     })
     assert resp.status_code == 404
+
+
+def test_writes_are_audited_with_row_data(client, mock_auth_header, patched, monkeypatch):
+    calls = []
+    monkeypatch.setattr(patched, "log_write_operation", lambda **k: calls.append(k))
+
+    # insert -> records the RETURNING row as after_data
+    _fake_conn_with_rows(monkeypatch, patched, [[2, "new"]], ["id", "status"])
+    r = client.post("/postgres/row", headers=mock_auth_header, json={
+        "server_id": SERVERS[0]["id"], "database": "app", "schema_name": "public",
+        "table": "orders", "values": {"status": "new"},
+    })
+    assert r.status_code == 200
+
+    # delete -> records the deleted row as before_data
+    _fake_conn_with_rows(monkeypatch, patched, [[7, "old"]], ["id", "status"])
+    r = client.request("DELETE", "/postgres/row", headers=mock_auth_header, json={
+        "server_id": SERVERS[0]["id"], "database": "app", "schema_name": "public",
+        "table": "orders", "pk": {"id": 7},
+    })
+    assert r.status_code == 200
+
+    ops = {c["operation"]: c for c in calls}
+    assert ops["insert"]["after_data"] == {"id": 2, "status": "new"}
+    assert ops["delete"]["before_data"] == {"id": 7, "status": "old"}

--- a/backend/tests/test_postgres_routes.py
+++ b/backend/tests/test_postgres_routes.py
@@ -186,3 +186,87 @@ def test_access_rejects_unknown_server(client, patched_admin):
         json={"server_id": "/bogus/id"},
     )
     assert resp.status_code == 404
+
+
+# --- Row CRUD routes ------------------------------------------------------
+
+
+def _fake_conn_with_rows(monkeypatch, patched, rows, columns, total=None):
+    """Patch get_table_info + a cursor that returns `rows`/`columns`, and for
+    browse a trailing count fetchone()."""
+    monkeypatch.setattr(
+        patched, "get_table_info",
+        lambda conn, schema, table: {
+            "columns": [
+                {"name": "id", "type": "integer", "nullable": False, "pk": True, "fk": None},
+                {"name": "status", "type": "text", "nullable": True, "pk": False, "fk": None},
+            ],
+            "indexes": [], "sample": {"columns": [], "rows": []},
+        },
+    )
+    cur = MagicMock()
+    cur.__enter__ = lambda s: cur
+    cur.__exit__ = lambda *a: False
+    cur.description = [(c,) for c in columns]
+    cur.fetchall.return_value = rows
+    cur.fetchone.return_value = (total,) if total is not None else None
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    monkeypatch.setattr(patched, "get_pg_connection", lambda *a, **k: conn)
+    return conn
+
+
+def test_rows_browse(client, mock_auth_header, patched, monkeypatch):
+    _fake_conn_with_rows(monkeypatch, patched, [[1, "paid"]], ["id", "status"], total=1)
+    resp = client.post("/postgres/rows", headers=mock_auth_header, json={
+        "server_id": SERVERS[0]["id"], "database": "app", "schema_name": "public",
+        "table": "orders", "filters": [], "limit": 50, "offset": 0,
+    })
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["columns"] == ["id", "status"]
+    assert body["total"] == 1
+    assert body["pk"] == ["id"]
+
+
+def test_insert_row(client, mock_auth_header, patched, monkeypatch):
+    _fake_conn_with_rows(monkeypatch, patched, [[2, "new"]], ["id", "status"])
+    monkeypatch.setattr(patched, "log_write_operation", lambda **k: None)
+    resp = client.post("/postgres/row", headers=mock_auth_header, json={
+        "server_id": SERVERS[0]["id"], "database": "app", "schema_name": "public",
+        "table": "orders", "values": {"status": "new"},
+    })
+    assert resp.status_code == 200
+    assert resp.json()["rows"] == [[2, "new"]]
+
+
+def test_delete_row_without_pk_is_409(client, mock_auth_header, patched, monkeypatch):
+    monkeypatch.setattr(
+        patched, "get_table_info",
+        lambda conn, schema, table: {
+            "columns": [{"name": "id", "type": "integer", "nullable": True,
+                         "pk": False, "fk": None}],
+            "indexes": [], "sample": {"columns": [], "rows": []},
+        },
+    )
+    monkeypatch.setattr(patched, "get_pg_connection", lambda *a, **k: MagicMock())
+    resp = client.request("DELETE", "/postgres/row", headers=mock_auth_header, json={
+        "server_id": SERVERS[0]["id"], "database": "app", "schema_name": "public",
+        "table": "logs", "pk": {"id": 1},
+    })
+    assert resp.status_code == 409
+
+
+def test_rows_unknown_table_is_404(client, mock_auth_header, patched, monkeypatch):
+    monkeypatch.setattr(
+        patched, "get_table_info",
+        lambda conn, schema, table: {
+            "columns": [], "indexes": [], "sample": {"columns": [], "rows": []},
+        },
+    )
+    monkeypatch.setattr(patched, "get_pg_connection", lambda *a, **k: MagicMock())
+    resp = client.post("/postgres/rows", headers=mock_auth_header, json={
+        "server_id": SERVERS[0]["id"], "database": "app", "schema_name": "public",
+        "table": "nonexistent", "filters": [], "limit": 50, "offset": 0,
+    })
+    assert resp.status_code == 404

--- a/backend/tests/test_postgres_routes.py
+++ b/backend/tests/test_postgres_routes.py
@@ -70,6 +70,23 @@ def test_execute_rejects_unknown_server(client, mock_auth_header, patched):
     assert resp.status_code == 404
 
 
+def test_analyze_returns_insight(client, mock_auth_header, patched, monkeypatch):
+    from services.gemini_service import PgInsight
+
+    monkeypatch.setattr(
+        patched,
+        "analyze_pg_result",
+        lambda **kw: PgInsight(summary="2 rows", points=["p1"], followups=["f1"]),
+    )
+    resp = client.post(
+        "/postgres/analyze",
+        headers=mock_auth_header,
+        json={"columns": ["id"], "rows": [[1], [2]], "user_input": "count"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"summary": "2 rows", "points": ["p1"], "followups": ["f1"]}
+
+
 # --- Access provisioning (admin) routes ---------------------------------
 
 import base64 as _b64
@@ -79,8 +96,12 @@ import json as _json
 def _admin_header():
     payload = (
         _b64.urlsafe_b64encode(
-            _json.dumps({"preferred_username": "admin@example.com", "roles": ["Admin"]}).encode()
-        ).rstrip(b"=").decode()
+            _json.dumps(
+                {"preferred_username": "admin@example.com", "roles": ["Admin"]}
+            ).encode()
+        )
+        .rstrip(b"=")
+        .decode()
     )
     return {"authorization": f"Bearer header.{payload}.sig"}
 
@@ -108,7 +129,9 @@ def test_grant_requires_admin(client, mock_auth_header, patched_admin):
 
 def test_grant_ok_for_admin(client, patched_admin, monkeypatch):
     monkeypatch.setattr(
-        patched_admin, "grant_access", lambda conn, email: {"granted": email, "created": True}
+        patched_admin,
+        "grant_access",
+        lambda conn, email: {"granted": email, "created": True},
     )
     resp = client.post(
         "/postgres/grant",

--- a/backend/tests/test_query_routes.py
+++ b/backend/tests/test_query_routes.py
@@ -228,6 +228,33 @@ def test_analyze_query(client):
         )
 
 
+def test_explain_query(client):
+    """Plain-English explanation of a generated Mongo query."""
+    from models.schemas import ExplainQueryResponse
+
+    with (
+        patch("routes.query.explain_mongo_query") as mock_explain,
+        patch(
+            "services.rbac.extract_claims_from_token",
+            return_value=TokenClaims(email="user@test.com", roles=["Analyst"]),
+        ),
+    ):
+        mock_explain.return_value = ExplainQueryResponse(
+            explanation="Finds all users in Canada, newest first."
+        )
+        headers = {"authorization": "Bearer valid-token"}
+        response = client.post(
+            "/query/explain",
+            json={"query": "db['users'].find({'country': 'Canada'})"},
+            headers=headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["explanation"].startswith("Finds all users")
+        mock_explain.assert_called_once_with(
+            "db['users'].find({'country': 'Canada'})", model="gemini-2.5-flash"
+        )
+
+
 from models.schemas import EvaluateWriteRequest
 from unittest.mock import patch, MagicMock
 

--- a/backend/tests/test_query_routes.py
+++ b/backend/tests/test_query_routes.py
@@ -204,6 +204,7 @@ def test_analyze_query(client):
             "chartType": "bar",
             "chartData": {"labels": ["A", "B"], "data": [1, 2]},
             "chartOptions": {"title": "Test Chart"},
+            "followups": ["Break down by province", "Show the newest 10"],
         }
 
         analyze_request = AnalyzeRequest(
@@ -221,6 +222,7 @@ def test_analyze_query(client):
         assert data["chartType"] == "bar"
         assert "chartData" in data
         assert "chartOptions" in data
+        assert data["followups"] == ["Break down by province", "Show the newest 10"]
 
         mock_analyze.assert_called_once_with(
             [{"name": "John", "age": 30}, {"name": "Jane", "age": 25}],

--- a/frontend/__tests__/PgRowDrawer.test.tsx
+++ b/frontend/__tests__/PgRowDrawer.test.tsx
@@ -8,6 +8,22 @@ const columns = [
 ];
 
 describe('PgRowDrawer', () => {
+  it('parses a json column value on save', () => {
+    const onSave = vi.fn();
+    const cols = [
+      { name: 'id', type: 'integer', nullable: false, pk: true, fk: null },
+      { name: 'meta', type: 'jsonb', nullable: true, pk: false, fk: null },
+    ];
+    render(
+      <PgRowDrawer columns={cols} pk={['id']} mode="edit"
+        row={{ id: 1, meta: {} }} onClose={() => {}} onSave={onSave} onDelete={() => {}} />,
+    );
+    const ta = screen.getByLabelText('meta') as HTMLTextAreaElement;
+    fireEvent.change(ta, { target: { value: '{"a":1}' } });
+    fireEvent.click(screen.getByText('Save'));
+    expect(onSave).toHaveBeenCalledWith({ meta: { a: 1 } });
+  });
+
   it('edits a field and saves only non-pk values', async () => {
     const onSave = vi.fn();
     render(

--- a/frontend/__tests__/PgRowDrawer.test.tsx
+++ b/frontend/__tests__/PgRowDrawer.test.tsx
@@ -51,6 +51,22 @@ describe('PgRowDrawer', () => {
     expect(onSave).toHaveBeenCalledWith({ tags: [1, 3] });
   });
 
+  it('omits blank fields on insert so DB defaults apply', () => {
+    const onSave = vi.fn();
+    const cols = [
+      { name: 'id', type: 'integer', nullable: false, pk: true, fk: null },
+      { name: 'name', type: 'text', nullable: false, pk: false, fk: null },
+      { name: 'note', type: 'text', nullable: true, pk: false, fk: null },
+    ];
+    render(
+      <PgRowDrawer columns={cols} pk={['id']} mode="new"
+        row={null} onClose={() => {}} onSave={onSave} onDelete={() => {}} />,
+    );
+    fireEvent.change(screen.getByLabelText('name'), { target: { value: 'Ada' } });
+    fireEvent.click(screen.getByText('Save'));
+    expect(onSave).toHaveBeenCalledWith({ name: 'Ada' }); // note omitted
+  });
+
   it('edits a field and saves only non-pk values', async () => {
     const onSave = vi.fn();
     render(

--- a/frontend/__tests__/PgRowDrawer.test.tsx
+++ b/frontend/__tests__/PgRowDrawer.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PgRowDrawer from '../components/PgRowDrawer';
+
+const columns = [
+  { name: 'id', type: 'integer', nullable: false, pk: true, fk: null },
+  { name: 'status', type: 'text', nullable: true, pk: false, fk: null },
+];
+
+describe('PgRowDrawer', () => {
+  it('edits a field and saves only non-pk values', async () => {
+    const onSave = vi.fn();
+    render(
+      <PgRowDrawer columns={columns} pk={['id']} mode="edit"
+        row={{ id: 7, status: 'paid' }} onClose={() => {}} onSave={onSave} onDelete={() => {}} />,
+    );
+    const input = screen.getByLabelText('status') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'refunded' } });
+    fireEvent.click(screen.getByText('Save'));
+    expect(onSave).toHaveBeenCalledWith({ status: 'refunded' });
+  });
+});

--- a/frontend/__tests__/PgRowDrawer.test.tsx
+++ b/frontend/__tests__/PgRowDrawer.test.tsx
@@ -67,6 +67,21 @@ describe('PgRowDrawer', () => {
     expect(onSave).toHaveBeenCalledWith({ name: 'Ada' }); // note omitted
   });
 
+  it('includes a typed (natural) primary key on insert', () => {
+    const onSave = vi.fn();
+    const cols = [
+      { name: 'project_name', type: 'text', nullable: false, pk: true, fk: null },
+      { name: 'status', type: 'text', nullable: true, pk: false, fk: null },
+    ];
+    render(
+      <PgRowDrawer columns={cols} pk={['project_name']} mode="new"
+        row={null} onClose={() => {}} onSave={onSave} onDelete={() => {}} />,
+    );
+    fireEvent.change(screen.getByLabelText('project_name'), { target: { value: 'Apollo' } });
+    fireEvent.click(screen.getByText('Save'));
+    expect(onSave).toHaveBeenCalledWith({ project_name: 'Apollo' });
+  });
+
   it('edits a field and saves only non-pk values', async () => {
     const onSave = vi.fn();
     render(

--- a/frontend/__tests__/PgRowDrawer.test.tsx
+++ b/frontend/__tests__/PgRowDrawer.test.tsx
@@ -24,6 +24,33 @@ describe('PgRowDrawer', () => {
     expect(onSave).toHaveBeenCalledWith({ meta: { a: 1 } });
   });
 
+  const arrayCols = [
+    { name: 'id', type: 'integer', nullable: false, pk: true, fk: null },
+    { name: 'tags', type: 'ARRAY', nullable: true, pk: false, fk: null },
+  ];
+
+  it('parses JSON array input into a JS array on save', () => {
+    const onSave = vi.fn();
+    render(
+      <PgRowDrawer columns={arrayCols} pk={['id']} mode="edit"
+        row={{ id: 1, tags: null }} onClose={() => {}} onSave={onSave} onDelete={() => {}} />,
+    );
+    fireEvent.change(screen.getByLabelText('tags'), { target: { value: '[1,3]' } });
+    fireEvent.click(screen.getByText('Save'));
+    expect(onSave).toHaveBeenCalledWith({ tags: [1, 3] });
+  });
+
+  it('parses PG {..} array literal input into a JS array on save', () => {
+    const onSave = vi.fn();
+    render(
+      <PgRowDrawer columns={arrayCols} pk={['id']} mode="edit"
+        row={{ id: 1, tags: null }} onClose={() => {}} onSave={onSave} onDelete={() => {}} />,
+    );
+    fireEvent.change(screen.getByLabelText('tags'), { target: { value: '{1,3}' } });
+    fireEvent.click(screen.getByText('Save'));
+    expect(onSave).toHaveBeenCalledWith({ tags: [1, 3] });
+  });
+
   it('edits a field and saves only non-pk values', async () => {
     const onSave = vi.fn();
     render(

--- a/frontend/__tests__/dbService.postgres.test.ts
+++ b/frontend/__tests__/dbService.postgres.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { listPostgresServers, pgExecute } from '../services/dbService';
+import { listPostgresServers, pgExecute, pgGrantAccess, pgRevokeAccess } from '../services/dbService';
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -21,5 +21,20 @@ describe('postgres dbService', () => {
     const out = await pgExecute('tok', '/sub/.../s', 'appdb', 'SELECT id FROM patients');
     expect(out).toEqual(body);
     expect(f.mock.calls[0][0]).toContain('/postgres/execute');
+  });
+
+  it('grants access via /postgres/grant', async () => {
+    const f = vi.fn(async () => ({ ok: true, json: async () => ({ granted: 'u@x.io', created: true }) }));
+    vi.stubGlobal('fetch', f);
+    await pgGrantAccess('tok', '/s', 'u@x.io');
+    expect(f.mock.calls[0][0]).toContain('/postgres/grant');
+    expect(JSON.parse(f.mock.calls[0][1].body)).toEqual({ server_id: '/s', user_email: 'u@x.io' });
+  });
+
+  it('revokes access via /postgres/revoke', async () => {
+    const f = vi.fn(async () => ({ ok: true, json: async () => ({ revoked: 'u@x.io' }) }));
+    vi.stubGlobal('fetch', f);
+    await pgRevokeAccess('tok', '/s', 'u@x.io');
+    expect(f.mock.calls[0][0]).toContain('/postgres/revoke');
   });
 });

--- a/frontend/__tests__/dbService.postgres.test.ts
+++ b/frontend/__tests__/dbService.postgres.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listPostgresServers, pgExecute } from '../services/dbService';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('postgres dbService', () => {
+  it('lists servers from /postgres/servers', async () => {
+    const servers = [{ name: 'database-patient-server', id: '/sub/.../s', fqdn: 's.postgres.database.azure.com' }];
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => servers })));
+    const out = await listPostgresServers('tok');
+    expect(out[0].name).toBe('database-patient-server');
+    expect((fetch as any).mock.calls[0][0]).toContain('/postgres/servers');
+  });
+
+  it('posts sql to /postgres/execute', async () => {
+    const body = { columns: ['id'], rows: [[1]] };
+    const f = vi.fn(async () => ({ ok: true, json: async () => body }));
+    vi.stubGlobal('fetch', f);
+    const out = await pgExecute('tok', '/sub/.../s', 'appdb', 'SELECT id FROM patients');
+    expect(out).toEqual(body);
+    expect(f.mock.calls[0][0]).toContain('/postgres/execute');
+  });
+});

--- a/frontend/components/AgentVerdict.tsx
+++ b/frontend/components/AgentVerdict.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+interface AgentVerdictProps {
+  isValid?: boolean;
+  explanation?: string;
+}
+
+/**
+ * Surfaces the ReAct agent's self-evaluation from the generate -> test-execute ->
+ * evaluate loop: whether it validated the query against the request, plus its
+ * critique. Shared by the Cosmos and PostgreSQL query workspaces.
+ */
+const AgentVerdict: React.FC<AgentVerdictProps> = ({ isValid, explanation }) => {
+  if (isValid === undefined && !explanation) return null;
+  const ok = isValid === true;
+  const tone = ok ? 'var(--status-ok)' : 'var(--status-warn)';
+  return (
+    <div
+      className="qa-card"
+      style={{
+        padding: '10px 14px', display: 'flex', gap: 10, alignItems: 'flex-start',
+        borderColor: `color-mix(in oklch, ${tone} 35%, var(--border))`,
+      }}
+    >
+      <span
+        className="qa-chip"
+        style={{ flexShrink: 0, background: `color-mix(in oklch, ${tone} 15%, var(--bg))`, color: tone, borderColor: 'transparent' }}
+        title="The AI ran and evaluated this query against your request during generation"
+      >
+        {ok ? '✓ Validated' : '⚠ Needs review'}
+      </span>
+      {explanation && (
+        <span style={{ fontSize: 12.5, color: 'var(--muted)', lineHeight: 1.5 }}>{explanation}</span>
+      )}
+    </div>
+  );
+};
+
+export default AgentVerdict;

--- a/frontend/components/AnalysisResultDisplay.tsx
+++ b/frontend/components/AnalysisResultDisplay.tsx
@@ -25,7 +25,6 @@ ChartJS.register(
 
 interface AnalysisResultDisplayProps {
   result: AnalysisResult;
-  onFollowup?: (prompt: string) => void;
 }
 
 const SparkleIcon = () => (
@@ -45,7 +44,7 @@ const CHART_TYPE_LABELS: Record<string, string> = {
   bubble: 'Bubble chart',
 };
 
-const AnalysisResultDisplay: React.FC<AnalysisResultDisplayProps> = ({ result, onFollowup }) => {
+const AnalysisResultDisplay: React.FC<AnalysisResultDisplayProps> = ({ result }) => {
   const { theme } = useTheme();
 
   const themedChartOptions = React.useMemo(() => {
@@ -130,57 +129,13 @@ const AnalysisResultDisplay: React.FC<AnalysisResultDisplayProps> = ({ result, o
         </span>
       </div>
 
-      {/* Body — insight + chart side by side */}
-      <div style={{ display: 'flex', minHeight: 320 }}>
-        {/* Insight panel */}
-        <div style={{
-          width: 220, flexShrink: 0,
-          padding: '16px 18px',
-          borderRight: '1px solid var(--border)',
-          display: 'flex', flexDirection: 'column', gap: 10,
-          background: 'var(--soft)',
-        }}>
-          <div style={{
-            fontSize: 10.5, fontWeight: 500,
-            textTransform: 'uppercase', letterSpacing: '0.08em',
-            color: 'var(--muted)', fontFamily: 'var(--font-body)',
-          }}>
-            Insight
-          </div>
-          <p style={{
-            fontSize: 13, color: 'var(--fg)', lineHeight: 1.65,
-            fontFamily: 'var(--font-body)', margin: 0,
-          }}>
-            {result.insight}
-          </p>
-          {result.followups && result.followups.length > 0 && onFollowup && (
-            <div style={{ marginTop: 'auto', display: 'flex', flexDirection: 'column', gap: 6 }}>
-              <div style={{ fontSize: 10.5, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)' }}>
-                Follow-ups
-              </div>
-              {result.followups.map((f, i) => (
-                <button
-                  key={i}
-                  onClick={() => onFollowup(f)}
-                  style={{ display: 'block', width: '100%', textAlign: 'left', padding: '6px 9px', borderRadius: 7, border: '1px solid var(--border)', background: 'var(--panel)', font: 'inherit', fontSize: 12, color: 'var(--fg)', cursor: 'pointer' }}
-                  onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--soft)'; }}
-                  onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--panel)'; }}
-                >
-                  <span style={{ color: 'var(--accent)', marginRight: 6 }}>→</span>{f}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Chart panel */}
-        <div style={{ flex: 1, padding: '20px 24px', position: 'relative', minWidth: 0 }}>
-          <Chart
-            type={result.chartType}
-            data={result.chartData}
-            options={themedChartOptions}
-          />
-        </div>
+      {/* Body — chart only (insight + follow-ups live in the workspace Insights rail) */}
+      <div style={{ padding: '20px 24px', position: 'relative', height: 360, boxSizing: 'border-box' }}>
+        <Chart
+          type={result.chartType}
+          data={result.chartData}
+          options={themedChartOptions}
+        />
       </div>
     </div>
   );

--- a/frontend/components/AnalysisResultDisplay.tsx
+++ b/frontend/components/AnalysisResultDisplay.tsx
@@ -25,6 +25,7 @@ ChartJS.register(
 
 interface AnalysisResultDisplayProps {
   result: AnalysisResult;
+  onFollowup?: (prompt: string) => void;
 }
 
 const SparkleIcon = () => (
@@ -44,7 +45,7 @@ const CHART_TYPE_LABELS: Record<string, string> = {
   bubble: 'Bubble chart',
 };
 
-const AnalysisResultDisplay: React.FC<AnalysisResultDisplayProps> = ({ result }) => {
+const AnalysisResultDisplay: React.FC<AnalysisResultDisplayProps> = ({ result, onFollowup }) => {
   const { theme } = useTheme();
 
   const themedChartOptions = React.useMemo(() => {
@@ -152,6 +153,24 @@ const AnalysisResultDisplay: React.FC<AnalysisResultDisplayProps> = ({ result })
           }}>
             {result.insight}
           </p>
+          {result.followups && result.followups.length > 0 && onFollowup && (
+            <div style={{ marginTop: 'auto', display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <div style={{ fontSize: 10.5, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)' }}>
+                Follow-ups
+              </div>
+              {result.followups.map((f, i) => (
+                <button
+                  key={i}
+                  onClick={() => onFollowup(f)}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', padding: '6px 9px', borderRadius: 7, border: '1px solid var(--border)', background: 'var(--panel)', font: 'inherit', fontSize: 12, color: 'var(--fg)', cursor: 'pointer' }}
+                  onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--soft)'; }}
+                  onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--panel)'; }}
+                >
+                  <span style={{ color: 'var(--accent)', marginRight: 6 }}>→</span>{f}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
 
         {/* Chart panel */}

--- a/frontend/components/AppLayout.tsx
+++ b/frontend/components/AppLayout.tsx
@@ -24,6 +24,11 @@ interface AppLayoutProps {
   availableAccounts?: CosmosDBAccount[];
   onSwitchAccount?: (account: CosmosDBAccount) => void;
   chipLoading?: boolean;
+  pgSchema?: { schema: string; tables: { name: string; rowEstimate: number }[] }[];
+  activePgTable?: string;
+  onPgTableSelect?: (schema: string, table: string) => void;
+  pgDatabases?: string[];
+  onSwitchPgDatabase?: (db: string) => void;
 }
 
 const AppLayout: React.FC<AppLayoutProps> = ({
@@ -44,6 +49,11 @@ const AppLayout: React.FC<AppLayoutProps> = ({
   availableAccounts,
   onSwitchAccount,
   chipLoading,
+  pgSchema,
+  activePgTable,
+  onPgTableSelect,
+  pgDatabases,
+  onSwitchPgDatabase,
 }) => {
   const navigate = useNavigate();
   const { toggleTheme } = useTheme();
@@ -102,6 +112,11 @@ const AppLayout: React.FC<AppLayoutProps> = ({
         availableAccounts={availableAccounts}
         onSwitchAccount={onSwitchAccount}
         chipLoading={chipLoading}
+        pgSchema={pgSchema}
+        activePgTable={activePgTable}
+        onPgTableSelect={onPgTableSelect}
+        pgDatabases={pgDatabases}
+        onSwitchPgDatabase={onSwitchPgDatabase}
       />
       <div className="qp-main">
         <AppTopBar

--- a/frontend/components/AppLayout.tsx
+++ b/frontend/components/AppLayout.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useTheme } from '../contexts/ThemeContext';
 import AppSidebar from './AppSidebar';
 import AppTopBar from './AppTopBar';
 import CommandPalette from './CommandPalette';
+import { savedQueriesTarget } from './UserMenuButton';
 import { CollectionSummary, DbInfo, CosmosDBAccount } from '../types';
 
 interface AppLayoutProps {
@@ -52,6 +53,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({
   onPgTableSelect,
 }) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { toggleTheme } = useTheme();
   const [paletteOpen, setPaletteOpen] = useState(false);
 
@@ -76,7 +78,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({
           case '2': e.preventDefault(); setPaletteOpen(false); if (explorerHref) navigate(explorerHref); return;
           case '3': e.preventDefault(); setPaletteOpen(false); navigate('/analytics'); return;
           case '4': e.preventDefault(); setPaletteOpen(false); navigate('/audit'); return;
-          case 'S': case 's': e.preventDefault(); setPaletteOpen(false); navigate('/query-generator?panel=saved'); return;
+          case 'S': case 's': e.preventDefault(); setPaletteOpen(false); navigate(savedQueriesTarget(location.pathname)); return;
         }
       } else {
         if (e.key === 'n' || e.key === 'N') {
@@ -89,7 +91,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({
     };
     window.addEventListener('keydown', handle);
     return () => window.removeEventListener('keydown', handle);
-  }, [navigate, explorerHref, onNewQuery, toggleTheme]);
+  }, [navigate, location.pathname, explorerHref, onNewQuery, toggleTheme]);
 
   return (
     <div className="qp-app">

--- a/frontend/components/AppLayout.tsx
+++ b/frontend/components/AppLayout.tsx
@@ -25,10 +25,8 @@ interface AppLayoutProps {
   onSwitchAccount?: (account: CosmosDBAccount) => void;
   chipLoading?: boolean;
   pgSchema?: { schema: string; tables: { name: string; rowEstimate: number }[] }[];
-  activePgTable?: string;
-  onPgTableSelect?: (schema: string, table: string) => void;
-  pgDatabases?: string[];
-  onSwitchPgDatabase?: (db: string) => void;
+  activePgTables?: string[];
+  onPgTableSelect?: (schema: string, table: string, ev?: { ctrlKey?: boolean; metaKey?: boolean }) => void;
 }
 
 const AppLayout: React.FC<AppLayoutProps> = ({
@@ -50,10 +48,8 @@ const AppLayout: React.FC<AppLayoutProps> = ({
   onSwitchAccount,
   chipLoading,
   pgSchema,
-  activePgTable,
+  activePgTables,
   onPgTableSelect,
-  pgDatabases,
-  onSwitchPgDatabase,
 }) => {
   const navigate = useNavigate();
   const { toggleTheme } = useTheme();
@@ -113,10 +109,8 @@ const AppLayout: React.FC<AppLayoutProps> = ({
         onSwitchAccount={onSwitchAccount}
         chipLoading={chipLoading}
         pgSchema={pgSchema}
-        activePgTable={activePgTable}
+        activePgTables={activePgTables}
         onPgTableSelect={onPgTableSelect}
-        pgDatabases={pgDatabases}
-        onSwitchPgDatabase={onSwitchPgDatabase}
       />
       <div className="qp-main">
         <AppTopBar

--- a/frontend/components/AppLayout.tsx
+++ b/frontend/components/AppLayout.tsx
@@ -28,6 +28,7 @@ interface AppLayoutProps {
   pgSchema?: { schema: string; tables: { name: string; rowEstimate: number }[] }[];
   activePgTables?: string[];
   onPgTableSelect?: (schema: string, table: string, ev?: { ctrlKey?: boolean; metaKey?: boolean }) => void;
+  pgSchemaLoading?: boolean;
 }
 
 const AppLayout: React.FC<AppLayoutProps> = ({
@@ -51,6 +52,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({
   pgSchema,
   activePgTables,
   onPgTableSelect,
+  pgSchemaLoading,
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -113,6 +115,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({
         pgSchema={pgSchema}
         activePgTables={activePgTables}
         onPgTableSelect={onPgTableSelect}
+        pgSchemaLoading={pgSchemaLoading}
       />
       <div className="qp-main">
         <AppTopBar

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { CollectionSummary, DbInfo, CosmosDBAccount } from '../types';
 import { API_BASE_URL } from '../app.config';
 import { useRoles } from '../hooks/useRoles';
-import { getAuthenticatedToken, listPostgresServers, PostgresServer } from '../services/dbService';
+import { getAuthenticatedToken, getAzureCosmosAccounts, listPostgresServers, PostgresServer } from '../services/dbService';
 
 interface AppSidebarProps {
   accountName?: string;
@@ -20,6 +20,13 @@ interface AppSidebarProps {
   availableAccounts?: CosmosDBAccount[];
   onSwitchAccount?: (account: CosmosDBAccount) => void;
   chipLoading?: boolean;
+  // PostgreSQL workspace: table tree + database switching live in the sidebar,
+  // mirroring how Cosmos collections do.
+  pgSchema?: { schema: string; tables: { name: string; rowEstimate: number }[] }[];
+  activePgTable?: string; // "schema.table"
+  onPgTableSelect?: (schema: string, table: string) => void;
+  pgDatabases?: string[];
+  onSwitchPgDatabase?: (db: string) => void;
 }
 
 type NavItem =
@@ -82,13 +89,20 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   availableAccounts,
   onSwitchAccount,
   chipLoading,
+  pgSchema,
+  activePgTable,
+  onPgTableSelect,
+  pgDatabases,
+  onSwitchPgDatabase,
 }) => {
   const location = useLocation();
   const navigate = useNavigate();
+  const isPg = location.pathname.startsWith('/postgres');
   const { can } = useRoles();
   const isAdmin = can('system:admin');
   const [showDbPicker, setShowDbPicker] = useState(false);
   const [pgServers, setPgServers] = useState<PostgresServer[]>([]);
+  const [cosmosAccounts, setCosmosAccounts] = useState<CosmosDBAccount[]>([]);
   const [latencyMs, setLatencyMs] = useState<number | null>(null);
 
   useEffect(() => {
@@ -96,6 +110,11 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
       .then((token) => listPostgresServers(token))
       .then(setPgServers)
       .catch(() => { /* best-effort; absence just hides the PostgreSQL group */ });
+    // Fetch Cosmos accounts too, so the account switcher is available from any
+    // workspace (including PostgreSQL), not just Cosmos pages that pass them in.
+    getAzureCosmosAccounts()
+      .then(setCosmosAccounts)
+      .catch(() => { /* best-effort; absence just hides the Cosmos group */ });
   }, []);
   const [collectionSort, setCollectionSort] = useState<'name_asc' | 'name_desc' | 'count_desc' | 'count_asc' | 'findings_desc' | 'findings_asc'>('name_asc');
   const chipRef = useRef<HTMLDivElement>(null);
@@ -130,6 +149,28 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   const explorerHref = accountId && databaseName
     ? `/data-explorer/${encodeURIComponent(accountId)}/${encodeURIComponent(databaseName)}`
     : null;
+
+  // In a PG workspace the sidebar's own listPostgresServers fetch can lose the
+  // race with the page's OBO calls (error swallowed above), so fall back to the
+  // current server we already know — keeps the PostgreSQL group consistent with
+  // the Cosmos workspace, which always shows it.
+  const pgServerList = React.useMemo(() => {
+    if (!isPg || !accountId || !accountName || pgServers.some((s) => s.id === accountId)) {
+      return pgServers;
+    }
+    return [{ id: accountId, name: accountName, fqdn: '' }, ...pgServers];
+  }, [isPg, accountId, accountName, pgServers]);
+
+  // Cosmos accounts: the page passes them on Cosmos pages; otherwise fall back to
+  // the sidebar's own fetch so the switcher is present in the PG workspace too.
+  const accountList = availableAccounts && availableAccounts.length > 0 ? availableAccounts : cosmosAccounts;
+
+  const showAccounts = accountList.length > 0;
+  const showDbs = !!availableDbs && availableDbs.length > 1;
+  const showPgServers = pgServerList.length > 0;
+  const showPgDbs = isPg && !!pgDatabases && pgDatabases.length > 0;
+
+  const hasPicker = showAccounts || showDbs || showPgServers || showPgDbs;
 
   const isActive = (href: string, matchPrefix?: boolean) => {
     if (matchPrefix) return location.pathname.startsWith(href);
@@ -167,11 +208,11 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
           ) : (
             <>
               <div
-                onClick={() => ((availableAccounts && availableAccounts.length > 1) || (availableDbs && availableDbs.length > 1) || pgServers.length > 0) ? setShowDbPicker(v => !v) : undefined}
+                onClick={() => hasPicker ? setShowDbPicker(v => !v) : undefined}
                 style={{
                   display: 'flex', alignItems: 'center', gap: 7,
                   padding: '5px 9px', background: 'var(--soft)', borderRadius: 7,
-                  cursor: ((availableAccounts && availableAccounts.length > 1) || (availableDbs && availableDbs.length > 1) || pgServers.length > 0) ? 'pointer' : 'default',
+                  cursor: hasPicker ? 'pointer' : 'default',
                 }}
               >
                 <span style={{ width: 14, height: 14, borderRadius: 4, background: '#1d6cf2', flexShrink: 0 }} />
@@ -185,7 +226,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                     </div>
                   )}
                 </div>
-                {((availableAccounts && availableAccounts.length > 1) || (availableDbs && availableDbs.length > 1)) && (
+                {hasPicker && (
                   <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" style={{ color: 'var(--muted)', flexShrink: 0 }}>
                     <path d="M4 6l4 4 4-4"/>
                   </svg>
@@ -198,17 +239,22 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                   background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 8,
                   boxShadow: '0 4px 16px rgba(0,0,0,0.10)', overflow: 'hidden',
                 }}>
-                  {availableAccounts && availableAccounts.length > 1 && (
+                  {showAccounts && (
                     <>
                       <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
                         Cosmos account
                       </div>
-                      {availableAccounts.map(acc => {
+                      {accountList.map(acc => {
                         const isCurrent = acc.id === accountId;
                         return (
                           <button
                             key={acc.id}
-                            onClick={() => { if (!isCurrent) { setShowDbPicker(false); onSwitchAccount?.(acc); } }}
+                            onClick={() => {
+                              if (isCurrent) return;
+                              setShowDbPicker(false);
+                              if (onSwitchAccount) onSwitchAccount(acc);
+                              else navigate('/query-generator', { state: { preselectedAccountId: acc.id, preselectedAccountName: acc.name } });
+                            }}
                             style={{
                               width: '100%', display: 'flex', alignItems: 'center', gap: 8,
                               padding: '7px 10px', border: 'none', textAlign: 'left',
@@ -232,10 +278,10 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                       })}
                     </>
                   )}
-                  {availableAccounts && availableAccounts.length > 1 && availableDbs && availableDbs.length > 1 && (
+                  {showAccounts && showDbs && (
                     <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
                   )}
-                  {availableDbs && availableDbs.length > 1 && (
+                  {showDbs && (
                     <>
                       <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
                         Database
@@ -270,15 +316,15 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                       })}
                     </>
                   )}
-                  {pgServers.length > 0 && (
+                  {showPgServers && (
                     <>
-                      {((availableAccounts && availableAccounts.length > 1) || (availableDbs && availableDbs.length > 1)) && (
+                      {(showAccounts || showDbs) && (
                         <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
                       )}
                       <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
                         PostgreSQL
                       </div>
-                      {pgServers.map(srv => {
+                      {pgServerList.map(srv => {
                         const isCurrent = srv.id === accountId;
                         return (
                           <button
@@ -297,6 +343,45 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                           >
                             <span style={{ width: 10, height: 10, borderRadius: 3, background: isCurrent ? '#1d6cf2' : 'var(--muted)', flexShrink: 0 }} />
                             <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{srv.name}</span>
+                            {isCurrent && (
+                              <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ color: 'var(--accent)', flexShrink: 0 }}>
+                                <path d="M3 8l4 4 6-6"/>
+                              </svg>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </>
+                  )}
+                  {showPgDbs && (
+                    <>
+                      {(showAccounts || showDbs || showPgServers) && (
+                        <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
+                      )}
+                      <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
+                        Database
+                      </div>
+                      {pgDatabases.map(db => {
+                        const isCurrent = db === databaseName;
+                        return (
+                          <button
+                            key={db}
+                            onClick={() => { setShowDbPicker(false); if (!isCurrent) onSwitchPgDatabase?.(db); }}
+                            style={{
+                              width: '100%', display: 'flex', alignItems: 'center', gap: 8,
+                              padding: '7px 10px', border: 'none', textAlign: 'left',
+                              cursor: isCurrent ? 'default' : 'pointer',
+                              background: isCurrent ? 'var(--accent-soft)' : 'transparent',
+                              color: isCurrent ? 'var(--accent)' : 'var(--fg)',
+                              fontSize: 12.5, fontFamily: 'var(--font-mono)',
+                            }}
+                            onMouseEnter={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                            onMouseLeave={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                          >
+                            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" style={{ color: isCurrent ? 'var(--accent)' : 'var(--muted)', flexShrink: 0 }}>
+                              <ellipse cx="8" cy="4" rx="6" ry="2"/><path d="M2 4v8c0 1.1 2.7 2 6 2s6-.9 6-2V4M2 8c0 1.1 2.7 2 6 2s6-.9 6-2"/>
+                            </svg>
+                            <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{db}</span>
                             {isCurrent && (
                               <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ color: 'var(--accent)', flexShrink: 0 }}>
                                 <path d="M3 8l4 4 6-6"/>
@@ -350,6 +435,20 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                 {iconSpan}
                 {item.label}
               </button>
+            );
+          }
+
+          // PostgreSQL workspace has no Cosmos Explorer / Analytics.
+          if (isPg && (item.label === 'Explorer' || item.label === 'Analytics')) {
+            return (
+              <span
+                key={item.label}
+                style={{ ...style, opacity: 0.4, cursor: 'not-allowed' }}
+                title="Not available for PostgreSQL"
+              >
+                {iconSpan}
+                {item.label}
+              </span>
             );
           }
 
@@ -509,6 +608,61 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                 </button>
               );
             })}
+          </div>
+        </div>
+      )}
+
+      {pgSchema && pgSchema.length > 0 && (
+        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', marginTop: 12 }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+            padding: '0 8px 6px 8px',
+            fontSize: 10.5, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.08em',
+            color: 'var(--muted)',
+          }}>
+            <span>Tables <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10 }}>
+              {pgSchema.reduce((n, g) => n + g.tables.length, 0)}
+            </span></span>
+          </div>
+          <div style={{ flex: 1, overflowY: 'auto', padding: '0 8px' }}>
+            {pgSchema.map((g) => (
+              <div key={g.schema} style={{ marginBottom: 8 }}>
+                {pgSchema.length > 1 && (
+                  <div style={{ fontSize: 10, color: 'var(--muted)', fontWeight: 500, padding: '2px 6px', fontFamily: 'var(--font-mono)' }}>{g.schema}</div>
+                )}
+                {g.tables.map((t) => {
+                  const active = activePgTable === `${g.schema}.${t.name}`;
+                  return (
+                    <button
+                      key={t.name}
+                      onClick={() => onPgTableSelect?.(g.schema, t.name)}
+                      style={{
+                        width: '100%', display: 'flex', alignItems: 'center',
+                        padding: '5px 8px', borderRadius: 6, border: 'none', cursor: 'pointer',
+                        background: active ? 'var(--accent-soft)' : 'transparent',
+                        color: active ? 'var(--fg)' : 'var(--muted)',
+                        fontSize: 12.5, fontFamily: 'var(--font-body)', marginBottom: 1,
+                        textAlign: 'left', transition: 'background 0.1s',
+                      }}
+                      onMouseEnter={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                      onMouseLeave={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                    >
+                      <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" style={{ marginRight: 7, flexShrink: 0, color: active ? 'var(--accent)' : 'var(--muted)' }}>
+                        <rect x="2" y="3" width="12" height="10" rx="1.5"/><path d="M2 6.5h12M6 6.5V13"/>
+                      </svg>
+                      <span style={{
+                        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1,
+                        fontFamily: 'var(--font-mono)', fontSize: 11.5,
+                      }}>{t.name}</span>
+                      <span style={{
+                        fontSize: 10, color: 'var(--muted)', flexShrink: 0, marginLeft: 4,
+                        fontFamily: 'var(--font-mono)',
+                      }}>{t.rowEstimate.toLocaleString()}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
           </div>
         </div>
       )}

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -279,47 +279,9 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                       })}
                     </>
                   )}
-                  {showAccounts && showDbs && (
-                    <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
-                  )}
-                  {showDbs && (
-                    <>
-                      <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
-                        Database
-                      </div>
-                      {availableDbs.map(db => {
-                        const isCurrent = db.name === databaseName;
-                        return (
-                          <button
-                            key={db.name}
-                            onClick={() => { if (!isCurrent) { setShowDbPicker(false); onSwitchDatabase?.(db); } }}
-                            style={{
-                              width: '100%', display: 'flex', alignItems: 'center', gap: 8,
-                              padding: '7px 10px', border: 'none', cursor: 'pointer', textAlign: 'left',
-                              background: isCurrent ? 'var(--accent-soft)' : 'transparent',
-                              color: isCurrent ? 'var(--accent)' : 'var(--fg)',
-                              fontSize: 12.5, fontFamily: 'var(--font-mono)',
-                            }}
-                            onMouseEnter={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
-                            onMouseLeave={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
-                          >
-                            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" style={{ color: isCurrent ? 'var(--accent)' : 'var(--muted)', flexShrink: 0 }}>
-                              <ellipse cx="8" cy="4" rx="6" ry="2"/><path d="M2 4v8c0 1.1 2.7 2 6 2s6-.9 6-2V4M2 8c0 1.1 2.7 2 6 2s6-.9 6-2"/>
-                            </svg>
-                            {db.name}
-                            {isCurrent && (
-                              <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ marginLeft: 'auto', color: 'var(--accent)', flexShrink: 0 }}>
-                                <path d="M3 8l4 4 6-6"/>
-                              </svg>
-                            )}
-                          </button>
-                        );
-                      })}
-                    </>
-                  )}
                   {showPgServers && (
                     <>
-                      {(showAccounts || showDbs) && (
+                      {showAccounts && (
                         <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
                       )}
                       <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
@@ -346,6 +308,44 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                             <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{srv.name}</span>
                             {isCurrent && (
                               <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ color: 'var(--accent)', flexShrink: 0 }}>
+                                <path d="M3 8l4 4 6-6"/>
+                              </svg>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </>
+                  )}
+                  {showDbs && (
+                    <>
+                      {(showAccounts || showPgServers) && (
+                        <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
+                      )}
+                      <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
+                        Database
+                      </div>
+                      {availableDbs.map(db => {
+                        const isCurrent = db.name === databaseName;
+                        return (
+                          <button
+                            key={db.name}
+                            onClick={() => { if (!isCurrent) { setShowDbPicker(false); onSwitchDatabase?.(db); } }}
+                            style={{
+                              width: '100%', display: 'flex', alignItems: 'center', gap: 8,
+                              padding: '7px 10px', border: 'none', cursor: 'pointer', textAlign: 'left',
+                              background: isCurrent ? 'var(--accent-soft)' : 'transparent',
+                              color: isCurrent ? 'var(--accent)' : 'var(--fg)',
+                              fontSize: 12.5, fontFamily: 'var(--font-mono)',
+                            }}
+                            onMouseEnter={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                            onMouseLeave={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                          >
+                            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" style={{ color: isCurrent ? 'var(--accent)' : 'var(--muted)', flexShrink: 0 }}>
+                              <ellipse cx="8" cy="4" rx="6" ry="2"/><path d="M2 4v8c0 1.1 2.7 2 6 2s6-.9 6-2V4M2 8c0 1.1 2.7 2 6 2s6-.9 6-2"/>
+                            </svg>
+                            {db.name}
+                            {isCurrent && (
+                              <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ marginLeft: 'auto', color: 'var(--accent)', flexShrink: 0 }}>
                                 <path d="M3 8l4 4 6-6"/>
                               </svg>
                             )}

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -179,6 +179,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   // Workspace paths are /postgres/:id[/db]; the -explorer/-audit variants don't
   // start with '/postgres/' so they're correctly excluded here.
   const isPgWorkspace = isPg && location.pathname.startsWith('/postgres/');
+  const isAdminPage = location.pathname.startsWith('/admin');
 
   // In a PG workspace the sidebar's own listPostgresServers fetch can lose the
   // race with the page's OBO calls (error swallowed above), so fall back to the
@@ -438,6 +439,21 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
               {item.icon}
             </span>
           );
+
+          // Role management is a standalone, connection-less page — the
+          // connection-scoped tabs don't apply here.
+          if (isAdminPage && (item.label === 'Workspace' || item.label === 'Audit')) {
+            return (
+              <span
+                key={item.label}
+                style={{ ...style, opacity: 0.4, cursor: 'not-allowed' }}
+                title="Not available on the role management page"
+              >
+                {iconSpan}
+                {item.label}
+              </span>
+            );
+          }
 
           if (item.panel) {
             return (

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -168,7 +168,12 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
     : isPg
       ? `/postgres-explorer/${encodeURIComponent(accountId)}/${encodeURIComponent(databaseName)}`
       : `/data-explorer/${encodeURIComponent(accountId)}/${encodeURIComponent(databaseName)}`;
+  const pgAuditHref = isPg && accountId ? `/postgres-audit/${encodeURIComponent(accountId)}` : null;
   const isPgExplorer = location.pathname.startsWith('/postgres-explorer');
+  const isPgAudit = location.pathname.startsWith('/postgres-audit');
+  // Workspace paths are /postgres/:id[/db]; the -explorer/-audit variants don't
+  // start with '/postgres/' so they're correctly excluded here.
+  const isPgWorkspace = isPg && location.pathname.startsWith('/postgres/');
 
   // In a PG workspace the sidebar's own listPostgresServers fetch can lose the
   // race with the page's OBO calls (error swallowed above), so fall back to the
@@ -310,7 +315,16 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                         return (
                           <button
                             key={srv.id}
-                            onClick={() => { setShowDbPicker(false); if (!isCurrent) navigate(`/postgres/${encodeURIComponent(srv.id)}`); }}
+                            onClick={() => {
+                              setShowDbPicker(false);
+                              if (isCurrent) return;
+                              // Switching server keeps you in the current section
+                              // (audit / explorer), not always the workspace.
+                              const base = (isPgAudit || location.pathname === '/audit')
+                                ? '/postgres-audit'
+                                : isPgExplorer ? '/postgres-explorer' : '/postgres';
+                              navigate(`${base}/${encodeURIComponent(srv.id)}`);
+                            }}
                             style={{
                               width: '100%', display: 'flex', alignItems: 'center', gap: 8,
                               padding: '7px 10px', border: 'none', textAlign: 'left',
@@ -399,11 +413,14 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
           let resolvedHref = item.href;
           if (item.label === 'Explorer') resolvedHref = explorerHref ?? item.href;
           else if (isPg && item.label === 'Workspace') resolvedHref = pgWorkspaceHref ?? item.href;
-          const active = item.label === 'Workspace'
-            ? (isPg ? !isPgExplorer : (resolvedHref ? isActive(resolvedHref, item.matchPrefix) : false))
-            : item.label === 'Explorer' && isPg
+          else if (isPg && item.label === 'Audit') resolvedHref = pgAuditHref ?? item.href;
+          const active = isPg && item.label === 'Workspace'
+            ? isPgWorkspace
+            : isPg && item.label === 'Explorer'
               ? isPgExplorer
-              : (resolvedHref ? isActive(resolvedHref, item.matchPrefix) : false);
+              : isPg && item.label === 'Audit'
+                ? isPgAudit
+                : (resolvedHref ? isActive(resolvedHref, item.matchPrefix) : false);
           const style: React.CSSProperties = {
             ...itemBase,
             color: active ? 'var(--fg)' : 'var(--muted)',

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -374,7 +374,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
           if (item.label === 'Explorer') resolvedHref = explorerHref ?? item.href;
           else if (isPg && item.label === 'Workspace') resolvedHref = pgWorkspaceHref ?? item.href;
           const active = item.label === 'Workspace'
-            ? (isPg ? isPg && !isPgExplorer : (resolvedHref ? isActive(resolvedHref, item.matchPrefix) : false))
+            ? (isPg ? !isPgExplorer : (resolvedHref ? isActive(resolvedHref, item.matchPrefix) : false))
             : item.label === 'Explorer' && isPg
               ? isPgExplorer
               : (resolvedHref ? isActive(resolvedHref, item.matchPrefix) : false);

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -163,11 +163,16 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   const pgWorkspaceHref = isPg && accountId
     ? `/postgres/${encodeURIComponent(accountId)}${databaseName ? '/' + encodeURIComponent(databaseName) : ''}`
     : null;
-  const explorerHref = !accountId || !databaseName
-    ? null
-    : isPg
-      ? `/postgres-explorer/${encodeURIComponent(accountId)}/${encodeURIComponent(databaseName)}`
-      : `/data-explorer/${encodeURIComponent(accountId)}/${encodeURIComponent(databaseName)}`;
+  // PG explorer works from just the server (the page redirects to the first
+  // database), so it stays enabled on pages without a database (e.g. audit).
+  // Cosmos still needs both account + database.
+  const explorerHref = isPg
+    ? (accountId
+      ? `/postgres-explorer/${encodeURIComponent(accountId)}${databaseName ? '/' + encodeURIComponent(databaseName) : ''}`
+      : null)
+    : (accountId && databaseName
+      ? `/data-explorer/${encodeURIComponent(accountId)}/${encodeURIComponent(databaseName)}`
+      : null);
   const pgAuditHref = isPg && accountId ? `/postgres-audit/${encodeURIComponent(accountId)}` : null;
   const isPgExplorer = location.pathname.startsWith('/postgres-explorer');
   const isPgAudit = location.pathname.startsWith('/postgres-audit');

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -25,7 +25,18 @@ interface AppSidebarProps {
   pgSchema?: { schema: string; tables: { name: string; rowEstimate: number }[] }[];
   activePgTables?: string[]; // ["schema.table", ...]
   onPgTableSelect?: (schema: string, table: string, ev?: { ctrlKey?: boolean; metaKey?: boolean }) => void;
+  // True while the PG schema/tables (and thus the switched-to database) are
+  // loading — drives the small spinners in the chip dropdown + tables panel.
+  pgSchemaLoading?: boolean;
 }
+
+// Small spinner reused by the PG database/table loading indicators.
+const MiniSpinner: React.FC<{ size?: number }> = ({ size = 11 }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.7"
+    style={{ animation: 'ws-spin 0.7s linear infinite', flexShrink: 0, color: 'var(--accent)' }}>
+    <path d="M8 2a6 6 0 1 0 6 6" />
+  </svg>
+);
 
 type NavItem =
   | { label: string; href: string; matchPrefix?: boolean; panel?: never; icon: React.ReactNode }
@@ -90,6 +101,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   pgSchema,
   activePgTables,
   onPgTableSelect,
+  pgSchemaLoading,
 }) => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -329,7 +341,13 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                         return (
                           <button
                             key={db.name}
-                            onClick={() => { if (!isCurrent) { setShowDbPicker(false); onSwitchDatabase?.(db); } }}
+                            onClick={() => {
+                              if (isCurrent) return;
+                              // Keep the picker open during a PG switch so its
+                              // spinner is visible; Cosmos (no loading flag) closes.
+                              if (pgSchemaLoading === undefined) setShowDbPicker(false);
+                              onSwitchDatabase?.(db);
+                            }}
                             style={{
                               width: '100%', display: 'flex', alignItems: 'center', gap: 8,
                               padding: '7px 10px', border: 'none', cursor: 'pointer', textAlign: 'left',
@@ -344,11 +362,13 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                               <ellipse cx="8" cy="4" rx="6" ry="2"/><path d="M2 4v8c0 1.1 2.7 2 6 2s6-.9 6-2V4M2 8c0 1.1 2.7 2 6 2s6-.9 6-2"/>
                             </svg>
                             {db.name}
-                            {isCurrent && (
+                            {isCurrent && pgSchemaLoading ? (
+                              <span style={{ marginLeft: 'auto', display: 'flex' }}><MiniSpinner /></span>
+                            ) : isCurrent ? (
                               <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ marginLeft: 'auto', color: 'var(--accent)', flexShrink: 0 }}>
                                 <path d="M3 8l4 4 6-6"/>
                               </svg>
-                            )}
+                            ) : null}
                           </button>
                         );
                       })}
@@ -580,7 +600,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
         </div>
       )}
 
-      {pgSchema && pgSchema.length > 0 && (
+      {((pgSchema && pgSchema.length > 0) || pgSchemaLoading) && (
         <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', marginTop: 12 }}>
           <div style={{
             display: 'flex', alignItems: 'center', justifyContent: 'space-between',
@@ -588,14 +608,19 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
             fontSize: 10.5, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.08em',
             color: 'var(--muted)',
           }}>
-            <span>Tables <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10 }}>
-              {pgSchema.reduce((n, g) => n + g.tables.length, 0)}
-            </span></span>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>Tables {pgSchemaLoading
+              ? <MiniSpinner size={10} />
+              : <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10 }}>{(pgSchema ?? []).reduce((n, g) => n + g.tables.length, 0)}</span>}
+            </span>
           </div>
           <div style={{ flex: 1, overflowY: 'auto', padding: '0 8px' }}>
-            {pgSchema.map((g) => (
+            {pgSchemaLoading ? (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px', fontSize: 12, color: 'var(--muted)' }}>
+                <MiniSpinner /> Loading tables…
+              </div>
+            ) : (pgSchema ?? []).map((g) => (
               <div key={g.schema} style={{ marginBottom: 8 }}>
-                {pgSchema.length > 1 && (
+                {(pgSchema?.length ?? 0) > 1 && (
                   <div style={{ fontSize: 10, color: 'var(--muted)', fontWeight: 500, padding: '2px 6px', fontFamily: 'var(--font-mono)' }}>{g.schema}</div>
                 )}
                 {g.tables.map((t) => {

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -651,10 +651,12 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                         overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1,
                         fontFamily: 'var(--font-mono)', fontSize: 11.5,
                       }}>{t.name}</span>
-                      <span style={{
-                        fontSize: 10, color: 'var(--muted)', flexShrink: 0, marginLeft: 4,
-                        fontFamily: 'var(--font-mono)',
-                      }}>{t.rowEstimate.toLocaleString()}</span>
+                      <span
+                        title={t.rowEstimate < 0 ? 'Row count unknown — table not analyzed yet (run ANALYZE)' : `~${t.rowEstimate.toLocaleString()} rows (estimate)`}
+                        style={{
+                          fontSize: 10, color: 'var(--muted)', flexShrink: 0, marginLeft: 4,
+                          fontFamily: 'var(--font-mono)',
+                        }}>{t.rowEstimate < 0 ? '—' : t.rowEstimate.toLocaleString()}</span>
                     </button>
                   );
                 })}

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { CollectionSummary, DbInfo, CosmosDBAccount } from '../types';
 import { API_BASE_URL } from '../app.config';
 import { useRoles } from '../hooks/useRoles';
+import { getAuthenticatedToken, listPostgresServers, PostgresServer } from '../services/dbService';
 
 interface AppSidebarProps {
   accountName?: string;
@@ -87,7 +88,15 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   const { can } = useRoles();
   const isAdmin = can('system:admin');
   const [showDbPicker, setShowDbPicker] = useState(false);
+  const [pgServers, setPgServers] = useState<PostgresServer[]>([]);
   const [latencyMs, setLatencyMs] = useState<number | null>(null);
+
+  useEffect(() => {
+    getAuthenticatedToken()
+      .then((token) => listPostgresServers(token))
+      .then(setPgServers)
+      .catch(() => { /* best-effort; absence just hides the PostgreSQL group */ });
+  }, []);
   const [collectionSort, setCollectionSort] = useState<'name_asc' | 'name_desc' | 'count_desc' | 'count_asc' | 'findings_desc' | 'findings_asc'>('name_asc');
   const chipRef = useRef<HTMLDivElement>(null);
 
@@ -158,11 +167,11 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
           ) : (
             <>
               <div
-                onClick={() => ((availableAccounts && availableAccounts.length > 1) || (availableDbs && availableDbs.length > 1)) ? setShowDbPicker(v => !v) : undefined}
+                onClick={() => ((availableAccounts && availableAccounts.length > 1) || (availableDbs && availableDbs.length > 1) || pgServers.length > 0) ? setShowDbPicker(v => !v) : undefined}
                 style={{
                   display: 'flex', alignItems: 'center', gap: 7,
                   padding: '5px 9px', background: 'var(--soft)', borderRadius: 7,
-                  cursor: ((availableAccounts && availableAccounts.length > 1) || (availableDbs && availableDbs.length > 1)) ? 'pointer' : 'default',
+                  cursor: ((availableAccounts && availableAccounts.length > 1) || (availableDbs && availableDbs.length > 1) || pgServers.length > 0) ? 'pointer' : 'default',
                 }}
               >
                 <span style={{ width: 14, height: 14, borderRadius: 4, background: '#1d6cf2', flexShrink: 0 }} />
@@ -253,6 +262,43 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                             {db.name}
                             {isCurrent && (
                               <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ marginLeft: 'auto', color: 'var(--accent)', flexShrink: 0 }}>
+                                <path d="M3 8l4 4 6-6"/>
+                              </svg>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </>
+                  )}
+                  {pgServers.length > 0 && (
+                    <>
+                      {((availableAccounts && availableAccounts.length > 1) || (availableDbs && availableDbs.length > 1)) && (
+                        <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
+                      )}
+                      <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
+                        PostgreSQL
+                      </div>
+                      {pgServers.map(srv => {
+                        const isCurrent = srv.id === accountId;
+                        return (
+                          <button
+                            key={srv.id}
+                            onClick={() => { setShowDbPicker(false); if (!isCurrent) navigate(`/postgres/${encodeURIComponent(srv.id)}`); }}
+                            style={{
+                              width: '100%', display: 'flex', alignItems: 'center', gap: 8,
+                              padding: '7px 10px', border: 'none', textAlign: 'left',
+                              cursor: isCurrent ? 'default' : 'pointer',
+                              background: isCurrent ? 'var(--accent-soft)' : 'transparent',
+                              color: isCurrent ? 'var(--accent)' : 'var(--fg)',
+                              fontSize: 12.5, fontFamily: 'var(--font-body)',
+                            }}
+                            onMouseEnter={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
+                            onMouseLeave={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                          >
+                            <span style={{ width: 10, height: 10, borderRadius: 3, background: isCurrent ? '#1d6cf2' : 'var(--muted)', flexShrink: 0 }} />
+                            <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{srv.name}</span>
+                            {isCurrent && (
+                              <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ color: 'var(--accent)', flexShrink: 0 }}>
                                 <path d="M3 8l4 4 6-6"/>
                               </svg>
                             )}

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -2,7 +2,6 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { CollectionSummary, DbInfo, CosmosDBAccount } from '../types';
 import { API_BASE_URL } from '../app.config';
-import { useRoles } from '../hooks/useRoles';
 import { getAuthenticatedToken, getAzureCosmosAccounts, listPostgresServers, PostgresServer } from '../services/dbService';
 
 interface AppSidebarProps {
@@ -74,6 +73,15 @@ const NAV_ITEMS: NavItem[] = [
       </svg>
     ),
   },
+  {
+    label: 'Audit',
+    href: '/audit',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+        <path d="M4 2h6l3 3v9H4z"/><path d="M6 7.5h5M6 10.5h5"/>
+      </svg>
+    ),
+  },
 ];
 
 const itemBase: React.CSSProperties = {
@@ -106,8 +114,6 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   const location = useLocation();
   const navigate = useNavigate();
   const isPg = location.pathname.startsWith('/postgres');
-  const { can } = useRoles();
-  const isAdmin = can('system:admin');
   const [showDbPicker, setShowDbPicker] = useState(false);
   const [pgServers, setPgServers] = useState<PostgresServer[]>([]);
   const [cosmosAccounts, setCosmosAccounts] = useState<CosmosDBAccount[]>([]);
@@ -479,31 +485,6 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
             </Link>
           );
         })}
-
-        {isAdmin && (() => {
-          const active = location.pathname === '/admin';
-          return (
-            <Link
-              to="/admin"
-              style={{
-                ...itemBase,
-                color: active ? 'var(--fg)' : 'var(--muted)',
-                background: active ? 'var(--soft)' : 'transparent',
-                fontWeight: active ? 500 : 400,
-              }}
-              onMouseEnter={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
-              onMouseLeave={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
-            >
-              <span style={{ color: active ? 'var(--accent)' : 'var(--muted)', display: 'flex', flexShrink: 0 }}>
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
-                  <circle cx="8" cy="5" r="3"/>
-                  <path d="M2 14c0-3 2.7-5 6-5s6 2 6 5"/>
-                </svg>
-              </span>
-              Admin
-            </Link>
-          );
-        })()}
       </div>
 
       {collections && collections.length > 0 && (

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -23,10 +23,8 @@ interface AppSidebarProps {
   // PostgreSQL workspace: table tree + database switching live in the sidebar,
   // mirroring how Cosmos collections do.
   pgSchema?: { schema: string; tables: { name: string; rowEstimate: number }[] }[];
-  activePgTable?: string; // "schema.table"
-  onPgTableSelect?: (schema: string, table: string) => void;
-  pgDatabases?: string[];
-  onSwitchPgDatabase?: (db: string) => void;
+  activePgTables?: string[]; // ["schema.table", ...]
+  onPgTableSelect?: (schema: string, table: string, ev?: { ctrlKey?: boolean; metaKey?: boolean }) => void;
 }
 
 type NavItem =
@@ -90,10 +88,8 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   onSwitchAccount,
   chipLoading,
   pgSchema,
-  activePgTable,
+  activePgTables,
   onPgTableSelect,
-  pgDatabases,
-  onSwitchPgDatabase,
 }) => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -168,9 +164,8 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
   const showAccounts = accountList.length > 0;
   const showDbs = !!availableDbs && availableDbs.length > 1;
   const showPgServers = pgServerList.length > 0;
-  const showPgDbs = isPg && !!pgDatabases && pgDatabases.length > 0;
 
-  const hasPicker = showAccounts || showDbs || showPgServers || showPgDbs;
+  const hasPicker = showAccounts || showDbs || showPgServers;
 
   const isActive = (href: string, matchPrefix?: boolean) => {
     if (matchPrefix) return location.pathname.startsWith(href);
@@ -353,45 +348,6 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                       })}
                     </>
                   )}
-                  {showPgDbs && (
-                    <>
-                      {(showAccounts || showDbs || showPgServers) && (
-                        <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
-                      )}
-                      <div style={{ padding: '6px 10px 4px', fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', fontWeight: 500 }}>
-                        Database
-                      </div>
-                      {pgDatabases.map(db => {
-                        const isCurrent = db === databaseName;
-                        return (
-                          <button
-                            key={db}
-                            onClick={() => { setShowDbPicker(false); if (!isCurrent) onSwitchPgDatabase?.(db); }}
-                            style={{
-                              width: '100%', display: 'flex', alignItems: 'center', gap: 8,
-                              padding: '7px 10px', border: 'none', textAlign: 'left',
-                              cursor: isCurrent ? 'default' : 'pointer',
-                              background: isCurrent ? 'var(--accent-soft)' : 'transparent',
-                              color: isCurrent ? 'var(--accent)' : 'var(--fg)',
-                              fontSize: 12.5, fontFamily: 'var(--font-mono)',
-                            }}
-                            onMouseEnter={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'var(--soft)'; }}
-                            onMouseLeave={(e) => { if (!isCurrent) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
-                          >
-                            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" style={{ color: isCurrent ? 'var(--accent)' : 'var(--muted)', flexShrink: 0 }}>
-                              <ellipse cx="8" cy="4" rx="6" ry="2"/><path d="M2 4v8c0 1.1 2.7 2 6 2s6-.9 6-2V4M2 8c0 1.1 2.7 2 6 2s6-.9 6-2"/>
-                            </svg>
-                            <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{db}</span>
-                            {isCurrent && (
-                              <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" style={{ color: 'var(--accent)', flexShrink: 0 }}>
-                                <path d="M3 8l4 4 6-6"/>
-                              </svg>
-                            )}
-                          </button>
-                        );
-                      })}
-                    </>
-                  )}
                 </div>
               )}
             </>
@@ -409,7 +365,8 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
 
         {NAV_ITEMS.map((item) => {
           const resolvedHref = item.label === 'Explorer' ? (explorerHref ?? item.href) : item.href;
-          const active = resolvedHref ? isActive(resolvedHref, item.matchPrefix) : false;
+          // The PostgreSQL explorer is itself the workspace, so mark that tab active there.
+          const active = (isPg && item.label === 'Workspace') || (resolvedHref ? isActive(resolvedHref, item.matchPrefix) : false);
           const style: React.CSSProperties = {
             ...itemBase,
             color: active ? 'var(--fg)' : 'var(--muted)',
@@ -435,6 +392,17 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                 {iconSpan}
                 {item.label}
               </button>
+            );
+          }
+
+          // In the PG workspace the Workspace tab is the current page — show it
+          // selected and non-navigating (its href points at the Cosmos workspace).
+          if (isPg && item.label === 'Workspace') {
+            return (
+              <span key={item.label} style={{ ...style, cursor: 'default' }}>
+                {iconSpan}
+                {item.label}
+              </span>
             );
           }
 
@@ -631,11 +599,12 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
                   <div style={{ fontSize: 10, color: 'var(--muted)', fontWeight: 500, padding: '2px 6px', fontFamily: 'var(--font-mono)' }}>{g.schema}</div>
                 )}
                 {g.tables.map((t) => {
-                  const active = activePgTable === `${g.schema}.${t.name}`;
+                  const active = activePgTables?.includes(`${g.schema}.${t.name}`) ?? false;
                   return (
                     <button
                       key={t.name}
-                      onClick={() => onPgTableSelect?.(g.schema, t.name)}
+                      title="Click to open · ⌘/Ctrl-click to add for a cross-table query"
+                      onClick={(e) => onPgTableSelect?.(g.schema, t.name, { ctrlKey: e.ctrlKey, metaKey: e.metaKey })}
                       style={{
                         width: '100%', display: 'flex', alignItems: 'center',
                         padding: '5px 8px', borderRadius: 6, border: 'none', cursor: 'pointer',

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -142,9 +142,15 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
     return () => clearInterval(id);
   }, []);
 
-  const explorerHref = accountId && databaseName
-    ? `/data-explorer/${encodeURIComponent(accountId)}/${encodeURIComponent(databaseName)}`
+  const pgWorkspaceHref = isPg && accountId
+    ? `/postgres/${encodeURIComponent(accountId)}${databaseName ? '/' + encodeURIComponent(databaseName) : ''}`
     : null;
+  const explorerHref = !accountId || !databaseName
+    ? null
+    : isPg
+      ? `/postgres-explorer/${encodeURIComponent(accountId)}/${encodeURIComponent(databaseName)}`
+      : `/data-explorer/${encodeURIComponent(accountId)}/${encodeURIComponent(databaseName)}`;
+  const isPgExplorer = location.pathname.startsWith('/postgres-explorer');
 
   // In a PG workspace the sidebar's own listPostgresServers fetch can lose the
   // race with the page's OBO calls (error swallowed above), so fall back to the
@@ -364,9 +370,14 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
         }}>Workspace</div>
 
         {NAV_ITEMS.map((item) => {
-          const resolvedHref = item.label === 'Explorer' ? (explorerHref ?? item.href) : item.href;
-          // The PostgreSQL explorer is itself the workspace, so mark that tab active there.
-          const active = (isPg && item.label === 'Workspace') || (resolvedHref ? isActive(resolvedHref, item.matchPrefix) : false);
+          let resolvedHref = item.href;
+          if (item.label === 'Explorer') resolvedHref = explorerHref ?? item.href;
+          else if (isPg && item.label === 'Workspace') resolvedHref = pgWorkspaceHref ?? item.href;
+          const active = item.label === 'Workspace'
+            ? (isPg ? isPg && !isPgExplorer : (resolvedHref ? isActive(resolvedHref, item.matchPrefix) : false))
+            : item.label === 'Explorer' && isPg
+              ? isPgExplorer
+              : (resolvedHref ? isActive(resolvedHref, item.matchPrefix) : false);
           const style: React.CSSProperties = {
             ...itemBase,
             color: active ? 'var(--fg)' : 'var(--muted)',
@@ -395,19 +406,8 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
             );
           }
 
-          // In the PG workspace the Workspace tab is the current page — show it
-          // selected and non-navigating (its href points at the Cosmos workspace).
-          if (isPg && item.label === 'Workspace') {
-            return (
-              <span key={item.label} style={{ ...style, cursor: 'default' }}>
-                {iconSpan}
-                {item.label}
-              </span>
-            );
-          }
-
-          // PostgreSQL workspace has no Cosmos Explorer / Analytics.
-          if (isPg && (item.label === 'Explorer' || item.label === 'Analytics')) {
+          // PostgreSQL has no Analytics page.
+          if (isPg && item.label === 'Analytics') {
             return (
               <span
                 key={item.label}

--- a/frontend/components/CollectionActionPanel.tsx
+++ b/frontend/components/CollectionActionPanel.tsx
@@ -69,9 +69,10 @@ export const SchemaRenderer: React.FC<SchemaRendererProps> = ({ data, indent = 0
 interface CollectionActionPanelProps {
   info: CollectionInfo;
   onClose: () => void;
+  onSeedQuery?: (code: string) => void;
 }
 
-const CollectionActionPanel: React.FC<CollectionActionPanelProps> = ({ info, onClose }) => {
+const CollectionActionPanel: React.FC<CollectionActionPanelProps> = ({ info, onClose, onSeedQuery }) => {
   const [isSchemaOpen, setIsSchemaOpen] = useState(true);
 
   useEffect(() => { setIsSchemaOpen(true); }, [info.name]);
@@ -151,6 +152,18 @@ const CollectionActionPanel: React.FC<CollectionActionPanelProps> = ({ info, onC
           </div>
         )}
       </div>
+
+      {onSeedQuery && (
+        <button
+          onClick={() => onSeedQuery(`db['${info.name}'].find({}).limit(20)`)}
+          className="qa-btn"
+          style={{ alignSelf: 'flex-start', fontSize: 12, gap: 6, marginBottom: 8 }}
+          title={`Seed a starter query for ${info.name}`}
+        >
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><polygon points="4,2 14,8 4,14" /></svg>
+          Query collection
+        </button>
+      )}
 
       {/* Close / deselect */}
       <button

--- a/frontend/components/CommandPalette.tsx
+++ b/frontend/components/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { savedQueriesTarget } from './UserMenuButton';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
 import { useRoles } from '../hooks/useRoles';
@@ -64,6 +65,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
   onNewQuery,
 }) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { theme, toggleTheme } = useTheme();
   const { logout } = useUnifiedAuth();
   const { can } = useRoles();
@@ -168,7 +170,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
           <path d="M6 7h5M6 10h3" />
         </svg>
       ),
-      action: () => navigate('/query-generator?panel=saved'),
+      action: () => navigate(savedQueriesTarget(location.pathname)),
     });
 
     cmds.push({
@@ -268,7 +270,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
     }
 
     return cmds;
-  }, [navigate, explorerHref, databaseName, accountId, theme, toggleTheme, logout, canAudit, onNewQuery, availableDbs, availableAccounts, collections, onSwitchDatabase, onSwitchAccount, onCollectionSelect]);
+  }, [navigate, location.pathname, explorerHref, databaseName, accountId, theme, toggleTheme, logout, canAudit, onNewQuery, availableDbs, availableAccounts, collections, onSwitchDatabase, onSwitchAccount, onCollectionSelect]);
 
   const filtered = useMemo(() => {
     if (!query.trim()) return commands;

--- a/frontend/components/PgRowDrawer.tsx
+++ b/frontend/components/PgRowDrawer.tsx
@@ -38,8 +38,13 @@ const PgRowDrawer: React.FC<{
   onSave: (values: Record<string, unknown>) => void | Promise<void>;
   onDelete: () => void | Promise<void>;
 }> = ({ columns, pk, mode, row, onClose, onSave, onDelete }) => {
-  // Editable = every non-pk column (serial/default pks are filled by the DB).
-  const editable = useMemo(() => columns.filter((c) => !pk.includes(c.name)), [columns, pk]);
+  // On insert, PK columns are editable too — natural/text keys must be typed
+  // (serial ones can be left blank and the DB fills them). On edit the PK is
+  // immutable, shown read-only below.
+  const editable = useMemo(
+    () => (mode === 'new' ? columns : columns.filter((c) => !pk.includes(c.name))),
+    [columns, pk, mode],
+  );
   const [form, setForm] = useState<Record<string, string>>(() =>
     Object.fromEntries(editable.map((c) => {
       const v = row?.[c.name];
@@ -104,7 +109,11 @@ const PgRowDrawer: React.FC<{
         ))}
         {editable.map((c) => (
           <label key={c.name} style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: 'var(--fg)' }}>
-            <span>{c.name} <span style={{ color: 'var(--muted)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>{c.type}{c.fk ? ` -> ${c.fk}` : ''}</span></span>
+            <span>
+              {c.name}{' '}
+              {pk.includes(c.name) && <span className="ws-keybadge pk">PK</span>}{' '}
+              <span style={{ color: 'var(--muted)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>{c.type}{c.fk ? ` -> ${c.fk}` : ''}</span>
+            </span>
             {isBool(c.type) ? (
               <select aria-label={c.name} disabled={noPk} value={form[c.name]} onChange={(e) => setForm((f) => ({ ...f, [c.name]: e.target.value }))}
                 style={{ padding: '6px 8px', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', background: 'var(--panel)', color: 'var(--fg)' }}>
@@ -120,8 +129,10 @@ const PgRowDrawer: React.FC<{
                 onChange={(e) => setForm((f) => ({ ...f, [c.name]: e.target.value }))}
                 style={{ padding: '6px 8px', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', background: 'var(--panel)', color: 'var(--fg)', fontFamily: 'var(--font-mono)', fontSize: 12 }} />
             )}
-            {typeHint(c.type) && (
-              <span style={{ fontSize: 10.5, color: 'var(--muted)' }}>{typeHint(c.type)}</span>
+            {(pk.includes(c.name) || typeHint(c.type)) && (
+              <span style={{ fontSize: 10.5, color: 'var(--muted)' }}>
+                {pk.includes(c.name) ? 'primary key — leave blank if auto-generated' : typeHint(c.type)}
+              </span>
             )}
           </label>
         ))}

--- a/frontend/components/PgRowDrawer.tsx
+++ b/frontend/components/PgRowDrawer.tsx
@@ -30,6 +30,7 @@ const PgRowDrawer: React.FC<{
     if (raw === '') return c.nullable ? null : '';
     if (isBool(c.type)) return raw === 'true';
     if (isNumber(c.type)) { const n = Number(raw); return Number.isNaN(n) ? raw : n; }
+    if (isJson(c.type)) { try { return JSON.parse(raw); } catch { return raw; } }
     return raw;
   };
 

--- a/frontend/components/PgRowDrawer.tsx
+++ b/frontend/components/PgRowDrawer.tsx
@@ -47,6 +47,7 @@ const PgRowDrawer: React.FC<{
     })));
   const [busy, setBusy] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
   const noPk = pk.length === 0;
 
   const coerce = (c: Column, raw: string): unknown => {
@@ -60,9 +61,29 @@ const PgRowDrawer: React.FC<{
 
   const submit = async () => {
     setBusy(true);
+    setErr(null);
     try {
-      const values = Object.fromEntries(editable.map((c) => [c.name, coerce(c, form[c.name])]));
+      // On insert, omit fields the user left blank so the column's DB default
+      // (serial, now(), etc.) applies instead of sending '' into a typed column.
+      const values: Record<string, unknown> = {};
+      for (const c of editable) {
+        const raw = form[c.name];
+        if (mode === 'new' && raw === '') continue;
+        values[c.name] = coerce(c, raw);
+      }
       await onSave(values);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally { setBusy(false); }
+  };
+
+  const doDelete = async () => {
+    setBusy(true);
+    setErr(null);
+    try {
+      await onDelete();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
     } finally { setBusy(false); }
   };
 
@@ -105,11 +126,16 @@ const PgRowDrawer: React.FC<{
           </label>
         ))}
       </div>
+      {err && (
+        <div style={{ margin: '0 14px 10px', padding: '8px 10px', borderRadius: 'var(--radius-sm)', fontSize: 11.5, lineHeight: 1.45, background: 'color-mix(in oklch, var(--status-err) 10%, var(--bg))', border: '1px solid color-mix(in oklch, var(--status-err) 30%, var(--border))', color: 'var(--status-err)', fontFamily: 'var(--font-mono)', wordBreak: 'break-word' }}>
+          {err}
+        </div>
+      )}
       <div style={{ display: 'flex', gap: 8, padding: '12px 14px', borderTop: '1px solid var(--border)' }}>
         <button className="qa-btn primary" disabled={noPk || busy} onClick={submit}>Save</button>
         {mode === 'edit' && (
           confirmDelete
-            ? <button className="qa-btn" style={{ color: 'var(--status-err)', borderColor: 'var(--status-err)' }} disabled={busy} onClick={onDelete}>Confirm delete</button>
+            ? <button className="qa-btn" style={{ color: 'var(--status-err)', borderColor: 'var(--status-err)' }} disabled={busy} onClick={doDelete}>Confirm delete</button>
             : <button className="qa-btn" style={{ color: 'var(--status-err)' }} disabled={noPk} onClick={() => setConfirmDelete(true)}>Delete</button>
         )}
         <button className="qa-btn" style={{ marginLeft: 'auto' }} onClick={onClose}>Cancel</button>

--- a/frontend/components/PgRowDrawer.tsx
+++ b/frontend/components/PgRowDrawer.tsx
@@ -5,6 +5,29 @@ interface Column { name: string; type: string; nullable: boolean; pk?: boolean; 
 const isBool = (t: string) => t === 'boolean';
 const isNumber = (t: string) => /int|numeric|real|double|decimal|serial/i.test(t);
 const isJson = (t: string) => /json/i.test(t);
+// information_schema reports array columns as data_type "ARRAY"; some setups
+// surface "integer[]" etc. Match both.
+const isArray = (t: string) => /array|\[\]/i.test(t);
+
+// One-line input help for types that aren't obvious to type by hand.
+const typeHint = (t: string): string =>
+  isArray(t) ? 'array — {1,2,3} or ["a","b"]'
+    : isJson(t) ? 'JSON — e.g. {"key": "value"}'
+    : '';
+
+// Parse array input into a real JS array (sent as JSON; psycopg2 adapts a list
+// to a PG array and handles quoting). Accepts JSON [1,3], PG {1,3}, or 1,3.
+const parseArray = (raw: string): unknown => {
+  const s = raw.trim();
+  try { const v = JSON.parse(s); if (Array.isArray(v)) return v; } catch { /* not JSON */ }
+  const inner = s.replace(/^\{/, '').replace(/\}$/, '');
+  if (inner.trim() === '') return [];
+  return inner.split(',').map((x) => {
+    const el = x.trim().replace(/^["']|["']$/g, '');
+    const n = Number(el);
+    return el !== '' && !Number.isNaN(n) ? n : el;
+  });
+};
 
 const PgRowDrawer: React.FC<{
   columns: Column[];
@@ -29,6 +52,7 @@ const PgRowDrawer: React.FC<{
   const coerce = (c: Column, raw: string): unknown => {
     if (raw === '') return c.nullable ? null : '';
     if (isBool(c.type)) return raw === 'true';
+    if (isArray(c.type)) return parseArray(raw);
     if (isNumber(c.type)) { const n = Number(raw); return Number.isNaN(n) ? raw : n; }
     if (isJson(c.type)) { try { return JSON.parse(raw); } catch { return raw; } }
     return raw;
@@ -65,13 +89,18 @@ const PgRowDrawer: React.FC<{
                 style={{ padding: '6px 8px', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', background: 'var(--panel)', color: 'var(--fg)' }}>
                 <option value="">(null)</option><option value="true">true</option><option value="false">false</option>
               </select>
-            ) : isJson(c.type) ? (
-              <textarea aria-label={c.name} disabled={noPk} rows={3} value={form[c.name]} onChange={(e) => setForm((f) => ({ ...f, [c.name]: e.target.value }))}
-                style={{ padding: '6px 8px', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', background: 'var(--panel)', color: 'var(--fg)', fontFamily: 'var(--font-mono)', fontSize: 12 }} />
+            ) : (isJson(c.type) || isArray(c.type)) ? (
+              <textarea aria-label={c.name} disabled={noPk} rows={isArray(c.type) ? 1 : 3} value={form[c.name]}
+                placeholder={isArray(c.type) ? '{1,2,3}' : '{"key": "value"}'}
+                onChange={(e) => setForm((f) => ({ ...f, [c.name]: e.target.value }))}
+                style={{ padding: '6px 8px', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', background: 'var(--panel)', color: 'var(--fg)', fontFamily: 'var(--font-mono)', fontSize: 12, resize: 'vertical' }} />
             ) : (
               <input aria-label={c.name} disabled={noPk} type={isNumber(c.type) ? 'number' : 'text'} value={form[c.name]}
                 onChange={(e) => setForm((f) => ({ ...f, [c.name]: e.target.value }))}
                 style={{ padding: '6px 8px', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', background: 'var(--panel)', color: 'var(--fg)', fontFamily: 'var(--font-mono)', fontSize: 12 }} />
+            )}
+            {typeHint(c.type) && (
+              <span style={{ fontSize: 10.5, color: 'var(--muted)' }}>{typeHint(c.type)}</span>
             )}
           </label>
         ))}

--- a/frontend/components/PgRowDrawer.tsx
+++ b/frontend/components/PgRowDrawer.tsx
@@ -1,0 +1,91 @@
+import React, { useMemo, useState } from 'react';
+
+interface Column { name: string; type: string; nullable: boolean; pk?: boolean; fk?: string | null }
+
+const isBool = (t: string) => t === 'boolean';
+const isNumber = (t: string) => /int|numeric|real|double|decimal|serial/i.test(t);
+const isJson = (t: string) => /json/i.test(t);
+
+const PgRowDrawer: React.FC<{
+  columns: Column[];
+  pk: string[];
+  mode: 'edit' | 'new';
+  row: Record<string, unknown> | null;
+  onClose: () => void;
+  onSave: (values: Record<string, unknown>) => void | Promise<void>;
+  onDelete: () => void | Promise<void>;
+}> = ({ columns, pk, mode, row, onClose, onSave, onDelete }) => {
+  // Editable = every non-pk column (serial/default pks are filled by the DB).
+  const editable = useMemo(() => columns.filter((c) => !pk.includes(c.name)), [columns, pk]);
+  const [form, setForm] = useState<Record<string, string>>(() =>
+    Object.fromEntries(editable.map((c) => {
+      const v = row?.[c.name];
+      return [c.name, v === null || v === undefined ? '' : String(v)];
+    })));
+  const [busy, setBusy] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const noPk = pk.length === 0;
+
+  const coerce = (c: Column, raw: string): unknown => {
+    if (raw === '') return c.nullable ? null : '';
+    if (isBool(c.type)) return raw === 'true';
+    if (isNumber(c.type)) { const n = Number(raw); return Number.isNaN(n) ? raw : n; }
+    return raw;
+  };
+
+  const submit = async () => {
+    setBusy(true);
+    try {
+      const values = Object.fromEntries(editable.map((c) => [c.name, coerce(c, form[c.name])]));
+      await onSave(values);
+    } finally { setBusy(false); }
+  };
+
+  return (
+    <aside style={{ width: 340, borderLeft: '1px solid var(--border)', background: 'var(--panel)', display: 'flex', flexDirection: 'column', flexShrink: 0 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 14px', borderBottom: '1px solid var(--border)' }}>
+        <span style={{ fontSize: 13, fontWeight: 500 }}>{mode === 'new' ? 'New row' : 'Edit row'}</span>
+        <button className="qa-iconbtn" style={{ marginLeft: 'auto' }} onClick={onClose} title="Close">&#x2715;</button>
+      </div>
+      <div style={{ padding: '12px 14px', overflowY: 'auto', flex: 1, display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {noPk && <div className="qa-chip" style={{ color: 'var(--status-warn)', borderColor: 'var(--status-warn)' }}>No primary key — read-only.</div>}
+        {mode === 'edit' && pk.map((c) => (
+          <label key={c} style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: 'var(--muted)' }}>
+            {c} <span className="ws-keybadge pk">PK</span>
+            <input aria-label={c} value={String(row?.[c] ?? '')} readOnly
+              style={{ padding: '6px 8px', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', background: 'var(--soft)', color: 'var(--muted)', fontFamily: 'var(--font-mono)', fontSize: 12 }} />
+          </label>
+        ))}
+        {editable.map((c) => (
+          <label key={c.name} style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: 'var(--fg)' }}>
+            <span>{c.name} <span style={{ color: 'var(--muted)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>{c.type}{c.fk ? ` -> ${c.fk}` : ''}</span></span>
+            {isBool(c.type) ? (
+              <select aria-label={c.name} disabled={noPk} value={form[c.name]} onChange={(e) => setForm((f) => ({ ...f, [c.name]: e.target.value }))}
+                style={{ padding: '6px 8px', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', background: 'var(--panel)', color: 'var(--fg)' }}>
+                <option value="">(null)</option><option value="true">true</option><option value="false">false</option>
+              </select>
+            ) : isJson(c.type) ? (
+              <textarea aria-label={c.name} disabled={noPk} rows={3} value={form[c.name]} onChange={(e) => setForm((f) => ({ ...f, [c.name]: e.target.value }))}
+                style={{ padding: '6px 8px', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', background: 'var(--panel)', color: 'var(--fg)', fontFamily: 'var(--font-mono)', fontSize: 12 }} />
+            ) : (
+              <input aria-label={c.name} disabled={noPk} type={isNumber(c.type) ? 'number' : 'text'} value={form[c.name]}
+                onChange={(e) => setForm((f) => ({ ...f, [c.name]: e.target.value }))}
+                style={{ padding: '6px 8px', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', background: 'var(--panel)', color: 'var(--fg)', fontFamily: 'var(--font-mono)', fontSize: 12 }} />
+            )}
+          </label>
+        ))}
+      </div>
+      <div style={{ display: 'flex', gap: 8, padding: '12px 14px', borderTop: '1px solid var(--border)' }}>
+        <button className="qa-btn primary" disabled={noPk || busy} onClick={submit}>Save</button>
+        {mode === 'edit' && (
+          confirmDelete
+            ? <button className="qa-btn" style={{ color: 'var(--status-err)', borderColor: 'var(--status-err)' }} disabled={busy} onClick={onDelete}>Confirm delete</button>
+            : <button className="qa-btn" style={{ color: 'var(--status-err)' }} disabled={noPk} onClick={() => setConfirmDelete(true)}>Delete</button>
+        )}
+        <button className="qa-btn" style={{ marginLeft: 'auto' }} onClick={onClose}>Cancel</button>
+      </div>
+    </aside>
+  );
+};
+
+export default PgRowDrawer;

--- a/frontend/components/QueryDisplay.tsx
+++ b/frontend/components/QueryDisplay.tsx
@@ -13,6 +13,8 @@ interface QueryDisplayProps {
   isTransferable?: boolean;
   onOpenInExplorer?: () => void;
   canWrite?: boolean;
+  onExplain?: () => void;
+  isExplaining?: boolean;
 }
 
 const WRITE_OPERATION_REGEX = /\.(insert_one|insert_many|update_one|update_many|replace_one|delete_one|delete_many|bulk_write|drop|drop_index|drop_indexes|create_index|create_indexes|rename_collection)\s*\(/i;
@@ -34,6 +36,7 @@ const QueryDisplay: React.FC<QueryDisplayProps> = ({
   code, onCodeChange, onRunQuery, onSaveQuery,
   isExecuting, historyCount, historyIndex, onNavigateHistory,
   isTransferable, onOpenInExplorer, canWrite = true,
+  onExplain, isExplaining,
 }) => {
   const [copied, setCopied] = useState(false);
   const [allowWrite, setAllowWrite] = useState(false);
@@ -214,6 +217,17 @@ const QueryDisplay: React.FC<QueryDisplayProps> = ({
         >
           Save
         </button>
+        {onExplain && (
+          <button
+            onClick={onExplain}
+            disabled={!code || isExplaining}
+            className="qa-btn"
+            style={{ fontSize: 12 }}
+            title="Explain in plain English what this query does"
+          >
+            {isExplaining ? 'Explaining…' : 'Explain'}
+          </button>
+        )}
         <button
           onClick={() => { onRunQuery(); setAllowWrite(false); }}
           disabled={isRunDisabled}

--- a/frontend/components/QueryResult.tsx
+++ b/frontend/components/QueryResult.tsx
@@ -37,6 +37,7 @@ interface QueryResultProps {
   isAnalyzing: boolean;
   analysisResult: AnalysisResult | null;
   analysisError: string | null;
+  onFollowup?: (prompt: string) => void;
   onEvaluateWrite?: () => void;
   isEvaluatingWrite?: boolean;
   writeEvaluationResult?: { evaluation: string } | null;
@@ -100,7 +101,7 @@ const QueryResult: React.FC<QueryResultProps> = ({
   isExecuting, executionError, executionResult,
   onDebug, isDebugging, debuggingResult, debugError,
   sourceCollection, onSetIntermediateContext, intermediateContext,
-  onAnalyze, isAnalyzing, analysisResult, analysisError,
+  onAnalyze, isAnalyzing, analysisResult, analysisError, onFollowup,
   onEvaluateWrite, isEvaluatingWrite, writeEvaluationResult, writeEvaluationError,
   isTutorialActive, tutorialStepIndex,
 }) => {
@@ -419,7 +420,7 @@ const QueryResult: React.FC<QueryResultProps> = ({
         {analysisError && (
           <div style={{ fontSize: 12, color: '#c94250', padding: '8px 0' }}>Analysis error: {analysisError}</div>
         )}
-        {analysisResult && <AnalysisResultDisplay result={analysisResult} />}
+        {analysisResult && <AnalysisResultDisplay result={analysisResult} onFollowup={onFollowup} />}
 
         {graphDrawer}
 

--- a/frontend/components/QueryResult.tsx
+++ b/frontend/components/QueryResult.tsx
@@ -14,7 +14,6 @@ import {
   AiSparkleIcon,
   PinIcon,
   DownloadIcon,
-  BarChartIcon,
   EditIcon,
   UndoIcon,
   RedoIcon,
@@ -33,7 +32,7 @@ interface QueryResultProps {
   sourceCollection: string | null;
   onSetIntermediateContext: (data: any, source: string) => void;
   intermediateContext: { data: any; source: string; } | null;
-  onAnalyze: (dataToAnalyze: any) => void;
+  onAnalyze?: (dataToAnalyze: any) => void; // deprecated: analysis is triggered from the workspace Insights rail
   isAnalyzing: boolean;
   analysisResult: AnalysisResult | null;
   analysisError: string | null;
@@ -101,7 +100,7 @@ const QueryResult: React.FC<QueryResultProps> = ({
   isExecuting, executionError, executionResult,
   onDebug, isDebugging, debuggingResult, debugError,
   sourceCollection, onSetIntermediateContext, intermediateContext,
-  onAnalyze, isAnalyzing, analysisResult, analysisError, onFollowup,
+  isAnalyzing, analysisResult, analysisError, onFollowup,
   onEvaluateWrite, isEvaluatingWrite, writeEvaluationResult, writeEvaluationError,
   isTutorialActive, tutorialStepIndex,
 }) => {
@@ -117,7 +116,6 @@ const QueryResult: React.FC<QueryResultProps> = ({
   const isWriteOpSummary = useMemo(() => isWriteSummary(executionResult), [executionResult]);
   const canBeTable = useMemo(() => isTableCompatible(executionResult), [executionResult]);
   const canBeContext = useMemo(() => isContextCompatible(executionResult), [executionResult]);
-  const isAnalyzable = useMemo(() => isTableCompatible(executionResult), [executionResult]);
 
   const allTableHeaders = useMemo(() => {
     if (!canBeTable) return [];
@@ -184,11 +182,6 @@ const QueryResult: React.FC<QueryResultProps> = ({
       const src = sourceCollection ? `'${sourceCollection}' collection` : 'the previous query';
       onSetIntermediateContext(processedDataForActions, src);
     }
-  };
-
-  const handleAnalyzeClick = () => {
-    if (!isAnalyzable || isAnalyzing || !!analysisResult) return;
-    onAnalyze(processedDataForActions);
   };
 
   const handleDownloadCSV = useCallback((separator: ',' | ';') => {
@@ -308,9 +301,6 @@ const QueryResult: React.FC<QueryResultProps> = ({
             <div style={{ display: 'flex', gap: 5 }}>
               <IconBtn title="Graph view" disabled={isTableEditMode} onClick={() => setIsGraphVisible(true)}>
                 <GraphIcon className="w-3 h-3" />
-              </IconBtn>
-              <IconBtn id="tutorial-analyze-button" title={isAnalyzing ? 'Analyzing…' : analysisResult ? 'Analyzed' : 'Analyze with AI'} disabled={!isAnalyzable || isAnalyzing || !!analysisResult || isTableEditMode} active={!!analysisResult} onClick={handleAnalyzeClick}>
-                <BarChartIcon className="w-3 h-3" />
               </IconBtn>
               <IconBtn title={isCurrentResultInContext ? 'Context set' : 'Use as context'} disabled={!canBeContext || isTableEditMode} active={isCurrentResultInContext} onClick={handleSetContextClick}>
                 <PinIcon className="w-3 h-3" />

--- a/frontend/components/QueryResult.tsx
+++ b/frontend/components/QueryResult.tsx
@@ -36,7 +36,6 @@ interface QueryResultProps {
   isAnalyzing: boolean;
   analysisResult: AnalysisResult | null;
   analysisError: string | null;
-  onFollowup?: (prompt: string) => void;
   onEvaluateWrite?: () => void;
   isEvaluatingWrite?: boolean;
   writeEvaluationResult?: { evaluation: string } | null;
@@ -100,7 +99,7 @@ const QueryResult: React.FC<QueryResultProps> = ({
   isExecuting, executionError, executionResult,
   onDebug, isDebugging, debuggingResult, debugError,
   sourceCollection, onSetIntermediateContext, intermediateContext,
-  isAnalyzing, analysisResult, analysisError, onFollowup,
+  isAnalyzing, analysisResult, analysisError,
   onEvaluateWrite, isEvaluatingWrite, writeEvaluationResult, writeEvaluationError,
   isTutorialActive, tutorialStepIndex,
 }) => {
@@ -410,7 +409,7 @@ const QueryResult: React.FC<QueryResultProps> = ({
         {analysisError && (
           <div style={{ fontSize: 12, color: '#c94250', padding: '8px 0' }}>Analysis error: {analysisError}</div>
         )}
-        {analysisResult && <AnalysisResultDisplay result={analysisResult} onFollowup={onFollowup} />}
+        {analysisResult && <AnalysisResultDisplay result={analysisResult} />}
 
         {graphDrawer}
 

--- a/frontend/components/UserMenuButton.tsx
+++ b/frontend/components/UserMenuButton.tsx
@@ -1,12 +1,18 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
 import { useRoles } from '../hooks/useRoles';
+
+// Saved queries live per-workspace: open the PG panel when in a PG workspace,
+// otherwise the Cosmos query generator.
+export const savedQueriesTarget = (pathname: string): string =>
+  pathname.startsWith('/postgres') ? `${pathname}?panel=saved` : '/query-generator?panel=saved';
 
 const UserMenuButton: React.FC = () => {
   const { user, logout } = useUnifiedAuth();
   const { can } = useRoles();
   const navigate = useNavigate();
+  const location = useLocation();
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [showSignOutConfirm, setShowSignOutConfirm] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -78,7 +84,7 @@ const UserMenuButton: React.FC = () => {
           {/* Saved queries */}
           <div style={{ padding: '6px 6px' }}>
             <button
-              onClick={() => { setShowUserMenu(false); navigate('/query-generator?panel=saved'); }}
+              onClick={() => { setShowUserMenu(false); navigate(savedQueriesTarget(location.pathname)); }}
               style={{
                 width: '100%', display: 'flex', alignItems: 'center', gap: 9,
                 padding: '7px 10px', borderRadius: 7, border: 'none',

--- a/frontend/pages/AdminPage.tsx
+++ b/frontend/pages/AdminPage.tsx
@@ -38,6 +38,7 @@ export default function AdminPage() {
   const [pgAccess, setPgAccess] = useState<Set<string>>(new Set());
   const [pgWrite, setPgWrite] = useState<Set<string>>(new Set());
   const [pgAccessLoading, setPgAccessLoading] = useState(false);
+  const [pgAccessError, setPgAccessError] = useState<string | null>(null);
   const [pgBusy, setPgBusy] = useState<Record<string, boolean>>({});
 
   // All hooks must be called before any early return (rules of hooks).
@@ -73,6 +74,7 @@ export default function AdminPage() {
     if (!pgServerId) return;
     let cancelled = false;
     setPgAccessLoading(true);
+    setPgAccessError(null);
     getAuthenticatedToken()
       .then((token) => pgListAccess(token, pgServerId))
       .then((entries) => {
@@ -80,7 +82,7 @@ export default function AdminPage() {
         setPgAccess(new Set(entries.map((e) => e.email.toLowerCase())));
         setPgWrite(new Set(entries.filter((e) => e.write).map((e) => e.email.toLowerCase())));
       })
-      .catch(() => { if (!cancelled) { setPgAccess(new Set()); setPgWrite(new Set()); } })
+      .catch((e) => { if (!cancelled) { setPgAccess(new Set()); setPgWrite(new Set()); setPgAccessError(e?.message || 'Failed to load PostgreSQL access'); } })
       .finally(() => { if (!cancelled) setPgAccessLoading(false); });
     return () => { cancelled = true; };
   }, [pgServerId]);
@@ -230,6 +232,13 @@ export default function AdminPage() {
             >
               {pgServers.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
             </select>
+            {pgAccessLoading && <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>Loading access…</span>}
+          </div>
+        )}
+
+        {pgAccessError && (
+          <div style={{ marginBottom: 16, padding: '10px 12px', borderRadius: 8, fontSize: 12, lineHeight: 1.5, background: 'color-mix(in oklch, var(--status-err) 10%, var(--bg))', border: '1px solid color-mix(in oklch, var(--status-err) 30%, var(--border))', color: 'var(--status-err)', fontFamily: 'var(--font-mono)', wordBreak: 'break-word' }}>
+            Couldn&apos;t load PostgreSQL access: {pgAccessError}
           </div>
         )}
 

--- a/frontend/pages/AdminPage.tsx
+++ b/frontend/pages/AdminPage.tsx
@@ -28,35 +28,48 @@ export default function AdminPage() {
   const [pgServers, setPgServers] = useState<PostgresServer[]>([]);
   const [pgServerId, setPgServerId] = useState<string>('');
   const [pgAccess, setPgAccess] = useState<Set<string>>(new Set());
+  const [pgAccessLoading, setPgAccessLoading] = useState(false);
   const [pgBusy, setPgBusy] = useState<Record<string, boolean>>({});
 
-  // All hooks must be called before any early return (rules of hooks)
+  // All hooks must be called before any early return (rules of hooks).
+  // Load users AND PG-server discovery together so the table (and whether the
+  // PostgreSQL column exists) renders once, with no pop-in afterwards.
   useEffect(() => {
     if (!can('system:admin')) return;
-    getAdminUsers()
-      .then(setUsers)
-      .catch((e) => setError(e.message))
-      .finally(() => setLoading(false));
-  }, []);
-
-  useEffect(() => {
-    if (!can('system:admin')) return;
-    getAuthenticatedToken()
-      .then((token) => listPostgresServers(token))
-      .then((servers) => {
-        setPgServers(servers);
-        if (servers.length > 0) setPgServerId(servers[0].id);
-      })
-      .catch(() => { /* PG provisioning is optional; absence hides the column */ });
+    (async () => {
+      try {
+        const [adminUsers] = await Promise.all([
+          getAdminUsers(),
+          // PG provisioning is optional — never fail the page over it.
+          (async () => {
+            try {
+              const token = await getAuthenticatedToken();
+              const servers = await listPostgresServers(token);
+              setPgServers(servers);
+              if (servers.length > 0) setPgServerId(servers[0].id);
+            } catch { /* absence just hides the column */ }
+          })(),
+        ]);
+        setUsers(adminUsers);
+      } catch (e: any) {
+        setError(e.message);
+      } finally {
+        setLoading(false);
+      }
+    })();
   }, []);
 
   // Load who currently has access whenever the selected server changes.
   useEffect(() => {
     if (!pgServerId) return;
+    let cancelled = false;
+    setPgAccessLoading(true);
     getAuthenticatedToken()
       .then((token) => pgListAccess(token, pgServerId))
-      .then((emails) => setPgAccess(new Set(emails.map((e) => e.toLowerCase()))))
-      .catch(() => setPgAccess(new Set()));
+      .then((emails) => { if (!cancelled) setPgAccess(new Set(emails.map((e) => e.toLowerCase()))); })
+      .catch(() => { if (!cancelled) setPgAccess(new Set()); })
+      .finally(() => { if (!cancelled) setPgAccessLoading(false); });
+    return () => { cancelled = true; };
   }, [pgServerId]);
 
   const setPgAccessFor = (email: string, has: boolean) =>
@@ -229,8 +242,10 @@ export default function AdminPage() {
                   </td>
 
                   {pgServers.length > 0 && (
-                    <td style={{ padding: '10px 10px' }}>
-                      {pgAccess.has(u.email.toLowerCase()) ? (
+                    <td style={{ padding: '10px 10px', minWidth: 120 }}>
+                      {pgAccessLoading ? (
+                        <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>Checking…</span>
+                      ) : pgAccess.has(u.email.toLowerCase()) ? (
                         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                           <span className="qa-chip ok" style={{ fontSize: 11 }}>● granted</span>
                           <button

--- a/frontend/pages/AdminPage.tsx
+++ b/frontend/pages/AdminPage.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
 import { useRoles } from '../hooks/useRoles';
-import { getAdminUsers, assignUserRole, removeUserRole, AdminUser } from '../services/dbService';
+import {
+  getAdminUsers, assignUserRole, removeUserRole, AdminUser,
+  getAuthenticatedToken, listPostgresServers, pgListAccess, pgGrantAccess, pgRevokeAccess,
+  PostgresServer,
+} from '../services/dbService';
 import AppLayout from '../components/AppLayout';
 
 const ROLES = ['Admin', 'Analyst', 'Viewer'] as const;
@@ -20,6 +24,12 @@ export default function AdminPage() {
   const [pendingRole, setPendingRole] = useState<Record<string, string>>({});
   const [actionError, setActionError] = useState<Record<string, string>>({});
 
+  // PostgreSQL access provisioning
+  const [pgServers, setPgServers] = useState<PostgresServer[]>([]);
+  const [pgServerId, setPgServerId] = useState<string>('');
+  const [pgAccess, setPgAccess] = useState<Set<string>>(new Set());
+  const [pgBusy, setPgBusy] = useState<Record<string, boolean>>({});
+
   // All hooks must be called before any early return (rules of hooks)
   useEffect(() => {
     if (!can('system:admin')) return;
@@ -28,6 +38,61 @@ export default function AdminPage() {
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    if (!can('system:admin')) return;
+    getAuthenticatedToken()
+      .then((token) => listPostgresServers(token))
+      .then((servers) => {
+        setPgServers(servers);
+        if (servers.length > 0) setPgServerId(servers[0].id);
+      })
+      .catch(() => { /* PG provisioning is optional; absence hides the column */ });
+  }, []);
+
+  // Load who currently has access whenever the selected server changes.
+  useEffect(() => {
+    if (!pgServerId) return;
+    getAuthenticatedToken()
+      .then((token) => pgListAccess(token, pgServerId))
+      .then((emails) => setPgAccess(new Set(emails.map((e) => e.toLowerCase()))))
+      .catch(() => setPgAccess(new Set()));
+  }, [pgServerId]);
+
+  const setPgAccessFor = (email: string, has: boolean) =>
+    setPgAccess((prev) => {
+      const next = new Set(prev);
+      if (has) next.add(email.toLowerCase()); else next.delete(email.toLowerCase());
+      return next;
+    });
+
+  const handlePgGrant = async (oid: string, email: string) => {
+    setPgBusy((p) => ({ ...p, [oid]: true }));
+    setActionError((p) => ({ ...p, [oid]: '' }));
+    try {
+      const token = await getAuthenticatedToken();
+      await pgGrantAccess(token, pgServerId, email);
+      setPgAccessFor(email, true);
+    } catch (e: any) {
+      setActionError((p) => ({ ...p, [oid]: e.message }));
+    } finally {
+      setPgBusy((p) => ({ ...p, [oid]: false }));
+    }
+  };
+
+  const handlePgRevoke = async (oid: string, email: string) => {
+    setPgBusy((p) => ({ ...p, [oid]: true }));
+    setActionError((p) => ({ ...p, [oid]: '' }));
+    try {
+      const token = await getAuthenticatedToken();
+      await pgRevokeAccess(token, pgServerId, email);
+      setPgAccessFor(email, false);
+    } catch (e: any) {
+      setActionError((p) => ({ ...p, [oid]: e.message }));
+    } finally {
+      setPgBusy((p) => ({ ...p, [oid]: false }));
+    }
+  };
 
   const handleAssign = async (oid: string) => {
     const role = pendingRole[oid];
@@ -70,6 +135,19 @@ export default function AdminPage() {
           </p>
         </div>
 
+        {pgServers.length > 0 && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+            <span style={{ fontSize: 12, color: 'var(--muted)' }}>PostgreSQL server:</span>
+            <select
+              value={pgServerId}
+              onChange={(e) => setPgServerId(e.target.value)}
+              style={{ fontSize: 12, fontFamily: 'var(--font-body)', background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 5, padding: '4px 8px', color: 'var(--fg)', cursor: 'pointer' }}
+            >
+              {pgServers.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+            </select>
+          </div>
+        )}
+
         {loading && (
           <div style={{ color: 'var(--muted)', fontSize: 13 }}>Loading users…</div>
         )}
@@ -86,7 +164,7 @@ export default function AdminPage() {
           <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
             <thead>
               <tr style={{ borderBottom: '1px solid var(--border)' }}>
-                {['User', 'Current Roles', 'Add Role'].map((h) => (
+                {['User', 'Current Roles', 'Add Role', ...(pgServers.length > 0 ? ['PostgreSQL'] : [])].map((h) => (
                   <th key={h} style={{ textAlign: 'left', padding: '6px 10px', color: 'var(--muted)', fontWeight: 500, fontSize: 11.5, textTransform: 'uppercase', letterSpacing: '0.06em' }}>{h}</th>
                 ))}
               </tr>
@@ -149,6 +227,33 @@ export default function AdminPage() {
                       <div style={{ fontSize: 11.5, color: 'var(--status-err)', marginTop: 4 }}>{actionError[u.oid]}</div>
                     )}
                   </td>
+
+                  {pgServers.length > 0 && (
+                    <td style={{ padding: '10px 10px' }}>
+                      {pgAccess.has(u.email.toLowerCase()) ? (
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                          <span className="qa-chip ok" style={{ fontSize: 11 }}>● granted</span>
+                          <button
+                            className="qa-btn"
+                            disabled={pgBusy[u.oid]}
+                            onClick={() => handlePgRevoke(u.oid, u.email)}
+                            style={{ fontSize: 12, padding: '4px 10px' }}
+                          >
+                            {pgBusy[u.oid] ? '…' : 'Revoke'}
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          className="qa-btn primary"
+                          disabled={pgBusy[u.oid]}
+                          onClick={() => handlePgGrant(u.oid, u.email)}
+                          style={{ fontSize: 12, padding: '4px 10px' }}
+                        >
+                          {pgBusy[u.oid] ? '…' : 'Grant'}
+                        </button>
+                      )}
+                    </td>
+                  )}
                 </tr>
               ))}
             </tbody>

--- a/frontend/pages/AdminPage.tsx
+++ b/frontend/pages/AdminPage.tsx
@@ -4,7 +4,7 @@ import { useRoles } from '../hooks/useRoles';
 import {
   getAdminUsers, assignUserRole, removeUserRole, AdminUser,
   getAuthenticatedToken, listPostgresServers, pgListAccess, pgGrantAccess, pgRevokeAccess,
-  PostgresServer,
+  pgGrantWrite, pgRevokeWrite, PostgresServer,
 } from '../services/dbService';
 import AppLayout from '../components/AppLayout';
 
@@ -28,6 +28,7 @@ export default function AdminPage() {
   const [pgServers, setPgServers] = useState<PostgresServer[]>([]);
   const [pgServerId, setPgServerId] = useState<string>('');
   const [pgAccess, setPgAccess] = useState<Set<string>>(new Set());
+  const [pgWrite, setPgWrite] = useState<Set<string>>(new Set());
   const [pgAccessLoading, setPgAccessLoading] = useState(false);
   const [pgBusy, setPgBusy] = useState<Record<string, boolean>>({});
 
@@ -66,18 +67,24 @@ export default function AdminPage() {
     setPgAccessLoading(true);
     getAuthenticatedToken()
       .then((token) => pgListAccess(token, pgServerId))
-      .then((emails) => { if (!cancelled) setPgAccess(new Set(emails.map((e) => e.toLowerCase()))); })
-      .catch(() => { if (!cancelled) setPgAccess(new Set()); })
+      .then((entries) => {
+        if (cancelled) return;
+        setPgAccess(new Set(entries.map((e) => e.email.toLowerCase())));
+        setPgWrite(new Set(entries.filter((e) => e.write).map((e) => e.email.toLowerCase())));
+      })
+      .catch(() => { if (!cancelled) { setPgAccess(new Set()); setPgWrite(new Set()); } })
       .finally(() => { if (!cancelled) setPgAccessLoading(false); });
     return () => { cancelled = true; };
   }, [pgServerId]);
 
-  const setPgAccessFor = (email: string, has: boolean) =>
-    setPgAccess((prev) => {
+  const setMembership = (setter: typeof setPgAccess) => (email: string, has: boolean) =>
+    setter((prev) => {
       const next = new Set(prev);
       if (has) next.add(email.toLowerCase()); else next.delete(email.toLowerCase());
       return next;
     });
+  const setPgAccessFor = setMembership(setPgAccess);
+  const setPgWriteFor = setMembership(setPgWrite);
 
   const handlePgGrant = async (oid: string, email: string) => {
     setPgBusy((p) => ({ ...p, [oid]: true }));
@@ -100,6 +107,35 @@ export default function AdminPage() {
       const token = await getAuthenticatedToken();
       await pgRevokeAccess(token, pgServerId, email);
       setPgAccessFor(email, false);
+      setPgWriteFor(email, false); // dropping the role removes write too
+    } catch (e: any) {
+      setActionError((p) => ({ ...p, [oid]: e.message }));
+    } finally {
+      setPgBusy((p) => ({ ...p, [oid]: false }));
+    }
+  };
+
+  const handlePgGrantWrite = async (oid: string, email: string) => {
+    setPgBusy((p) => ({ ...p, [oid]: true }));
+    setActionError((p) => ({ ...p, [oid]: '' }));
+    try {
+      const token = await getAuthenticatedToken();
+      await pgGrantWrite(token, pgServerId, email);
+      setPgWriteFor(email, true);
+    } catch (e: any) {
+      setActionError((p) => ({ ...p, [oid]: e.message }));
+    } finally {
+      setPgBusy((p) => ({ ...p, [oid]: false }));
+    }
+  };
+
+  const handlePgRevokeWrite = async (oid: string, email: string) => {
+    setPgBusy((p) => ({ ...p, [oid]: true }));
+    setActionError((p) => ({ ...p, [oid]: '' }));
+    try {
+      const token = await getAuthenticatedToken();
+      await pgRevokeWrite(token, pgServerId, email);
+      setPgWriteFor(email, false);
     } catch (e: any) {
       setActionError((p) => ({ ...p, [oid]: e.message }));
     } finally {
@@ -246,13 +282,38 @@ export default function AdminPage() {
                       {pgAccessLoading ? (
                         <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>Checking…</span>
                       ) : pgAccess.has(u.email.toLowerCase()) ? (
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                          <span className="qa-chip ok" style={{ fontSize: 11 }}>● granted</span>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                          <span className="qa-chip ok" style={{ fontSize: 11 }}>● read</span>
+                          {pgWrite.has(u.email.toLowerCase()) ? (
+                            <>
+                              <span className="qa-chip accent" style={{ fontSize: 11 }}>● write</span>
+                              <button
+                                className="qa-btn"
+                                disabled={pgBusy[u.oid]}
+                                onClick={() => handlePgRevokeWrite(u.oid, u.email)}
+                                style={{ fontSize: 12, padding: '4px 10px' }}
+                                title="Remove INSERT/UPDATE/DELETE, keep read"
+                              >
+                                {pgBusy[u.oid] ? '…' : 'Revoke write'}
+                              </button>
+                            </>
+                          ) : (
+                            <button
+                              className="qa-btn"
+                              disabled={pgBusy[u.oid]}
+                              onClick={() => handlePgGrantWrite(u.oid, u.email)}
+                              style={{ fontSize: 12, padding: '4px 10px' }}
+                              title="Allow INSERT/UPDATE/DELETE (pg_write_all_data)"
+                            >
+                              {pgBusy[u.oid] ? '…' : 'Grant write'}
+                            </button>
+                          )}
                           <button
                             className="qa-btn"
                             disabled={pgBusy[u.oid]}
                             onClick={() => handlePgRevoke(u.oid, u.email)}
                             style={{ fontSize: 12, padding: '4px 10px' }}
+                            title="Remove all access"
                           >
                             {pgBusy[u.oid] ? '…' : 'Revoke'}
                           </button>

--- a/frontend/pages/AdminPage.tsx
+++ b/frontend/pages/AdminPage.tsx
@@ -237,8 +237,19 @@ export default function AdminPage() {
         )}
 
         {pgAccessError && (
-          <div style={{ marginBottom: 16, padding: '10px 12px', borderRadius: 8, fontSize: 12, lineHeight: 1.5, background: 'color-mix(in oklch, var(--status-err) 10%, var(--bg))', border: '1px solid color-mix(in oklch, var(--status-err) 30%, var(--border))', color: 'var(--status-err)', fontFamily: 'var(--font-mono)', wordBreak: 'break-word' }}>
-            Couldn&apos;t load PostgreSQL access: {pgAccessError}
+          <div style={{ marginBottom: 16, padding: '11px 13px', borderRadius: 8, fontSize: 12.5, lineHeight: 1.55, background: 'color-mix(in oklch, var(--status-err) 10%, var(--bg))', border: '1px solid color-mix(in oklch, var(--status-err) 30%, var(--border))', color: 'var(--status-err)', wordBreak: 'break-word' }}>
+            {/timeout|connection .*failed|could not connect|no pg_hba|could not translate host/i.test(pgAccessError) ? (
+              <>
+                <strong>Can&apos;t reach the PostgreSQL server.</strong> Your current IP is most likely not
+                allow-listed on the server firewall — this commonly happens after switching networks or connecting
+                to a VPN. Ask a tenant / Azure admin to whitelist your current public IP on{' '}
+                <span style={{ fontFamily: 'var(--font-mono)' }}>{pgServers.find((s) => s.id === pgServerId)?.name ?? 'the server'}</span> so you can manage
+                database access, then reload this page.
+                <div style={{ marginTop: 6, fontSize: 10.5, opacity: 0.75, fontFamily: 'var(--font-mono)' }}>{pgAccessError}</div>
+              </>
+            ) : (
+              <span style={{ fontFamily: 'var(--font-mono)' }}>Couldn&apos;t load PostgreSQL access: {pgAccessError}</span>
+            )}
           </div>
         )}
 

--- a/frontend/pages/AdminPage.tsx
+++ b/frontend/pages/AdminPage.tsx
@@ -16,6 +16,14 @@ const chipColor: Record<string, string> = {
   Viewer: 'var(--muted)',
 };
 
+// Human-readable capabilities per role (cumulative). Kept in sync with the
+// permission sets in hooks/useRoles.ts + backend services/rbac.py.
+const ROLE_INFO: { name: string; caps: string[] }[] = [
+  { name: 'Viewer', caps: ['Run queries & browse data (read-only)', 'See own write activity'] },
+  { name: 'Analyst', caps: ['Everything a Viewer can', 'Create, edit & delete data', 'Run data-quality audits'] },
+  { name: 'Admin', caps: ['Everything an Analyst can', 'View the full audit log (all users)', 'Manage roles & database access (this page)'] },
+];
+
 export default function AdminPage() {
   const { can } = useRoles();
   const [users, setUsers] = useState<AdminUser[]>([]);
@@ -182,6 +190,34 @@ export default function AdminPage() {
           <p style={{ fontSize: 12.5, color: 'var(--muted)', margin: '6px 0 0' }}>
             Changes take effect on the user&apos;s next sign-in.
           </p>
+        </div>
+
+        {/* Roles & permissions reference */}
+        <div className="qa-card" style={{ padding: 16, marginBottom: 20 }}>
+          <div style={{ fontSize: 12.5, fontWeight: 600, marginBottom: 12 }}>Roles &amp; permissions</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {ROLE_INFO.map((r) => (
+              <div key={r.name} style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+                <span style={{
+                  flexShrink: 0, width: 62, textAlign: 'center', fontSize: 11, fontWeight: 600, padding: '2px 0',
+                  borderRadius: 5, color: chipColor[r.name], background: `color-mix(in oklch, ${chipColor[r.name]} 14%, var(--panel))`,
+                  border: `1px solid color-mix(in oklch, ${chipColor[r.name]} 35%, var(--border))`,
+                }}>{r.name}</span>
+                <div style={{ fontSize: 12.5, color: 'var(--muted)', lineHeight: 1.6 }}>
+                  {r.caps.join(' · ')}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div style={{ height: 1, background: 'var(--border)', margin: '14px 0 12px' }} />
+          <div style={{ fontSize: 11.5, color: 'var(--muted)', lineHeight: 1.6 }}>
+            <strong style={{ color: 'var(--fg)', fontWeight: 500 }}>Scope:</strong> roles are cumulative and apply
+            app-wide (across every connection).{pgServers.length > 0 && (
+              <> <strong style={{ color: 'var(--fg)', fontWeight: 500 }}>PostgreSQL access</strong> (right column below)
+              is separate and scoped to a single server via Entra: <em>Read</em> grants SELECT; <em>Write</em> adds
+              INSERT / UPDATE / DELETE. Editing rows needs an Analyst/Admin role <em>and</em> PostgreSQL write access.</>
+            )}
+          </div>
         </div>
 
         {pgServers.length > 0 && (

--- a/frontend/pages/AuditPage.tsx
+++ b/frontend/pages/AuditPage.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
 import { useRoles } from '../hooks/useRoles';
 import { API_BASE_URL, USE_MSAL_AUTH } from '../app.config';
 import AppLayout from '../components/AppLayout';
 import ChartDisplay, { VisualizationConfig } from '../components/ChartDisplay';
 import { MOCK_AUDIT_EVENTS } from '../services/mockAuditData';
-import { getDatabasesForAccount, getAzureCosmosAccounts } from '../services/dbService';
+import { getDatabasesForAccount, getAzureCosmosAccounts, listPostgresServers } from '../services/dbService';
 import { CosmosDBAccount, DbInfo, CollectionSummary } from '../types';
 
 /* ── session connection (shared shape written by the connect flow) ────────── */
@@ -703,6 +703,28 @@ const AuditPage: React.FC = () => {
     const [conn, setConn] = useState<SessionConnection | null>(() => readSessionConnection());
     const [accountSwitching, setAccountSwitching] = useState(false);
 
+    // PostgreSQL audit: reached via /postgres-audit/:serverId. Keeps the PG
+    // shell (path starts with /postgres) and scopes events to that server,
+    // instead of falling back to the last Cosmos session connection.
+    const { serverId: rawServerId } = useParams<{ serverId?: string }>();
+    const pgServerId = rawServerId ? decodeURIComponent(rawServerId) : null;
+    const isPgAudit = !!pgServerId;
+    const [pgServerName, setPgServerName] = useState('');
+    useEffect(() => {
+        if (!isPgAudit) return;
+        let cancelled = false;
+        (async () => {
+            try {
+                const token = await getToken();
+                if (!token) return;
+                const servers = await listPostgresServers(token);
+                const srv = servers.find((s) => s.id === pgServerId);
+                if (!cancelled) setPgServerName(srv?.name ?? pgServerId!);
+            } catch { /* non-critical — fall back to the id */ }
+        })();
+        return () => { cancelled = true; };
+    }, [isPgAudit, pgServerId, getToken]);
+
     const [tab, setTab] = useState<'activity' | 'history' | 'ask'>('activity');
     const [range, setRange] = useState(7);
     const [opFilter, setOpFilter] = useState('all');
@@ -715,7 +737,7 @@ const AuditPage: React.FC = () => {
 
     // The audit log is scoped to the selected Cosmos account. database_name is
     // stored as "<account>.<database>", so we filter on the account segment.
-    const scopedAccount = conn?.accountName;
+    const scopedAccount = isPgAudit ? undefined : conn?.accountName;
 
     useEffect(() => {
         let cancelled = false;
@@ -758,10 +780,16 @@ const AuditPage: React.FC = () => {
         return () => { cancelled = true; };
     }, [getToken, scopedAccount]);
 
+    // In PG mode scope to this server's writes (database_name === serverId).
+    const baseEvents = useMemo(
+        () => (isPgAudit ? allEvents.filter((e) => e.database_name === pgServerId) : allEvents),
+        [allEvents, isPgAudit, pgServerId],
+    );
+
     const windowed = useMemo(() => {
         const cutoff = now - range * 86400000;
-        return allEvents.filter((e) => e.ts.getTime() >= cutoff);
-    }, [allEvents, range, now]);
+        return baseEvents.filter((e) => e.ts.getTime() >= cutoff);
+    }, [baseEvents, range, now]);
 
     const filtered = useMemo(() => windowed.filter((e) =>
         (opFilter === 'all' || e.operation === opFilter) &&
@@ -790,9 +818,9 @@ const AuditPage: React.FC = () => {
     }, [windowed, range, now]);
 
     const userOpts: DropdownOption[] = [{ value: 'all', label: 'All users' },
-        ...[...new Map(allEvents.map((e) => [e.user_email, e.person.name])).entries()].map(([email, name]) => ({ value: email, label: name }))];
+        ...[...new Map(baseEvents.map((e) => [e.user_email, e.person.name])).entries()].map(([email, name]) => ({ value: email, label: name }))];
     const collOpts: DropdownOption[] = [{ value: 'all', label: 'All collections' },
-        ...[...new Set(allEvents.map((e) => e.collection_name))].map((c) => ({ value: c, label: c }))];
+        ...[...new Set(baseEvents.map((e) => e.collection_name))].map((c) => ({ value: c, label: c }))];
     const opOpts: DropdownOption[] = [{ value: 'all', label: 'All operations' },
         ...OP_ORDER.map((k) => ({ value: k, label: OP[k].label, dot: OP[k].color }))];
     const ranges: [number, string][] = [[1, '24h'], [7, '7d'], [30, '30d'], [90, '90d']];
@@ -800,9 +828,13 @@ const AuditPage: React.FC = () => {
     // Prefer the live session connection (enables the chip switcher + Explorer
     // button); fall back to parsing the newest event's "account.database" string.
     const dbParts = (allEvents[0]?.database_name || '').split('.');
-    const accountId = conn?.accountId;
-    const accountName = conn?.accountName ?? dbParts[0] ?? undefined;
-    const databaseName = conn?.databaseName ?? dbParts.slice(1).join('.') ?? undefined;
+    const accountId = isPgAudit ? pgServerId! : conn?.accountId;
+    const accountName = isPgAudit
+        ? (pgServerName || pgServerId!)
+        : (conn?.accountName ?? dbParts[0] ?? undefined);
+    const databaseName = isPgAudit
+        ? undefined
+        : (conn?.databaseName ?? dbParts.slice(1).join('.') ?? undefined);
 
     const handleSwitchDatabase = useCallback((db: DbInfo) => {
         if (!conn) return;
@@ -840,9 +872,11 @@ const AuditPage: React.FC = () => {
     if (!isAdmin && !isAnalyst) {
         return (
             <AppLayout accountId={accountId} accountName={accountName} databaseName={databaseName}
-                collections={conn?.collections} availableAccounts={conn?.availableAccounts}
-                availableDbs={conn?.availableDbs} onSwitchDatabase={handleSwitchDatabase}
-                onSwitchAccount={handleSwitchAccount} chipLoading={accountSwitching}>
+                collections={isPgAudit ? undefined : conn?.collections}
+                availableAccounts={isPgAudit ? undefined : conn?.availableAccounts}
+                availableDbs={isPgAudit ? undefined : conn?.availableDbs}
+                onSwitchDatabase={isPgAudit ? undefined : handleSwitchDatabase}
+                onSwitchAccount={isPgAudit ? undefined : handleSwitchAccount} chipLoading={accountSwitching}>
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', flex: 1, gap: 12, color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>
                     <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                         <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
@@ -862,11 +896,11 @@ const AuditPage: React.FC = () => {
             accountId={accountId}
             accountName={accountName}
             databaseName={databaseName}
-            collections={conn?.collections}
-            availableAccounts={conn?.availableAccounts}
-            availableDbs={conn?.availableDbs}
-            onSwitchDatabase={handleSwitchDatabase}
-            onSwitchAccount={handleSwitchAccount}
+            collections={isPgAudit ? undefined : conn?.collections}
+            availableAccounts={isPgAudit ? undefined : conn?.availableAccounts}
+            availableDbs={isPgAudit ? undefined : conn?.availableDbs}
+            onSwitchDatabase={isPgAudit ? undefined : handleSwitchDatabase}
+            onSwitchAccount={isPgAudit ? undefined : handleSwitchAccount}
             chipLoading={accountSwitching}
         >
             <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, fontFamily: 'var(--font-body)' }}>

--- a/frontend/pages/AuditPage.tsx
+++ b/frontend/pages/AuditPage.tsx
@@ -629,8 +629,10 @@ function HistoryTimeline({ events, onOpen, now, isPg }: { events: AuditEvent[]; 
 /* ── Ask the log (NL → SQL via existing backend) ──────────────────────────── */
 interface AskResult { sql_query: string; results: any[]; summary: string; visualization?: VisualizationConfig }
 
-function AskPanel({ getToken }: { getToken: () => Promise<string | null> }) {
-    const [q, setQ] = useState('How many documents were updated in the last 7 days, grouped by collection?');
+function AskPanel({ getToken, isPg }: { getToken: () => Promise<string | null>; isPg: boolean }) {
+    const [q, setQ] = useState(isPg
+        ? 'How many rows were updated in the last 7 days, grouped by table?'
+        : 'How many documents were updated in the last 7 days, grouped by collection?');
     const [loading, setLoading] = useState(false);
     const [data, setData] = useState<AskResult | null>(null);
     const [error, setError] = useState<string | null>(null);
@@ -946,7 +948,7 @@ const AuditPage: React.FC = () => {
                 </div>
 
                 {tab === 'ask' ? (
-                    <div style={{ flex: 1, overflowY: 'auto', padding: '22px 28px' }}><AskPanel getToken={getToken} /></div>
+                    <div style={{ flex: 1, overflowY: 'auto', padding: '22px 28px' }}><AskPanel getToken={getToken} isPg={isPgAudit} /></div>
                 ) : tab === 'history' ? (
                     <div style={{ flex: 1, overflowY: 'auto', padding: '18px 28px 26px', display: 'flex', flexDirection: 'column', gap: 16 }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>

--- a/frontend/pages/AuditPage.tsx
+++ b/frontend/pages/AuditPage.tsx
@@ -851,6 +851,16 @@ const AuditPage: React.FC = () => {
 
     const handleSwitchAccount = useCallback(async (account: CosmosDBAccount) => {
         if (account.id === conn?.accountId) return;
+        // Coming from PG audit: the Cosmos audit only scopes by account name, so
+        // switch immediately and leave the PG shell. Don't block on (or fail
+        // silently in) a Cosmos databases fetch — the chip refetches on /audit.
+        if (isPgAudit) {
+            const next: SessionConnection = { accountId: account.id, accountName: account.name };
+            writeSessionConnection(next);
+            setConn(next);
+            navigate('/audit');
+            return;
+        }
         setAccountSwitching(true);
         try {
             const databases = await getDatabasesForAccount(account.id);
@@ -866,9 +876,6 @@ const AuditPage: React.FC = () => {
             };
             writeSessionConnection(next);
             setConn(next);
-            // Coming from PG audit: leave the PG shell for the Cosmos audit,
-            // scoped to the account we just wrote to the session.
-            if (isPgAudit) navigate('/audit');
         } catch (e) {
             console.error('Failed to switch account:', e);
         } finally {

--- a/frontend/pages/AuditPage.tsx
+++ b/frontend/pages/AuditPage.tsx
@@ -947,7 +947,14 @@ const AuditPage: React.FC = () => {
                     </div>
                 </div>
 
-                {tab === 'ask' ? (
+                {loading && allEvents.length === 0 && tab !== 'ask' ? (
+                    <div style={{ flex: 1, display: 'grid', placeItems: 'center' }}>
+                        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12, color: 'var(--muted)' }}>
+                            <svg width="22" height="22" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" style={{ animation: 'ws-spin 0.7s linear infinite', color: 'var(--accent)' }}><path d="M8 2a6 6 0 1 0 6 6" /></svg>
+                            <span style={{ fontSize: 12.5 }}>Loading audit log…</span>
+                        </div>
+                    </div>
+                ) : tab === 'ask' ? (
                     <div style={{ flex: 1, overflowY: 'auto', padding: '22px 28px' }}><AskPanel getToken={getToken} isPg={isPgAudit} /></div>
                 ) : tab === 'history' ? (
                     <div style={{ flex: 1, overflowY: 'auto', padding: '18px 28px 26px', display: 'flex', flexDirection: 'column', gap: 16 }}>

--- a/frontend/pages/AuditPage.tsx
+++ b/frontend/pages/AuditPage.tsx
@@ -305,12 +305,14 @@ function ValueCell({ value }: { value: any }) {
     return <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg)', wordBreak: 'break-word' }}>{typeof value === 'string' ? `"${value}"` : String(value)}</span>;
 }
 
-function DiffDrawer({ event, onClose, now, availableAccounts }: {
+function DiffDrawer({ event, onClose, now, availableAccounts, isPg }: {
     event: AuditEvent | null; onClose: () => void; now: number;
-    availableAccounts: CosmosDBAccount[];
+    availableAccounts: CosmosDBAccount[]; isPg: boolean;
 }) {
     const navigate = useNavigate();
     if (!event) return null;
+    const noun = isPg ? 'row' : 'document';
+    const Noun = isPg ? 'Row' : 'Document';
 
     // event.database_name is stored as "accountName.databaseName"
     const dbParts = event.database_name.split('.');
@@ -339,7 +341,7 @@ function DiffDrawer({ event, onClose, now, availableAccounts }: {
                     <OpBadge op={event.operation} />
                     <div style={{ flex: 1, minWidth: 0 }}>
                         <div style={{ fontSize: 13.5, fontWeight: 500 }}>
-                            {event.person.name} <span style={{ color: 'var(--muted)', fontWeight: 400 }}>{o.verb} a document in</span> <span style={{ fontFamily: 'var(--font-mono)' }}>{event.collection_name}</span>
+                            {event.person.name} <span style={{ color: 'var(--muted)', fontWeight: 400 }}>{o.verb} a {noun} in</span> <span style={{ fontFamily: 'var(--font-mono)' }}>{event.collection_name}</span>
                         </div>
                         <div style={{ fontSize: 11.5, color: 'var(--muted)', marginTop: 3 }}>{absTime(event.ts)} · {relTime(event.ts, now)}</div>
                     </div>
@@ -349,7 +351,7 @@ function DiffDrawer({ event, onClose, now, availableAccounts }: {
                 </div>
 
                 <div style={{ padding: '14px 20px', borderBottom: '1px solid var(--border)', display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '7px 14px', fontSize: 12 }}>
-                    {[['Actor', event.user_email], ['Database', event.database_name], ['Collection', event.collection_name], ['Document', event.document_id]].map(([k, v]) => (
+                    {[['Actor', event.user_email], ['Database', event.database_name], [isPg ? 'Table' : 'Collection', event.collection_name], [Noun, event.document_id]].map(([k, v]) => (
                         <React.Fragment key={k}>
                             <span style={{ color: 'var(--muted)' }}>{k}</span>
                             <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11.5, wordBreak: 'break-all' }}>{v}</span>
@@ -383,7 +385,7 @@ function DiffDrawer({ event, onClose, now, availableAccounts }: {
 
                     {event.operation === 'insert' && (
                         <div>
-                            <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em', color: '#3a8c5f', marginBottom: 9, fontWeight: 600 }}>Document created with</div>
+                            <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em', color: '#3a8c5f', marginBottom: 9, fontWeight: 600 }}>{Noun} created with</div>
                             <JsonBlock value={doc} />
                         </div>
                     )}
@@ -392,7 +394,7 @@ function DiffDrawer({ event, onClose, now, availableAccounts }: {
                         <div>
                             <div style={{ fontSize: 12.5, color: '#c94250', fontWeight: 500, marginBottom: 9, display: 'flex', alignItems: 'center', gap: 7 }}>
                                 <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M8 5v4M8 11h.01M8 1.5L1 14h14z" /></svg>
-                                Document was deleted. Snapshot at time of deletion:
+                                {Noun} was deleted. Snapshot at time of deletion:
                             </div>
                             <JsonBlock value={doc} />
                         </div>
@@ -404,8 +406,8 @@ function DiffDrawer({ event, onClose, now, availableAccounts }: {
                         className="qa-btn"
                         disabled={!canOpen}
                         title={
-                            event.operation === 'delete' ? 'Document was deleted' :
-                            (event.document_id === '—' || !event.document_id) ? 'Document ID unknown' :
+                            event.operation === 'delete' ? `${Noun} was deleted` :
+                            (event.document_id === '—' || !event.document_id) ? `${Noun} id unknown` :
                             !resolvedAccountId ? 'Account not found in your connections' :
                             undefined
                         }
@@ -417,7 +419,7 @@ function DiffDrawer({ event, onClose, now, availableAccounts }: {
                         }}
                     >
                         <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4"><path d="M3 8l3 3 7-7" /></svg>
-                        Open document
+                        Open {noun}
                     </button>
                     <button className="qa-btn" style={{ marginLeft: 'auto', gap: 6 }} onClick={() => navigator.clipboard?.writeText(JSON.stringify(event.diff_data, null, 2))}>
                         <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4"><rect x="3" y="3" width="8" height="10" rx="1" /><path d="M5 3V1.5h6V11" /></svg>
@@ -440,11 +442,12 @@ function FieldChips({ fields }: { fields: string[] }) {
     );
 }
 
-function EventRow({ e, onOpen, now }: { e: AuditEvent; onOpen: (e: AuditEvent) => void; now: number }) {
+function EventRow({ e, onOpen, now, isPg }: { e: AuditEvent; onOpen: (e: AuditEvent) => void; now: number; isPg: boolean }) {
     let summary: React.ReactNode;
     const d = e.diff_data || {};
+    const noun = isPg ? 'row' : 'document';
     if (e.operation === 'update') summary = <FieldChips fields={e.changedFields} />;
-    else summary = <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>{d.studyId || d.name || d.title || (e.operation === 'insert' ? 'new document' : 'document removed')}</span>;
+    else summary = <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>{d.studyId || d.name || d.title || (e.operation === 'insert' ? `new ${noun}` : `${noun} removed`)}</span>;
 
     return (
         <tr className="ad-row" onClick={() => onOpen(e)}>
@@ -505,8 +508,8 @@ function Dropdown({ label, value, options, onChange }: { label: string; value: s
     );
 }
 
-function EventLog({ events, onOpen, now }: { events: AuditEvent[]; onOpen: (e: AuditEvent) => void; now: number }) {
-    const cols = ['Operation', 'Actor', 'Collection', 'Document', 'What changed', 'When', ''];
+function EventLog({ events, onOpen, now, isPg }: { events: AuditEvent[]; onOpen: (e: AuditEvent) => void; now: number; isPg: boolean }) {
+    const cols = ['Operation', 'Actor', isPg ? 'Table' : 'Collection', isPg ? 'Row' : 'Document', 'What changed', 'When', ''];
 
     const exportCsv = () => {
         const header = ['operation', 'user_email', 'collection_name', 'document_id', 'timestamp_utc'];
@@ -542,7 +545,7 @@ function EventLog({ events, onOpen, now }: { events: AuditEvent[]; onOpen: (e: A
                     <tbody>
                         {events.length === 0 ? (
                             <tr><td colSpan={cols.length} style={{ padding: '40px 14px', textAlign: 'center', color: 'var(--muted)', fontSize: 12.5 }}>No events match these filters.</td></tr>
-                        ) : events.map((e) => <EventRow key={e.id} e={e} onOpen={onOpen} now={now} />)}
+                        ) : events.map((e) => <EventRow key={e.id} e={e} onOpen={onOpen} now={now} isPg={isPg} />)}
                     </tbody>
                 </table>
             </div>
@@ -561,7 +564,7 @@ function dayLabel(d: Date, now: number): string {
     return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'long', year: 'numeric' });
 }
 
-function HistoryTimeline({ events, onOpen, now }: { events: AuditEvent[]; onOpen: (e: AuditEvent) => void; now: number }) {
+function HistoryTimeline({ events, onOpen, now, isPg }: { events: AuditEvent[]; onOpen: (e: AuditEvent) => void; now: number; isPg: boolean }) {
     const groups = useMemo(() => {
         const m = new Map<string, { key: string; label: string; date: Date; items: AuditEvent[] }>();
         events.forEach((e) => {
@@ -603,7 +606,7 @@ function HistoryTimeline({ events, onOpen, now }: { events: AuditEvent[]; onOpen
                                     <div style={{ flex: 1, minWidth: 0, paddingBottom: idx < g.items.length - 1 ? 10 : 0 }}>
                                         <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, flexWrap: 'wrap' }}>
                                             <span style={{ fontSize: 12.5, fontWeight: 500 }}>{e.person.name}</span>
-                                            <span style={{ fontSize: 12.5, color: 'var(--muted)' }}>{o.verb} a document in</span>
+                                            <span style={{ fontSize: 12.5, color: 'var(--muted)' }}>{o.verb} a {isPg ? 'row' : 'document'} in</span>
                                             <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11.5 }}>{e.collection_name}</span>
                                             <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--muted)', whiteSpace: 'nowrap' }} title={absTime(e.ts)}>{relTime(e.ts, now)}</span>
                                         </div>
@@ -958,7 +961,7 @@ const AuditPage: React.FC = () => {
                         {loadError && (
                             <div style={{ padding: '12px 16px', borderRadius: 10, background: 'color-mix(in oklch, var(--status-err) 12%, var(--bg))', border: '1px solid color-mix(in oklch, var(--status-err) 25%, var(--border))', color: 'var(--status-err)', fontSize: 13 }}>{loadError}</div>
                         )}
-                        <HistoryTimeline events={windowed} onOpen={setSelected} now={now} />
+                        <HistoryTimeline events={windowed} onOpen={setSelected} now={now} isPg={isPgAudit} />
                     </div>
                 ) : (
                     <div style={{ flex: 1, overflowY: 'auto', padding: '18px 28px 26px', display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -972,8 +975,8 @@ const AuditPage: React.FC = () => {
                             </div>
                             <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>
                                 {isAdmin
-                                    ? `${counts.total} writes by ${counts.users} actors across ${counts.docs} documents`
-                                    : `${counts.total} writes across ${counts.docs} documents`
+                                    ? `${counts.total} writes by ${counts.users} actors across ${counts.docs} ${isPgAudit ? 'rows' : 'documents'}`
+                                    : `${counts.total} writes across ${counts.docs} ${isPgAudit ? 'rows' : 'documents'}`
                                 }
                             </span>
                         </div>
@@ -1001,7 +1004,7 @@ const AuditPage: React.FC = () => {
                             <Dropdown label="Collection" value={collFilter} options={collOpts} onChange={setCollFilter} />
                             <div style={{ display: 'flex', alignItems: 'center', gap: 7, height: 30, padding: '0 10px', background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 7, minWidth: 200 }}>
                                 <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="var(--muted)" strokeWidth="1.4"><circle cx="7" cy="7" r="4.5" /><path d="M11 11l3 3" /></svg>
-                                <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search document id or actor…"
+                                <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder={isPgAudit ? 'Search row id or actor…' : 'Search document id or actor…'}
                                     style={{ border: 'none', outline: 'none', background: 'transparent', fontFamily: 'inherit', fontSize: 12, color: 'var(--fg)', flex: 1, minWidth: 0 }} />
                             </div>
                             {hasFilters && (
@@ -1013,7 +1016,7 @@ const AuditPage: React.FC = () => {
 
                         {/* log + insights */}
                         <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1fr) 290px', gap: 16, alignItems: 'start' }}>
-                            <EventLog events={filtered} onOpen={setSelected} now={now} />
+                            <EventLog events={filtered} onOpen={setSelected} now={now} isPg={isPgAudit} />
                             <InsightsPanel events={windowed} />
                         </div>
 
@@ -1023,7 +1026,7 @@ const AuditPage: React.FC = () => {
                     </div>
                 )}
 
-                <DiffDrawer event={selected} onClose={() => setSelected(null)} now={now} availableAccounts={cosmosAccounts} />
+                <DiffDrawer event={selected} onClose={() => setSelected(null)} now={now} availableAccounts={cosmosAccounts} isPg={isPgAudit} />
             </div>
         </AppLayout>
     );

--- a/frontend/pages/AuditPage.tsx
+++ b/frontend/pages/AuditPage.tsx
@@ -108,7 +108,7 @@ function deriveEvent(r: RawAuditEvent, i: number): AuditEvent {
 
 /* ── operation badge ──────────────────────────────────────────────────────── */
 function OpBadge({ op, withLabel = true }: { op: Operation; withLabel?: boolean }) {
-    const o = OP[op];
+    const o = OP[op] ?? { label: op, verb: op, color: 'var(--muted)' };
     const icon = {
         insert: <path d="M8 3v10M3 8h10" />,
         update: <path d="M3 11l6-6 2 2-6 6H3zM10 4l2 2" />,
@@ -742,8 +742,13 @@ const AuditPage: React.FC = () => {
 
     useEffect(() => {
         let cancelled = false;
+        // This dashboard is a data-write view (insert/update/delete). Drop other
+        // recorded operations — e.g. PG grant/revoke access changes, which share
+        // the audit log — so counts, charts and badges stay coherent.
+        const CRUD = new Set(['insert', 'update', 'delete']);
         const toEvents = (raw: RawAuditEvent[]) =>
-            raw.map(deriveEvent).sort((a, b) => b.ts.getTime() - a.ts.getTime());
+            raw.filter((r) => CRUD.has(r.operation)).map(deriveEvent)
+                .sort((a, b) => b.ts.getTime() - a.ts.getTime());
         const load = async () => {
             setLoading(true); setLoadError(null);
             try {

--- a/frontend/pages/AuditPage.tsx
+++ b/frontend/pages/AuditPage.tsx
@@ -692,6 +692,7 @@ function AskPanel({ getToken }: { getToken: () => Promise<string | null> }) {
 /* ── main dashboard ───────────────────────────────────────────────────────── */
 const AuditPage: React.FC = () => {
     const { getToken } = useUnifiedAuth();
+    const navigate = useNavigate();
     const { can } = useRoles();
     const isAdmin = can('audit:read');
     const isAnalyst = !isAdmin && can('self:manage');
@@ -844,7 +845,7 @@ const AuditPage: React.FC = () => {
     }, [conn]);
 
     const handleSwitchAccount = useCallback(async (account: CosmosDBAccount) => {
-        if (!conn || account.id === conn.accountId) return;
+        if (account.id === conn?.accountId) return;
         setAccountSwitching(true);
         try {
             const databases = await getDatabasesForAccount(account.id);
@@ -855,17 +856,20 @@ const AuditPage: React.FC = () => {
                 accountName: account.name,
                 databaseName: firstDb.name,
                 collections: firstDb.collections,
-                availableAccounts: conn.availableAccounts,
+                availableAccounts: conn?.availableAccounts,
                 availableDbs: databases,
             };
             writeSessionConnection(next);
             setConn(next);
+            // Coming from PG audit: leave the PG shell for the Cosmos audit,
+            // scoped to the account we just wrote to the session.
+            if (isPgAudit) navigate('/audit');
         } catch (e) {
             console.error('Failed to switch account:', e);
         } finally {
             setAccountSwitching(false);
         }
-    }, [conn]);
+    }, [conn, isPgAudit, navigate]);
 
     const hasFilters = opFilter !== 'all' || userFilter !== 'all' || collFilter !== 'all' || !!search;
 
@@ -876,7 +880,7 @@ const AuditPage: React.FC = () => {
                 availableAccounts={isPgAudit ? undefined : conn?.availableAccounts}
                 availableDbs={isPgAudit ? undefined : conn?.availableDbs}
                 onSwitchDatabase={isPgAudit ? undefined : handleSwitchDatabase}
-                onSwitchAccount={isPgAudit ? undefined : handleSwitchAccount} chipLoading={accountSwitching}>
+                onSwitchAccount={handleSwitchAccount} chipLoading={accountSwitching}>
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', flex: 1, gap: 12, color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>
                     <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                         <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
@@ -900,7 +904,7 @@ const AuditPage: React.FC = () => {
             availableAccounts={isPgAudit ? undefined : conn?.availableAccounts}
             availableDbs={isPgAudit ? undefined : conn?.availableDbs}
             onSwitchDatabase={isPgAudit ? undefined : handleSwitchDatabase}
-            onSwitchAccount={isPgAudit ? undefined : handleSwitchAccount}
+            onSwitchAccount={handleSwitchAccount}
             chipLoading={accountSwitching}
         >
             <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, fontFamily: 'var(--font-body)' }}>

--- a/frontend/pages/HubPage.tsx
+++ b/frontend/pages/HubPage.tsx
@@ -336,13 +336,18 @@ const HubPage: React.FC = () => {
                 const isPg = engine === 'pg';
                 const account = accounts.find((a) => a.id === r.accountId);
                 const inert = !!busyAccountId;
-                const actionLabel = r.action === 'query' ? 'Query' : r.action === 'explorer' ? 'Explorer' : 'Workspace';
+                const actionLabel = r.action === 'explorer' ? 'Explorer' : 'Workspace';
                 return (
                   <button
                     key={`${r.accountId}-${r.action}`}
                     disabled={inert}
                     onClick={() => {
-                      if (isPg) { navigate(`/postgres/${encodeURIComponent(r.accountId)}`); return; }
+                      if (isPg) {
+                        navigate(r.action === 'explorer'
+                          ? `/postgres-explorer/${encodeURIComponent(r.accountId)}`
+                          : `/postgres/${encodeURIComponent(r.accountId)}`);
+                        return;
+                      }
                       const acc = account ?? ({ id: r.accountId, name: r.accountName } as CosmosDBAccount);
                       if (r.action === 'query') handleOpenAccount(acc);
                       else handleOpenExplorer(acc);
@@ -360,7 +365,7 @@ const HubPage: React.FC = () => {
                   >
                     <div style={{ width: 22, height: 22, borderRadius: 5, background: isPg ? '#31648c' : '#1a4f8c', color: '#fff', display: 'grid', placeItems: 'center', fontFamily: 'var(--font-display)', fontSize: 12, fontWeight: 600, flexShrink: 0 }}>{isPg ? 'P' : 'C'}</div>
                     <span style={{ fontSize: 13, fontWeight: 500 }}>{r.accountName}</span>
-                    <span className={`qa-chip${r.action === 'query' ? ' accent' : ''}`} style={{ fontSize: 10 }}>
+                    <span className={`qa-chip${r.action === 'explorer' ? '' : ' accent'}`} style={{ fontSize: 10 }}>
                       {actionLabel}
                     </span>
                     <span style={{ fontSize: 11, color: 'var(--muted)' }}>{formatRelativeTime(new Date(r.accessedAt).toISOString())}</span>
@@ -431,6 +436,11 @@ const HubPage: React.FC = () => {
                   saveRecent({ engine: 'pg', accountId: s.id, accountName: s.name, action: 'workspace' });
                   setRecents(loadRecents());
                   navigate(`/postgres/${encodeURIComponent(s.id)}`);
+                }}
+                onOpenExplorer={(s) => {
+                  saveRecent({ engine: 'pg', accountId: s.id, accountName: s.name, action: 'explorer' });
+                  setRecents(loadRecents());
+                  navigate(`/postgres-explorer/${encodeURIComponent(s.id)}`);
                 }}
               />
             ))}
@@ -660,8 +670,10 @@ const ConnectionCard: React.FC<{
 const PgConnectionCard: React.FC<{
   server: PostgresServer;
   onOpen: (s: PostgresServer) => void;
-}> = ({ server, onOpen }) => {
+  onOpenExplorer: (s: PostgresServer) => void;
+}> = ({ server, onOpen, onOpenExplorer }) => {
   const [hovered, setHovered] = useState(false);
+  const [explorerHovered, setExplorerHovered] = useState(false);
   return (
     <div
       onMouseEnter={() => setHovered(true)}
@@ -698,20 +710,41 @@ const PgConnectionCard: React.FC<{
 
       <div style={{ paddingTop: 12, borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
         <span className="qa-chip ok">● live</span>
-        <button
-          onClick={() => onOpen(server)}
-          style={{
-            display: 'inline-flex', alignItems: 'center', gap: 4,
-            fontSize: 12.5, padding: '5px 10px', borderRadius: 6,
-            border: 'none', background: 'none', color: 'var(--accent)',
-            cursor: 'pointer', fontFamily: 'var(--font-body)',
-          }}
-        >
-          Open
-          <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
-            <path d="M3 8h10M9 4l4 4-4 4"/>
-          </svg>
-        </button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <button
+            onClick={() => onOpenExplorer(server)}
+            onMouseEnter={() => setExplorerHovered(true)}
+            onMouseLeave={() => setExplorerHovered(false)}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 4,
+              fontSize: 12, padding: '5px 10px', borderRadius: 6,
+              border: `1px solid ${explorerHovered ? 'var(--accent)' : 'var(--border)'}`,
+              background: explorerHovered ? 'var(--accent-soft)' : 'var(--soft)',
+              color: explorerHovered ? 'var(--accent)' : 'var(--muted)',
+              cursor: 'pointer', fontFamily: 'var(--font-body)',
+              transition: 'border-color 0.12s, background 0.12s, color 0.12s',
+            }}
+          >
+            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M2 3h12v3H2zM2 7h12v3H2zM2 11h12v3H2z"/>
+            </svg>
+            Explorer
+          </button>
+          <button
+            onClick={() => onOpen(server)}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 4,
+              fontSize: 12.5, padding: '5px 10px', borderRadius: 6,
+              border: 'none', background: 'none', color: 'var(--accent)',
+              cursor: 'pointer', fontFamily: 'var(--font-body)',
+            }}
+          >
+            Open
+            <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
+              <path d="M3 8h10M9 4l4 4-4 4"/>
+            </svg>
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/pages/HubPage.tsx
+++ b/frontend/pages/HubPage.tsx
@@ -116,10 +116,9 @@ const DB_ENGINES = [
     markBg: '#326690',
     label: 'PostgreSQL',
     sub: 'Azure Flexible Server',
-    badge: 'Unavailable',
-    badgeOk: false,
-    locked: true,
-    opacity: 0.4,
+    badge: 'Generally available',
+    badgeOk: true,
+    locked: false,
   },
   {
     key: 'snow',
@@ -182,6 +181,8 @@ const HubPage: React.FC = () => {
   const [recents, setRecents] = useState<RecentConnection[]>(loadRecents);
 
   const [pgServers, setPgServers] = useState<PostgresServer[]>([]);
+  // Filter "Your connections" by engine when an enabled engine card is clicked.
+  const [engineFilter, setEngineFilter] = useState<'cosmos' | 'pg' | null>(null);
 
   useEffect(() => {
     getAzureCosmosAccounts()
@@ -371,6 +372,15 @@ const HubPage: React.FC = () => {
             <h2 style={{ fontFamily: 'var(--font-display)', fontWeight: 500, fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--muted)', margin: 0 }}>
               Your connections
             </h2>
+            {engineFilter && (
+              <button
+                onClick={() => setEngineFilter(null)}
+                style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 11.5, color: 'var(--accent)', background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'var(--font-body)' }}
+              >
+                Filtered: {engineFilter === 'pg' ? 'PostgreSQL' : 'Cosmos DB'}
+                <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6"><path d="M4 4l8 8M12 4l-8 8"/></svg>
+              </button>
+            )}
           </div>
 
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))', gap: 14 }}>
@@ -398,7 +408,7 @@ const HubPage: React.FC = () => {
                 No database connections found. Add a connection below.
               </div>
             )}
-            {accounts.map((account) => (
+            {engineFilter !== 'pg' && accounts.map((account) => (
               <ConnectionCard
                 key={account.id}
                 account={account}
@@ -408,22 +418,12 @@ const HubPage: React.FC = () => {
                 disabled={!!busyAccountId && busyAccountId !== account.id}
               />
             ))}
-            {pgServers.map((srv) => (
-              <button
+            {engineFilter !== 'cosmos' && pgServers.map((srv) => (
+              <PgConnectionCard
                 key={srv.id}
-                onClick={() => navigate(`/postgres/${encodeURIComponent(srv.id)}`)}
-                style={{
-                  textAlign: 'left', background: 'var(--panel)', border: '1px solid var(--border)',
-                  borderRadius: 14, padding: 22, cursor: 'pointer', display: 'flex',
-                  flexDirection: 'column', gap: 10,
-                }}
-              >
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                  <span className="qa-chip accent" style={{ fontSize: 11 }}>PostgreSQL</span>
-                </div>
-                <div style={{ fontFamily: 'var(--font-display)', fontSize: 16, color: 'var(--fg)' }}>{srv.name}</div>
-                <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11.5, color: 'var(--muted)' }}>{srv.fqdn}</div>
-              </button>
+                server={srv}
+                onOpen={(s) => navigate(`/postgres/${encodeURIComponent(s.id)}`)}
+              />
             ))}
           </div>
         </section>
@@ -437,9 +437,21 @@ const HubPage: React.FC = () => {
           </div>
 
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 12 }}>
-            {DB_ENGINES.map((engine) => (
-              <DbEngineCard key={engine.key} engine={engine} />
-            ))}
+            {DB_ENGINES.map((engine) => {
+              const filterable = engine.key === 'cosmos' || engine.key === 'pg';
+              return (
+                <DbEngineCard
+                  key={engine.key}
+                  engine={engine}
+                  active={filterable && engineFilter === engine.key}
+                  onSelect={
+                    filterable
+                      ? () => setEngineFilter((f) => (f === engine.key ? null : (engine.key as 'cosmos' | 'pg')))
+                      : undefined
+                  }
+                />
+              );
+            })}
           </div>
         </section>
 
@@ -635,16 +647,88 @@ const ConnectionCard: React.FC<{
   );
 };
 
-/* ── DB engine card ── */
-const DbEngineCard: React.FC<{ engine: typeof DB_ENGINES[0] }> = ({ engine }) => {
+/* ── PostgreSQL connection card (mirrors ConnectionCard for visual coherence) ── */
+const PgConnectionCard: React.FC<{
+  server: PostgresServer;
+  onOpen: (s: PostgresServer) => void;
+}> = ({ server, onOpen }) => {
+  const [hovered, setHovered] = useState(false);
   return (
     <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
       style={{
-        background: engine.locked ? 'var(--soft)' : 'var(--panel)',
-        border: '1px solid var(--border)', borderRadius: 12,
+        background: 'var(--panel)',
+        border: `1px solid ${hovered ? 'color-mix(in oklch, var(--accent) 35%, var(--border))' : 'var(--border)'}`,
+        borderRadius: 14, padding: 22,
+        display: 'flex', flexDirection: 'column', gap: 14,
+        transform: hovered ? 'translateY(-1px)' : 'none',
+        boxShadow: hovered ? '0 12px 24px -16px rgba(20,18,14,0.18)' : 'none',
+        transition: 'transform 0.12s, border-color 0.12s, box-shadow 0.12s',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <div style={{
+          width: 38, height: 38, borderRadius: 9, background: '#326690', color: '#fff',
+          display: 'grid', placeItems: 'center',
+          fontFamily: 'var(--font-display)', fontSize: 18, fontWeight: 500, letterSpacing: '-0.03em',
+          flexShrink: 0,
+        }}>P</div>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontSize: 15, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {server.name}
+          </div>
+          <div style={{
+            fontSize: 11.5, color: 'var(--muted)', fontFamily: 'var(--font-mono)',
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginTop: 2,
+          }}>
+            {server.fqdn}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ paddingTop: 12, borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+        <span className="qa-chip ok">● live</span>
+        <button
+          onClick={() => onOpen(server)}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 4,
+            fontSize: 12.5, padding: '5px 10px', borderRadius: 6,
+            border: 'none', background: 'none', color: 'var(--accent)',
+            cursor: 'pointer', fontFamily: 'var(--font-body)',
+          }}
+        >
+          Open
+          <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
+            <path d="M3 8h10M9 4l4 4-4 4"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+/* ── DB engine card ── */
+const DbEngineCard: React.FC<{
+  engine: typeof DB_ENGINES[0];
+  active?: boolean;
+  onSelect?: () => void;
+}> = ({ engine, active, onSelect }) => {
+  const [hovered, setHovered] = useState(false);
+  const clickable = !!onSelect;
+  return (
+    <div
+      onClick={onSelect}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        background: engine.locked ? 'var(--soft)' : active ? 'var(--accent-soft)' : 'var(--panel)',
+        border: `1px solid ${active ? 'var(--accent)' : clickable && hovered ? 'color-mix(in oklch, var(--accent) 35%, var(--border))' : 'var(--border)'}`,
+        borderRadius: 12,
         padding: 18, display: 'flex', flexDirection: 'column', gap: 10,
         minHeight: 160, opacity: engine.opacity ?? 1,
-        cursor: engine.locked ? 'default' : 'pointer',
+        cursor: clickable ? 'pointer' : 'default',
+        transition: 'border-color 0.12s, background 0.12s',
       }}
     >
       <div style={{

--- a/frontend/pages/HubPage.tsx
+++ b/frontend/pages/HubPage.tsx
@@ -4,7 +4,7 @@ import { useUnifiedAuth } from '../hooks/useUnifiedAuth';
 import { useTheme } from '../contexts/ThemeContext';
 import UserMenuButton from '../components/UserMenuButton';
 import CommandPalette from '../components/CommandPalette';
-import { getAzureCosmosAccounts } from '../services/dbService';
+import { getAzureCosmosAccounts, listPostgresServers, PostgresServer } from '../services/dbService';
 import { CosmosDBAccount } from '../types';
 import { API_BASE_URL } from '../app.config';
 
@@ -181,12 +181,21 @@ const HubPage: React.FC = () => {
   const [recentActivity, setRecentActivity] = useState<RecentActivityItem[]>([]);
   const [recents, setRecents] = useState<RecentConnection[]>(loadRecents);
 
+  const [pgServers, setPgServers] = useState<PostgresServer[]>([]);
+
   useEffect(() => {
     getAzureCosmosAccounts()
       .then((accs) => { setAccounts(accs); })
       .catch((err) => { setError(err.message || 'Failed to load accounts'); })
       .finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    getToken()
+      .then((token) => (token ? listPostgresServers(token) : []))
+      .then(setPgServers)
+      .catch(() => { /* PG discovery is best-effort; absence just hides the section */ });
+  }, [getToken]);
 
   useEffect(() => {
     const fetchRecent = async () => {
@@ -381,12 +390,12 @@ const HubPage: React.FC = () => {
                 {error}
               </div>
             )}
-            {!loading && !error && accounts.length === 0 && (
+            {!loading && !error && accounts.length === 0 && pgServers.length === 0 && (
               <div style={{
                 background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 14,
                 padding: 22, color: 'var(--muted)', fontSize: 13,
               }}>
-                No Cosmos DB accounts found. Add a connection below.
+                No database connections found. Add a connection below.
               </div>
             )}
             {accounts.map((account) => (
@@ -398,6 +407,23 @@ const HubPage: React.FC = () => {
                 busyAction={busyAccountId === account.id ? busyAction : null}
                 disabled={!!busyAccountId && busyAccountId !== account.id}
               />
+            ))}
+            {pgServers.map((srv) => (
+              <button
+                key={srv.id}
+                onClick={() => navigate(`/postgres/${encodeURIComponent(srv.id)}`)}
+                style={{
+                  textAlign: 'left', background: 'var(--panel)', border: '1px solid var(--border)',
+                  borderRadius: 14, padding: 22, cursor: 'pointer', display: 'flex',
+                  flexDirection: 'column', gap: 10,
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span className="qa-chip accent" style={{ fontSize: 11 }}>PostgreSQL</span>
+                </div>
+                <div style={{ fontFamily: 'var(--font-display)', fontSize: 16, color: 'var(--fg)' }}>{srv.name}</div>
+                <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11.5, color: 'var(--muted)' }}>{srv.fqdn}</div>
+              </button>
             ))}
           </div>
         </section>

--- a/frontend/pages/HubPage.tsx
+++ b/frontend/pages/HubPage.tsx
@@ -12,9 +12,10 @@ const RECENT_KEY = 'qp_recent_connections';
 const MAX_RECENTS = 3;
 
 interface RecentConnection {
-  accountId: string;
+  engine?: 'cosmos' | 'pg'; // absent on legacy entries => cosmos
+  accountId: string; // cosmos account id, or PG server id
   accountName: string;
-  action: 'query' | 'explorer';
+  action: 'query' | 'explorer' | 'workspace'; // pg uses 'workspace'
   accessedAt: number;
 }
 
@@ -331,13 +332,17 @@ const HubPage: React.FC = () => {
             </h2>
             <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
               {recents.map((r) => {
+                const engine = r.engine ?? 'cosmos';
+                const isPg = engine === 'pg';
                 const account = accounts.find((a) => a.id === r.accountId);
                 const inert = !!busyAccountId;
+                const actionLabel = r.action === 'query' ? 'Query' : r.action === 'explorer' ? 'Explorer' : 'Workspace';
                 return (
                   <button
                     key={`${r.accountId}-${r.action}`}
                     disabled={inert}
                     onClick={() => {
+                      if (isPg) { navigate(`/postgres/${encodeURIComponent(r.accountId)}`); return; }
                       const acc = account ?? ({ id: r.accountId, name: r.accountName } as CosmosDBAccount);
                       if (r.action === 'query') handleOpenAccount(acc);
                       else handleOpenExplorer(acc);
@@ -353,10 +358,10 @@ const HubPage: React.FC = () => {
                     onMouseEnter={(e) => { if (!inert) { (e.currentTarget as HTMLButtonElement).style.borderColor = 'color-mix(in oklch, var(--accent) 35%, var(--border))'; (e.currentTarget as HTMLButtonElement).style.background = 'var(--soft)'; } }}
                     onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--border)'; (e.currentTarget as HTMLButtonElement).style.background = 'var(--panel)'; }}
                   >
-                    <div style={{ width: 22, height: 22, borderRadius: 5, background: '#1a4f8c', color: '#fff', display: 'grid', placeItems: 'center', fontFamily: 'var(--font-display)', fontSize: 12, fontWeight: 600, flexShrink: 0 }}>C</div>
+                    <div style={{ width: 22, height: 22, borderRadius: 5, background: isPg ? '#31648c' : '#1a4f8c', color: '#fff', display: 'grid', placeItems: 'center', fontFamily: 'var(--font-display)', fontSize: 12, fontWeight: 600, flexShrink: 0 }}>{isPg ? 'P' : 'C'}</div>
                     <span style={{ fontSize: 13, fontWeight: 500 }}>{r.accountName}</span>
                     <span className={`qa-chip${r.action === 'query' ? ' accent' : ''}`} style={{ fontSize: 10 }}>
-                      {r.action === 'query' ? 'Query' : 'Explorer'}
+                      {actionLabel}
                     </span>
                     <span style={{ fontSize: 11, color: 'var(--muted)' }}>{formatRelativeTime(new Date(r.accessedAt).toISOString())}</span>
                   </button>
@@ -422,7 +427,11 @@ const HubPage: React.FC = () => {
               <PgConnectionCard
                 key={srv.id}
                 server={srv}
-                onOpen={(s) => navigate(`/postgres/${encodeURIComponent(s.id)}`)}
+                onOpen={(s) => {
+                  saveRecent({ engine: 'pg', accountId: s.id, accountName: s.name, action: 'workspace' });
+                  setRecents(loadRecents());
+                  navigate(`/postgres/${encodeURIComponent(s.id)}`);
+                }}
               />
             ))}
           </div>

--- a/frontend/pages/HubPage.tsx
+++ b/frontend/pages/HubPage.tsx
@@ -42,7 +42,7 @@ interface RecentActivityItem {
   database_name: string;
   collection_name: string;
   operation: string;
-  document_id: string;
+  document_id: string | null;
   user_email: string;
   timestamp_utc: string;
 }

--- a/frontend/pages/PostgresDataExplorerPage.tsx
+++ b/frontend/pages/PostgresDataExplorerPage.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import AppLayout from '../components/AppLayout';
 import PgRowDrawer from '../components/PgRowDrawer';
+import { DbInfo } from '../types';
 import {
   getAuthenticatedToken, getPgDatabases, getPgSchema, getPgTableInfo,
   getPgRows, pgInsertRow, pgUpdateRow, pgDeleteRow, listPostgresServers,
@@ -27,6 +28,7 @@ const PostgresDataExplorerPage: React.FC = () => {
   const database = rawDatabase ? decodeURIComponent(rawDatabase) : '';
 
   const [serverName, setServerName] = useState('');
+  const [databases, setDatabases] = useState<string[]>([]);
   const [schema, setSchema] = useState<SchemaGroup[]>([]);
   const [activeKey, setActiveKey] = useState<string | null>(null);
   const [columns, setColumns] = useState<Column[]>([]);
@@ -55,13 +57,16 @@ const PostgresDataExplorerPage: React.FC = () => {
         if (!srv) throw new Error('PostgreSQL server not found or not accessible.');
         if (cancelled) return;
         setServerName(srv.name);
+        const dbs = await getPgDatabases(token, serverId);
+        if (cancelled) return;
+        setDatabases(dbs);
         if (!database) {
-          const dbs = await getPgDatabases(token, serverId);
           const first = dbs[0];
           if (!first) throw new Error('No databases found on this server.');
           navigate(`/postgres-explorer/${encodeURIComponent(serverId)}/${encodeURIComponent(first)}`, { replace: true });
           return;
         }
+        setActiveKey(null); // dropping the selected table when the database changes
         const overview = await getPgSchema(token, serverId, database) as SchemaGroup[];
         if (!cancelled) setSchema(overview);
       } catch (e) {
@@ -113,6 +118,17 @@ const PostgresDataExplorerPage: React.FC = () => {
   const onPgTableSelect = useCallback((s: string, t: string) => {
     setActiveKey(`${s}.${t}`); setFilters([]); setSort(null); setPage(0);
   }, []);
+
+  // Connection-chip database switcher (parity with the Cosmos explorer). DbInfo
+  // needs name/collections/totalDocuments/size, but the chip only reads .name.
+  const availableDbs = useMemo<DbInfo[]>(
+    () => databases.map((name) => ({ name, collections: [], totalDocuments: 0, size: null })),
+    [databases],
+  );
+  const switchDatabase = useCallback((db: DbInfo) => {
+    if (db.name === database) return;
+    navigate(`/postgres-explorer/${encodeURIComponent(serverId)}/${encodeURIComponent(db.name)}`);
+  }, [database, serverId, navigate]);
 
   const toggleSort = (col: string) => setSort((prev) =>
     prev?.column === col ? { column: col, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { column: col, dir: 'asc' });
@@ -170,6 +186,8 @@ const PostgresDataExplorerPage: React.FC = () => {
       pgSchema={schema}
       activePgTables={activeKey ? [activeKey] : []}
       onPgTableSelect={onPgTableSelect}
+      availableDbs={availableDbs}
+      onSwitchDatabase={switchDatabase}
     >
       <div style={{ display: 'flex', height: '100%', overflow: 'hidden', background: 'var(--bg)', color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, padding: '18px 22px 0' }}>

--- a/frontend/pages/PostgresDataExplorerPage.tsx
+++ b/frontend/pages/PostgresDataExplorerPage.tsx
@@ -40,6 +40,7 @@ const PostgresDataExplorerPage: React.FC = () => {
   const [filters, setFilters] = useState<PgFilter[]>([]);
   const [sort, setSort] = useState<PgSort | null>(null);
   const [loading, setLoading] = useState(false);
+  const [schemaLoading, setSchemaLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [drawer, setDrawer] = useState<{ mode: 'edit' | 'new'; row?: Record<string, unknown> } | null>(null);
 
@@ -67,10 +68,13 @@ const PostgresDataExplorerPage: React.FC = () => {
           return;
         }
         setActiveKey(null); // dropping the selected table when the database changes
+        setSchemaLoading(true);
         const overview = await getPgSchema(token, serverId, database) as SchemaGroup[];
         if (!cancelled) setSchema(overview);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setSchemaLoading(false);
       }
     })();
     return () => { cancelled = true; };
@@ -186,6 +190,7 @@ const PostgresDataExplorerPage: React.FC = () => {
       pgSchema={schema}
       activePgTables={activeKey ? [activeKey] : []}
       onPgTableSelect={onPgTableSelect}
+      pgSchemaLoading={schemaLoading}
       availableDbs={availableDbs}
       onSwitchDatabase={switchDatabase}
     >

--- a/frontend/pages/PostgresDataExplorerPage.tsx
+++ b/frontend/pages/PostgresDataExplorerPage.tsx
@@ -1,0 +1,291 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import AppLayout from '../components/AppLayout';
+import PgRowDrawer from '../components/PgRowDrawer';
+import {
+  getAuthenticatedToken, getPgDatabases, getPgSchema, getPgTableInfo,
+  getPgRows, pgInsertRow, pgUpdateRow, pgDeleteRow, listPostgresServers,
+  PgFilter, PgSort,
+} from '../services/dbService';
+
+export interface Column { name: string; type: string; nullable: boolean; pk?: boolean; fk?: string | null }
+interface SchemaGroup { schema: string; tables: { name: string; rowEstimate: number }[] }
+
+const PAGE_SIZE = 50;
+const cellText = (v: unknown): string =>
+  v === null || v === undefined ? '' : typeof v === 'object' ? JSON.stringify(v) : String(v);
+
+const KeyBadge: React.FC<{ col: Column }> = ({ col }) =>
+  col.pk ? <span className="ws-keybadge pk" title="Primary key">PK</span>
+    : col.fk ? <span className="ws-keybadge fk" title={`Foreign key -> ${col.fk}`}>FK</span>
+      : <span className="ws-keybadge none">·</span>;
+
+const PostgresDataExplorerPage: React.FC = () => {
+  const { serverId: rawServerId, database: rawDatabase } = useParams<{ serverId: string; database?: string }>();
+  const navigate = useNavigate();
+  const serverId = rawServerId ? decodeURIComponent(rawServerId) : '';
+  const database = rawDatabase ? decodeURIComponent(rawDatabase) : '';
+
+  const [serverName, setServerName] = useState('');
+  const [schema, setSchema] = useState<SchemaGroup[]>([]);
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+  const [columns, setColumns] = useState<Column[]>([]);
+  const [pk, setPk] = useState<string[]>([]);
+  const [rows, setRows] = useState<unknown[][]>([]);
+  const [colNames, setColNames] = useState<string[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(0);
+  const [filters, setFilters] = useState<PgFilter[]>([]);
+  const [sort, setSort] = useState<PgSort | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [drawer, setDrawer] = useState<{ mode: 'edit' | 'new'; row?: Record<string, unknown> } | null>(null);
+
+  const [activeSchema, activeTable] = activeKey ? activeKey.split(/\.(.*)/s) : [null, null];
+
+  // Resolve server name + schema tree; redirect to first db if none in URL.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        setError(null);
+        const token = await getAuthenticatedToken();
+        const servers = await listPostgresServers(token);
+        const srv = servers.find((s) => s.id === serverId);
+        if (!srv) throw new Error('PostgreSQL server not found or not accessible.');
+        if (cancelled) return;
+        setServerName(srv.name);
+        if (!database) {
+          const dbs = await getPgDatabases(token, serverId);
+          const first = dbs[0];
+          if (!first) throw new Error('No databases found on this server.');
+          navigate(`/postgres-explorer/${encodeURIComponent(serverId)}/${encodeURIComponent(first)}`, { replace: true });
+          return;
+        }
+        const overview = await getPgSchema(token, serverId, database) as SchemaGroup[];
+        if (!cancelled) setSchema(overview);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [serverId, database, navigate]);
+
+  // On table change: load column metadata, reset view.
+  useEffect(() => {
+    if (!activeSchema || !activeTable) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        setError(null);
+        const token = await getAuthenticatedToken();
+        const info = await getPgTableInfo(token, serverId, database, activeSchema, activeTable) as { columns: Column[] };
+        if (cancelled) return;
+        setColumns(info.columns);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [activeKey, serverId, database]);
+
+  const fetchRows = useCallback(async () => {
+    if (!activeSchema || !activeTable) return;
+    try {
+      setLoading(true); setError(null);
+      const token = await getAuthenticatedToken();
+      const out = await getPgRows(token, {
+        serverId, database, schema: activeSchema, table: activeTable,
+        filters, sort, limit: PAGE_SIZE, offset: page * PAGE_SIZE,
+      });
+      setRows(out.rows); setColNames(out.columns); setTotal(out.total); setPk(out.pk);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [activeKey, serverId, database, filters, sort, page]);
+
+  useEffect(() => { fetchRows(); }, [fetchRows]);
+
+  // Manual table pick clears the view; the column-load effect only loads
+  // columns (it must NOT reset filters, or FK-nav filters below get clobbered).
+  const onPgTableSelect = useCallback((s: string, t: string) => {
+    setActiveKey(`${s}.${t}`); setFilters([]); setSort(null); setPage(0);
+  }, []);
+
+  const toggleSort = (col: string) => setSort((prev) =>
+    prev?.column === col ? { column: col, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { column: col, dir: 'asc' });
+
+  const onFkClick = (fk: string, value: unknown) => {
+    const [refTable, refCol] = fk.split('.');
+    setSort(null); setPage(0);
+    setActiveKey(`${activeSchema}.${refTable}`);
+    setFilters([{ column: refCol, op: '=', value }]);
+  };
+
+  // Filter builder (column -> operator -> value; AND-combined chips).
+  const OPS = ['=', '!=', '<', '>', '<=', '>=', 'ilike', 'isnull', 'isnotnull'];
+  const [draft, setDraft] = useState<{ column: string; op: string; value: string }>({ column: '', op: '=', value: '' });
+  const addFilter = () => {
+    if (!draft.column) return;
+    const nullary = draft.op === 'isnull' || draft.op === 'isnotnull';
+    setFilters((fs) => [...fs, { column: draft.column, op: draft.op, ...(nullary ? {} : { value: draft.value }) }]);
+    setDraft({ column: '', op: '=', value: '' });
+    setPage(0);
+  };
+
+  const rowToObject = (r: unknown[]): Record<string, unknown> =>
+    Object.fromEntries(colNames.map((c, i) => [c, r[i]]));
+  const pkOf = (row: Record<string, unknown>) => Object.fromEntries(pk.map((c) => [c, row[c]]));
+
+  const saveRow = async (values: Record<string, unknown>) => {
+    const token = await getAuthenticatedToken();
+    if (drawer?.mode === 'edit' && drawer.row) {
+      await pgUpdateRow(token, { serverId, database, schema: activeSchema!, table: activeTable!, pk: pkOf(drawer.row), values });
+    } else {
+      await pgInsertRow(token, { serverId, database, schema: activeSchema!, table: activeTable!, values });
+    }
+    setDrawer(null);
+    await fetchRows();
+  };
+
+  const deleteRow = async () => {
+    if (!drawer?.row) return;
+    const token = await getAuthenticatedToken();
+    await pgDeleteRow(token, { serverId, database, schema: activeSchema!, table: activeTable!, pk: pkOf(drawer.row) });
+    setDrawer(null);
+    await fetchRows();
+  };
+
+  const from = total === 0 ? 0 : page * PAGE_SIZE + 1;
+  const to = Math.min(total, (page + 1) * PAGE_SIZE);
+  const colFor = useMemo(() => new Map(columns.map((c) => [c.name, c])), [columns]);
+
+  return (
+    <AppLayout
+      accountName={serverName || 'PostgreSQL'}
+      accountId={serverId}
+      databaseName={database}
+      pgSchema={schema}
+      activePgTables={activeKey ? [activeKey] : []}
+      onPgTableSelect={onPgTableSelect}
+    >
+      <div style={{ display: 'flex', height: '100%', overflow: 'hidden', background: 'var(--bg)', color: 'var(--fg)', fontFamily: 'var(--font-body)' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, padding: '18px 22px 0' }}>
+          {error && (
+            <div style={{ background: 'color-mix(in oklch, var(--status-err) 10%, var(--bg))', border: '1px solid color-mix(in oklch, var(--status-err) 30%, var(--border))', color: 'var(--status-err)', padding: '10px 14px', borderRadius: 'var(--radius-md)', fontSize: 13, marginBottom: 12 }}>
+              <strong>Error: </strong>{error}
+            </div>
+          )}
+
+          {!activeKey ? (
+            <div style={{ margin: 'auto', textAlign: 'center', color: 'var(--muted)', fontSize: 13 }}>
+              Select a table from the sidebar to browse its rows.
+            </div>
+          ) : (
+            <>
+              {/* Header bar */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10, flexWrap: 'wrap' }}>
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 14, fontWeight: 500 }}>{activeKey}</span>
+                <button className="qa-btn primary" style={{ height: 28 }} disabled={pk.length === 0}
+                  title={pk.length === 0 ? 'Table has no primary key — read-only' : 'Insert a new row'}
+                  onClick={() => setDrawer({ mode: 'new' })}>+ New row</button>
+                <span style={{ marginLeft: 'auto', fontSize: 12, color: 'var(--muted)', fontFamily: 'var(--font-mono)' }}>
+                  {from}-{to} of {total.toLocaleString()}
+                </span>
+                <button className="qa-iconbtn" disabled={page === 0} onClick={() => setPage((p) => p - 1)} title="Previous page">&#x2039;</button>
+                <button className="qa-iconbtn" disabled={to >= total} onClick={() => setPage((p) => p + 1)} title="Next page">&#x203a;</button>
+              </div>
+
+              {/* Filter builder */}
+              <div style={{ display: 'flex', gap: 6, marginBottom: 10, flexWrap: 'wrap', alignItems: 'center' }}>
+                <select value={draft.column} onChange={(e) => setDraft((d) => ({ ...d, column: e.target.value }))}
+                  className="qa-btn" style={{ appearance: 'auto', height: 28 }}>
+                  <option value="">filter column…</option>
+                  {columns.map((c) => <option key={c.name} value={c.name}>{c.name}</option>)}
+                </select>
+                <select value={draft.op} onChange={(e) => setDraft((d) => ({ ...d, op: e.target.value }))}
+                  className="qa-btn" style={{ appearance: 'auto', height: 28 }}>
+                  {OPS.map((o) => <option key={o} value={o}>{o}</option>)}
+                </select>
+                {draft.op !== 'isnull' && draft.op !== 'isnotnull' && (
+                  <input value={draft.value} onChange={(e) => setDraft((d) => ({ ...d, value: e.target.value }))}
+                    placeholder="value"
+                    style={{ padding: '5px 8px', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', background: 'var(--panel)', color: 'var(--fg)', fontFamily: 'var(--font-mono)', fontSize: 12, height: 28, boxSizing: 'border-box' }} />
+                )}
+                <button className="qa-btn" style={{ height: 28 }} disabled={!draft.column} onClick={addFilter}>Add filter</button>
+              </div>
+
+              {/* Filter chips */}
+              {filters.length > 0 && (
+                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 10 }}>
+                  {filters.map((f, i) => (
+                    <span key={i} className="qa-chip accent" style={{ cursor: 'pointer' }}
+                      title="Remove filter"
+                      onClick={() => { setFilters((fs) => fs.filter((_, j) => j !== i)); setPage(0); }}>
+                      {f.column} {f.op} {cellText(f.value)} &#x2715;
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {/* Grid */}
+              <div className="qa-card" style={{ padding: 0, overflow: 'auto', flex: 1, minHeight: 0 }}>
+                <table className="ws-grid">
+                  <thead>
+                    <tr>
+                      <th className="rownum"></th>
+                      {colNames.map((c) => {
+                        const meta = colFor.get(c);
+                        return (
+                          <th key={c} onClick={() => toggleSort(c)} style={{ cursor: 'pointer', whiteSpace: 'nowrap' }} title={meta?.type}>
+                            {meta && <KeyBadge col={meta} />} {c}
+                            {sort?.column === c ? (sort.dir === 'asc' ? ' ▲' : ' ▼') : ''}
+                          </th>
+                        );
+                      })}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {loading && <tr><td colSpan={colNames.length + 1} style={{ padding: 16, color: 'var(--muted)' }}>Loading…</td></tr>}
+                    {!loading && rows.length === 0 && <tr><td colSpan={colNames.length + 1} style={{ padding: 16, color: 'var(--muted)' }}>No rows.</td></tr>}
+                    {!loading && rows.map((r, i) => (
+                      <tr key={i} style={{ cursor: 'pointer' }} onClick={() => setDrawer({ mode: 'edit', row: rowToObject(r as unknown[]) })}>
+                        <td className="rownum">{from + i}</td>
+                        {(r as unknown[]).map((v, j) => {
+                          const meta = colFor.get(colNames[j]);
+                          if (v === null || v === undefined) return <td key={j} className="null">NULL</td>;
+                          if (meta?.fk) return (
+                            <td key={j} onClick={(e) => { e.stopPropagation(); onFkClick(meta.fk!, v); }} style={{ color: 'var(--accent)', cursor: 'pointer' }} title={`Go to ${meta.fk}`}>{cellText(v)} →</td>
+                          );
+                          if (typeof v === 'number') return <td key={j} style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{v}</td>;
+                          const text = cellText(v);
+                          return <td key={j} title={text} style={{ maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis' }}>{text}</td>;
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+        </div>
+
+        {drawer && activeSchema && activeTable && (
+          <PgRowDrawer
+            columns={columns}
+            pk={pk}
+            mode={drawer.mode}
+            row={drawer.row ?? null}
+            onClose={() => setDrawer(null)}
+            onSave={saveRow}
+            onDelete={deleteRow}
+          />
+        )}
+      </div>
+    </AppLayout>
+  );
+};
+
+export default PostgresDataExplorerPage;

--- a/frontend/pages/PostgresExplorerPage.tsx
+++ b/frontend/pages/PostgresExplorerPage.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import AppLayout from '../components/AppLayout';
+import AgentVerdict from '../components/AgentVerdict';
 import {
   getAuthenticatedToken,
   getPgDatabases,
@@ -352,6 +353,7 @@ const PostgresExplorerPage: React.FC = () => {
   const [generating, setGenerating] = useState(false);
   const [sql, setSql] = useState('');
   const [sqlWriteNotice, setSqlWriteNotice] = useState<string | null>(null);
+  const [verdict, setVerdict] = useState<{ isValid?: boolean; explanation?: string } | null>(null);
 
   // Execution / results
   const [runState, setRunState] = useState<RunState>('idle');
@@ -439,7 +441,7 @@ const PostgresExplorerPage: React.FC = () => {
     return () => { cancelled = true; };
   }, [serverId, database, navigate]);
 
-  const resetResults = () => { setRunState('idle'); setSqlResult(null); setPlan(''); setMessages([]); setInsight(null); };
+  const resetResults = () => { setRunState('idle'); setSqlResult(null); setPlan(''); setMessages([]); setInsight(null); setVerdict(null); };
 
   const openTable = useCallback(async (
     schemaName: string, table: string, ev?: { ctrlKey?: boolean; metaKey?: boolean },
@@ -496,6 +498,7 @@ const PostgresExplorerPage: React.FC = () => {
         user_input: prompt, model, max_iterations: maxIterations,
       });
       setSql(out.generated_code || '');
+      setVerdict({ isValid: out.is_valid, explanation: out.explanation });
       if (out.is_write_action) {
         setSqlWriteNotice('Write/DDL detected — not executed. Review before running manually.');
       } else if (out.query_result && typeof out.query_result === 'object' && 'columns' in out.query_result) {
@@ -689,6 +692,8 @@ const PostgresExplorerPage: React.FC = () => {
                 Generate a query above, click a column to build one, or “Query table”.
               </div>
             )}
+
+            {verdict && <AgentVerdict isValid={verdict.isValid} explanation={verdict.explanation} />}
 
             {/* Results card */}
             {runState !== 'idle' && (

--- a/frontend/pages/PostgresExplorerPage.tsx
+++ b/frontend/pages/PostgresExplorerPage.tsx
@@ -1,0 +1,292 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import AppLayout from '../components/AppLayout';
+import {
+  getAuthenticatedToken,
+  getPgDatabases,
+  getPgSchema,
+  getPgTableInfo,
+  listPostgresServers,
+  pgExecute,
+  pgNl2Sql,
+} from '../services/dbService';
+
+// Shapes returned by the /postgres backend (see backend/services/azure_postgres_resources.py).
+interface SchemaGroup {
+  schema: string;
+  tables: { name: string; rowEstimate: number }[];
+}
+interface TableInfo {
+  schema: string;
+  table: string;
+  columns: { name: string; type: string; nullable: boolean }[];
+  indexes: string[];
+  sample: { columns: string[]; rows: any[][] };
+}
+interface SqlResult {
+  columns: string[];
+  rows: any[][];
+}
+
+const cellText = (v: any): string =>
+  v === null || v === undefined ? '' : typeof v === 'object' ? JSON.stringify(v) : String(v);
+
+const ResultTable: React.FC<{ columns: string[]; rows: any[][] }> = ({ columns, rows }) => (
+  <div style={{ overflow: 'auto', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)' }}>
+    <table style={{ borderCollapse: 'collapse', width: '100%', fontFamily: 'var(--font-mono)', fontSize: 12.5 }}>
+      <thead>
+        <tr>
+          {columns.map((c) => (
+            <th key={c} style={{ textAlign: 'left', padding: '6px 10px', borderBottom: '1px solid var(--border)', background: 'var(--soft)', color: 'var(--muted)', position: 'sticky', top: 0 }}>
+              {c}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, i) => (
+          <tr key={i}>
+            {row.map((v, j) => (
+              <td key={j} style={{ padding: '6px 10px', borderBottom: '1px solid var(--border)', color: 'var(--fg)', whiteSpace: 'nowrap' }}>
+                {cellText(v)}
+              </td>
+            ))}
+          </tr>
+        ))}
+        {rows.length === 0 && (
+          <tr><td colSpan={Math.max(columns.length, 1)} style={{ padding: '10px', color: 'var(--muted)' }}>No rows.</td></tr>
+        )}
+      </tbody>
+    </table>
+  </div>
+);
+
+const PostgresExplorerPage: React.FC = () => {
+  const { serverId: rawServerId, database: rawDatabase } = useParams<{ serverId: string; database?: string }>();
+  const navigate = useNavigate();
+  const serverId = rawServerId ? decodeURIComponent(rawServerId) : '';
+  const database = rawDatabase ? decodeURIComponent(rawDatabase) : '';
+
+  const [serverName, setServerName] = useState<string>('');
+  const [databases, setDatabases] = useState<string[]>([]);
+  const [schema, setSchema] = useState<SchemaGroup[]>([]);
+  const [tableInfo, setTableInfo] = useState<TableInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // NL->SQL state
+  const [prompt, setPrompt] = useState('');
+  const [generating, setGenerating] = useState(false);
+  const [sql, setSql] = useState('');
+  const [sqlResult, setSqlResult] = useState<SqlResult | null>(null);
+  const [sqlWriteNotice, setSqlWriteNotice] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+
+  // schema_context handed to the NL->SQL agent.
+  const schemaContext = useMemo(
+    () =>
+      schema
+        .flatMap((g) => g.tables.map((t) => `${g.schema}.${t.name}`))
+        .join('\n'),
+    [schema],
+  );
+
+  // Resolve server name + database list; if no database in URL, redirect to the first one.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const token = await getAuthenticatedToken();
+        const servers = await listPostgresServers(token);
+        const srv = servers.find((s) => s.id === serverId);
+        if (!srv) throw new Error('PostgreSQL server not found or not accessible.');
+        if (cancelled) return;
+        setServerName(srv.name);
+
+        const dbs = await getPgDatabases(token, serverId);
+        if (cancelled) return;
+        setDatabases(dbs);
+
+        if (!database) {
+          const first = dbs[0];
+          if (!first) throw new Error('No databases found on this server.');
+          navigate(`/postgres/${encodeURIComponent(serverId)}/${encodeURIComponent(first)}`, { replace: true });
+          return;
+        }
+
+        const overview = await getPgSchema(token, serverId, database);
+        if (cancelled) return;
+        setSchema(overview);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [serverId, database, navigate]);
+
+  const openTable = useCallback(async (schemaName: string, table: string) => {
+    try {
+      setError(null);
+      const token = await getAuthenticatedToken();
+      const info = await getPgTableInfo(token, serverId, database, schemaName, table);
+      setTableInfo(info);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [serverId, database]);
+
+  const generate = useCallback(async () => {
+    if (!prompt.trim()) return;
+    try {
+      setGenerating(true);
+      setError(null);
+      setSqlResult(null);
+      setSqlWriteNotice(null);
+      const token = await getAuthenticatedToken();
+      const out = await pgNl2Sql(token, {
+        server_id: serverId,
+        database,
+        schema_context: schemaContext,
+        user_input: prompt,
+      });
+      setSql(out.generated_code || '');
+      if (out.is_write_action) {
+        setSqlWriteNotice('Write/DDL detected — not executed. Review before running manually.');
+      } else if (out.query_result && typeof out.query_result === 'object' && 'columns' in out.query_result) {
+        setSqlResult(out.query_result as SqlResult);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setGenerating(false);
+    }
+  }, [prompt, serverId, database, schemaContext]);
+
+  const runSql = useCallback(async () => {
+    if (!sql.trim()) return;
+    try {
+      setRunning(true);
+      setError(null);
+      const token = await getAuthenticatedToken();
+      const out = await pgExecute(token, serverId, database, sql);
+      setSqlResult(out as SqlResult);
+      setSqlWriteNotice(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRunning(false);
+    }
+  }, [sql, serverId, database]);
+
+  const switchDatabase = (db: string) =>
+    navigate(`/postgres/${encodeURIComponent(serverId)}/${encodeURIComponent(db)}`);
+
+  return (
+    <AppLayout accountName={serverName || 'PostgreSQL'} accountId={serverId} databaseName={database}>
+      <div style={{ display: 'flex', height: '100%', background: 'var(--bg)' }}>
+        {/* Left: database picker + schema/tables */}
+        <div style={{ width: 280, borderRight: '1px solid var(--border)', overflow: 'auto', padding: 14, flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+            <span className="qa-chip accent" style={{ fontSize: 11 }}>PostgreSQL</span>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12.5, color: 'var(--muted)' }}>{serverName}</span>
+          </div>
+          <label style={{ fontSize: 11, color: 'var(--muted)', display: 'block', marginBottom: 4 }}>Database</label>
+          <select
+            value={database}
+            onChange={(e) => switchDatabase(e.target.value)}
+            style={{ width: '100%', marginBottom: 16, padding: '6px 8px', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'var(--panel)', color: 'var(--fg)', fontFamily: 'var(--font-mono)', fontSize: 12.5 }}
+          >
+            {databases.map((d) => <option key={d} value={d}>{d}</option>)}
+          </select>
+
+          {schema.map((g) => (
+            <div key={g.schema} style={{ marginBottom: 14 }}>
+              <div style={{ fontSize: 11, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 4 }}>{g.schema}</div>
+              {g.tables.map((t) => (
+                <button
+                  key={t.name}
+                  onClick={() => openTable(g.schema, t.name)}
+                  style={{
+                    display: 'flex', justifyContent: 'space-between', width: '100%', textAlign: 'left',
+                    padding: '5px 8px', border: 'none', borderRadius: 'var(--radius-sm)', cursor: 'pointer',
+                    background: tableInfo?.table === t.name && tableInfo?.schema === g.schema ? 'var(--accent-soft)' : 'transparent',
+                    color: 'var(--fg)', fontFamily: 'var(--font-mono)', fontSize: 12.5,
+                  }}
+                >
+                  <span>{t.name}</span>
+                  <span style={{ color: 'var(--muted)' }}>{t.rowEstimate}</span>
+                </button>
+              ))}
+            </div>
+          ))}
+        </div>
+
+        {/* Right: detail + NL->SQL */}
+        <div style={{ flex: 1, overflow: 'auto', padding: 20 }}>
+          {error && (
+            <div style={{ color: 'var(--status-err)', fontSize: 13, marginBottom: 14, fontFamily: 'var(--font-body)' }}>Error: {error}</div>
+          )}
+          {loading && <div style={{ color: 'var(--muted)', fontSize: 13 }}>Loading…</div>}
+
+          {/* NL -> SQL */}
+          <div className="qa-card" style={{ padding: 16, marginBottom: 20 }}>
+            <div style={{ fontFamily: 'var(--font-display)', fontSize: 15, marginBottom: 8 }}>Ask in natural language</div>
+            <textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="e.g. list the 10 most recent patients"
+              rows={2}
+              style={{ width: '100%', padding: 8, borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'var(--panel)', color: 'var(--fg)', fontFamily: 'var(--font-body)', fontSize: 13, resize: 'vertical' }}
+            />
+            <div style={{ marginTop: 8, display: 'flex', gap: 8 }}>
+              <button className="qa-btn primary" disabled={generating || !prompt.trim()} onClick={generate}>
+                {generating ? 'Generating…' : 'Generate SQL'}
+              </button>
+              {sql && (
+                <button className="qa-btn" disabled={running} onClick={runSql}>
+                  {running ? 'Running…' : 'Run'}
+                </button>
+              )}
+            </div>
+            {sql && (
+              <pre style={{ marginTop: 12, padding: 12, background: 'var(--soft)', borderRadius: 'var(--radius-sm)', fontFamily: 'var(--font-mono)', fontSize: 12.5, color: 'var(--fg)', whiteSpace: 'pre-wrap', overflow: 'auto' }}>{sql}</pre>
+            )}
+            {sqlWriteNotice && (
+              <div className="qa-chip warn" style={{ marginTop: 8 }}>{sqlWriteNotice}</div>
+            )}
+            {sqlResult && (
+              <div style={{ marginTop: 12 }}><ResultTable columns={sqlResult.columns} rows={sqlResult.rows} /></div>
+            )}
+          </div>
+
+          {/* Table detail */}
+          {tableInfo && (
+            <div className="qa-card" style={{ padding: 16 }}>
+              <div style={{ fontFamily: 'var(--font-display)', fontSize: 15, marginBottom: 4 }}>
+                {tableInfo.schema}.{tableInfo.table}
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--muted)', marginBottom: 12 }}>
+                {tableInfo.columns.length} columns · indexes: {tableInfo.indexes.join(', ') || 'none'}
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 16 }}>
+                {tableInfo.columns.map((c) => (
+                  <span key={c.name} className="qa-chip" style={{ fontFamily: 'var(--font-mono)', fontSize: 11.5 }}>
+                    {c.name} <span style={{ color: 'var(--muted)' }}>{c.type}{c.nullable ? '?' : ''}</span>
+                  </span>
+                ))}
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--muted)', marginBottom: 6 }}>Sample rows</div>
+              <ResultTable columns={tableInfo.sample.columns} rows={tableInfo.sample.rows} />
+            </div>
+          )}
+        </div>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default PostgresExplorerPage;

--- a/frontend/pages/PostgresExplorerPage.tsx
+++ b/frontend/pages/PostgresExplorerPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import AppLayout from '../components/AppLayout';
 import {
@@ -7,6 +7,7 @@ import {
   getPgSchema,
   getPgTableInfo,
   listPostgresServers,
+  pgAnalyze,
   pgExecute,
   pgNl2Sql,
 } from '../services/dbService';
@@ -16,50 +17,294 @@ interface SchemaGroup {
   schema: string;
   tables: { name: string; rowEstimate: number }[];
 }
+interface Column {
+  name: string;
+  type: string;
+  nullable: boolean;
+  pk?: boolean;
+  fk?: string | null;
+}
+interface IndexInfo {
+  name: string;
+  cols: string;
+  kind: 'uniq' | 'gin' | 'index';
+}
 interface TableInfo {
   schema: string;
   table: string;
-  columns: { name: string; type: string; nullable: boolean }[];
-  indexes: string[];
+  columns: Column[];
+  indexes: IndexInfo[];
   sample: { columns: string[]; rows: any[][]; error?: string };
 }
 interface SqlResult {
   columns: string[];
   rows: any[][];
 }
+interface Insight {
+  summary: string;
+  points: string[];
+  followups: string[];
+}
+type Message = { t: string; kind: 'ok' | 'err'; msg: string };
+type RunState = 'idle' | 'running' | 'done';
 
 const cellText = (v: any): string =>
   v === null || v === undefined ? '' : typeof v === 'object' ? JSON.stringify(v) : String(v);
 
-const ResultTable: React.FC<{ columns: string[]; rows: any[][] }> = ({ columns, rows }) => (
-  <div style={{ overflow: 'auto', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)' }}>
-    <table style={{ borderCollapse: 'collapse', width: '100%', fontFamily: 'var(--font-mono)', fontSize: 12.5 }}>
-      <thead>
-        <tr>
-          {columns.map((c) => (
-            <th key={c} style={{ textAlign: 'left', padding: '6px 10px', borderBottom: '1px solid var(--border)', background: 'var(--soft)', color: 'var(--muted)', position: 'sticky', top: 0 }}>
-              {c}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row, i) => (
-          <tr key={i}>
-            {row.map((v, j) => (
-              <td key={j} style={{ padding: '6px 10px', borderBottom: '1px solid var(--border)', color: 'var(--fg)', whiteSpace: 'nowrap' }}>
-                {cellText(v)}
-              </td>
-            ))}
-          </tr>
-        ))}
-        {rows.length === 0 && (
-          <tr><td colSpan={Math.max(columns.length, 1)} style={{ padding: '10px', color: 'var(--muted)' }}>No rows.</td></tr>
-        )}
-      </tbody>
-    </table>
-  </div>
+const now = () =>
+  new Date().toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+
+// ── SQL syntax highlighter (ported from the Query Workspace design) ──────────
+const SQL_KW = new Set(['select', 'from', 'where', 'join', 'left', 'right', 'inner', 'outer', 'full', 'on', 'and', 'or', 'not', 'null', 'as', 'order', 'by', 'group', 'having', 'limit', 'offset', 'distinct', 'ilike', 'like', 'in', 'is', 'asc', 'desc', 'case', 'when', 'then', 'else', 'end', 'explain', 'analyze', 'interval', 'union', 'all', 'using', 'between', 'exists', 'with']);
+const SQL_FN = new Set(['count', 'sum', 'avg', 'min', 'max', 'now', 'coalesce', 'date_trunc', 'lower', 'upper', 'round', 'age', 'extract', 'array_agg', 'cast']);
+const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+function highlightSQL(code: string): string {
+  let out = '';
+  let i = 0;
+  const re = /--[^\n]*|'(?:[^'\\]|\\.)*'|\b\d+\.?\d*\b|[A-Za-z_][A-Za-z0-9_]*|\s+|[^\sA-Za-z0-9_]/y;
+  while (i < code.length) {
+    re.lastIndex = i;
+    const m = re.exec(code);
+    if (!m) { out += esc(code[i]); i++; continue; }
+    const t = m[0];
+    if (t.startsWith('--')) out += `<span class="tk-cm">${esc(t)}</span>`;
+    else if (t[0] === "'") out += `<span class="tk-st">${esc(t)}</span>`;
+    else if (/^\d/.test(t)) out += `<span class="tk-nm">${esc(t)}</span>`;
+    else if (/^[A-Za-z_]/.test(t)) {
+      const l = t.toLowerCase();
+      out += SQL_KW.has(l) ? `<span class="tk-kw">${esc(t)}</span>`
+        : SQL_FN.has(l) ? `<span class="tk-fn">${esc(t)}</span>` : esc(t);
+    } else if (/^\s+$/.test(t)) out += t;
+    else out += `<span class="tk-pu">${esc(t)}</span>`;
+    i += t.length;
+  }
+  return out;
+}
+function highlightPlan(text: string): string {
+  return esc(text)
+    .replace(/\b(Limit|Sort|Hash Join|Hash|Seq Scan|Index Scan|Index Only Scan|Bitmap Heap Scan|Nested Loop|Aggregate|Gather|Materialize)\b/g, '<span class="pn">$1</span>')
+    .replace(/\b(cost|actual time|rows|loops|width|Memory|Buckets|Batches)\b/g, '<span class="pc">$1</span>')
+    .replace(/\b(\d+\.?\d*)\b/g, '<span class="pv">$1</span>');
+}
+
+const SparkIcon = ({ stroke = 'currentColor' }: { stroke?: string }) => (
+  <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke={stroke} strokeWidth="1.5"><path d="M8 1.5l1.4 3.8L13 6.5l-3.6 1.2L8 11.5 6.6 7.7 3 6.5l3.6-1.2z" /></svg>
 );
+const Spinner = ({ size = 13 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" style={{ animation: 'ws-spin 0.7s linear infinite' }}><path d="M8 2a6 6 0 1 0 6 6" /></svg>
+);
+const PlayIcon = () => (
+  <svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor"><polygon points="4,2 14,8 4,14" /></svg>
+);
+const dbIcon = (
+  <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" style={{ flexShrink: 0 }}>
+    <ellipse cx="8" cy="4" rx="6" ry="2" /><path d="M2 4v8c0 1.1 2.7 2 6 2s6-.9 6-2V4M2 8c0 1.1 2.7 2 6 2s6-.9 6-2" />
+  </svg>
+);
+
+// ── Column key badge (PK / FK / none) ───────────────────────────────────────
+const KeyBadge: React.FC<{ col: Column }> = ({ col }) => {
+  if (col.pk) return <span className="ws-keybadge pk" title="Primary key">PK</span>;
+  if (col.fk) return <span className="ws-keybadge fk" title={`Foreign key → ${col.fk}`}>FK</span>;
+  return <span className="ws-keybadge none">·</span>;
+};
+
+// ── Two-column schema card ───────────────────────────────────────────────────
+const SchemaCard: React.FC<{
+  info: TableInfo;
+  rowEstimate: number | null;
+  open: boolean;
+  onToggle: () => void;
+  onInsert: (snippet: string) => void;
+  onQueryTable: () => void;
+}> = ({ info, rowEstimate, open, onToggle, onInsert, onQueryTable }) => {
+  const fks = info.columns.filter((c) => c.fk);
+  return (
+    <div className="qa-card" style={{ padding: 0, overflow: 'hidden' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '10px 14px', borderBottom: open ? '1px solid var(--border)' : 'none' }}>
+        <span style={{ color: 'var(--accent)', display: 'flex' }}>
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3"><rect x="2" y="3" width="12" height="10" rx="1.5" /><path d="M2 6.5h12M6 6.5V13" /></svg>
+        </span>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 13.5, fontWeight: 500 }}>{info.schema}.{info.table}</span>
+        {rowEstimate != null && <span className="qa-tag">~{rowEstimate.toLocaleString()} rows</span>}
+        <span className="qa-tag">{info.columns.length} cols</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 7, alignItems: 'center' }}>
+          <button className="qa-btn primary" style={{ height: 27, gap: 6 }} onClick={onQueryTable}>
+            <PlayIcon /> Query table
+          </button>
+          <button className="qa-iconbtn" onClick={onToggle} title={open ? 'Collapse schema' : 'Expand schema'}>
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" style={{ transform: open ? 'none' : 'rotate(-90deg)', transition: 'transform .12s' }}><path d="M4 6l4 4 4-4" /></svg>
+          </button>
+        </div>
+      </div>
+      {open && (
+        <div className="ws-schemacard">
+          <div className="ws-scol">
+            <div className="ws-sec-h">Columns <span className="n">{info.columns.length}</span></div>
+            {info.columns.map((c) => (
+              <div className="ws-col" key={c.name} onClick={() => onInsert(`${info.table}.${c.name}`)} title={`Insert ${info.table}.${c.name}`}>
+                <KeyBadge col={c} />
+                <span className={'ws-col-name' + (c.fk ? ' fk' : '')}>{c.name}</span>
+                <span style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span className="ws-col-type">{c.type}</span>
+                  <span className={'ws-nn ' + (!c.nullable ? 'on' : 'off')} title={!c.nullable ? 'NOT NULL' : 'nullable'} />
+                  <svg className="ws-col-add" width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6"><path d="M8 3v10M3 8h10" /></svg>
+                </span>
+              </div>
+            ))}
+          </div>
+          <div className="ws-scol">
+            <div className="ws-sec-h">Indexes <span className="n">{info.indexes.length}</span></div>
+            {info.indexes.length === 0
+              ? <div style={{ padding: '2px 6px', fontSize: 11.5, color: 'var(--muted)' }}>No indexes.</div>
+              : info.indexes.map((ix) => (
+                <div className="ws-idx" key={ix.name}>
+                  <span className={'ws-idx-kind ' + (ix.kind === 'uniq' ? 'uniq' : ix.kind === 'gin' ? 'gin' : '')}>{ix.kind === 'uniq' ? 'UQ' : ix.kind === 'gin' ? 'GIN' : 'IDX'}</span>
+                  <span className="ws-idx-name" title={ix.name}>{ix.name}</span>
+                  {ix.cols && <span className="ws-idx-cols">({ix.cols})</span>}
+                </div>
+              ))}
+            <div className="ws-sec-h" style={{ marginTop: 14 }}>Foreign keys <span className="n">{fks.length}</span></div>
+            {fks.length === 0
+              ? <div style={{ padding: '2px 6px', fontSize: 11.5, color: 'var(--muted)' }}>No outbound references.</div>
+              : fks.map((c) => (
+                <div className="ws-fk" key={c.name}>
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="var(--muted)" strokeWidth="1.4" style={{ flexShrink: 0 }}><path d="M6 10a3 3 0 0 1 0-4l1-1a3 3 0 0 1 4 4M10 6a3 3 0 0 1 0 4l-1 1a3 3 0 0 1-4-4" /></svg>
+                  <span className="src">{c.name}</span><span className="arr">→</span><span className="dst">{c.fk}</span>
+                </div>
+              ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ── Dark SQL editor with highlight overlay ───────────────────────────────────
+const SqlEditor: React.FC<{
+  sql: string;
+  onChange: (v: string) => void;
+  taRef: React.RefObject<HTMLTextAreaElement | null>;
+  onRun: () => void;
+  onExplain: () => void;
+  running: boolean;
+}> = ({ sql, onChange, taRef, onRun, onExplain, running }) => {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+  const onScroll = (e: React.UIEvent<HTMLTextAreaElement>) => {
+    if (preRef.current) { preRef.current.scrollTop = e.currentTarget.scrollTop; preRef.current.scrollLeft = e.currentTarget.scrollLeft; }
+  };
+  const copy = () => { navigator.clipboard?.writeText(sql); setCopied(true); setTimeout(() => setCopied(false), 1500); };
+  return (
+    <div className="qa-card" style={{ padding: '10px 14px 12px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg)' }}>// generated SQL</span>
+      </div>
+      <div className="ws-editor">
+        <pre className="hl" ref={preRef} aria-hidden="true" dangerouslySetInnerHTML={{ __html: highlightSQL(sql) + '\n' }} />
+        <textarea ref={taRef} value={sql} spellCheck={false} onScroll={onScroll} onChange={(e) => onChange(e.target.value)} />
+        <button className="ws-copy" onClick={copy} style={{ color: copied ? '#8fce9e' : undefined }}>{copied ? '✓ copied' : 'copy'}</button>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10 }}>
+        <button className="qa-btn" style={{ height: 30, gap: 6 }} disabled={running || !sql.trim()} onClick={onExplain}>
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4"><path d="M2 13h12M4 11V7M7 11V4M10 11V8M13 11V5" /></svg>
+          Explain
+        </button>
+        <button className="qa-btn primary" style={{ height: 30, gap: 6 }} disabled={running || !sql.trim()} onClick={onRun}>
+          {running ? <><Spinner size={12} /> Running</> : <><PlayIcon /> Run</>}
+        </button>
+        <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--muted)', fontFamily: 'var(--font-mono)' }}>⌘↩ run</span>
+      </div>
+    </div>
+  );
+};
+
+// ── Results grid ─────────────────────────────────────────────────────────────
+const ResultsGrid: React.FC<{ columns: string[]; rows: any[][] }> = ({ columns, rows }) => (
+  <table className="ws-grid">
+    <thead><tr><th className="rownum"></th>{columns.map((c) => <th key={c}>{c}</th>)}</tr></thead>
+    <tbody>
+      {rows.map((r, i) => (
+        <tr key={i}>
+          <td className="rownum">{i + 1}</td>
+          {r.map((v, j) => {
+            if (v === null || v === undefined) return <td key={j} className="null">NULL</td>;
+            if (typeof v === 'number') return <td key={j} style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{v}</td>;
+            const text = cellText(v);
+            return <td key={j} title={text} style={{ maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis' }}>{text}</td>;
+          })}
+        </tr>
+      ))}
+      {rows.length === 0 && <tr><td colSpan={columns.length + 1} style={{ padding: 12, color: 'var(--muted)' }}>No rows.</td></tr>}
+    </tbody>
+  </table>
+);
+
+// ── Right-rail AI insights ───────────────────────────────────────────────────
+const InsightsPanel: React.FC<{
+  hasResult: boolean;
+  insight: Insight | null;
+  analyzing: boolean;
+  onAnalyze: () => void;
+  onFollowup: (f: string) => void;
+}> = ({ hasResult, insight, analyzing, onAnalyze, onFollowup }) => (
+  <aside className="ws-insights">
+    <div className="ws-ins-hd">
+      <SparkIcon stroke="var(--accent)" />
+      <span className="t">Insights</span>
+      <span className="qa-tag" style={{ marginLeft: 'auto' }}>AI</span>
+    </div>
+    <div className="ws-ins-body">
+      {!hasResult ? (
+        <div style={{ padding: '8px 2px' }}>
+          <div style={{ fontSize: 13, fontWeight: 500, marginBottom: 5 }}>Run a query to see AI insights</div>
+          <div style={{ fontSize: 12.5, color: 'var(--muted)', lineHeight: 1.55 }}>After executing, use “Analyze” on the results to get patterns, anomalies, and follow-up suggestions.</div>
+        </div>
+      ) : !insight ? (
+        <div className="ws-anim" style={{ padding: '8px 2px' }}>
+          <div style={{ fontSize: 12.5, color: 'var(--muted)', lineHeight: 1.55, marginBottom: 12 }}>
+            Results ready. Analyze them for patterns, anomalies and suggested follow-ups.
+          </div>
+          <button className="qa-btn primary" style={{ width: '100%', justifyContent: 'center', height: 34 }} disabled={analyzing} onClick={onAnalyze}>
+            {analyzing ? <><Spinner /> Analyzing…</> : <><SparkIcon /> Analyze results</>}
+          </button>
+        </div>
+      ) : (
+        <div className="ws-anim" style={{ padding: '4px 0 8px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div>
+            <div style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.07em', color: 'var(--muted)', fontWeight: 500, marginBottom: 7 }}>Summary</div>
+            <div style={{ fontSize: 12.5, lineHeight: 1.6 }}>{insight.summary}</div>
+          </div>
+          {insight.points.length > 0 && (
+            <div>
+              <div style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.07em', color: 'var(--muted)', fontWeight: 500, marginBottom: 7 }}>Patterns</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>
+                {insight.points.map((p, i) => (
+                  <div key={i} style={{ display: 'flex', gap: 8, fontSize: 12.5, lineHeight: 1.5 }}>
+                    <span style={{ width: 5, height: 5, borderRadius: 99, background: 'var(--accent)', marginTop: 6, flexShrink: 0 }} />
+                    <span>{p}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {insight.followups.length > 0 && (
+            <div>
+              <div style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.07em', color: 'var(--muted)', fontWeight: 500, marginBottom: 3 }}>Suggested follow-ups</div>
+              {insight.followups.map((f, i) => (
+                <button key={i} className="ws-sug" onClick={() => onFollowup(f)}>
+                  <span style={{ color: 'var(--accent)', marginRight: 6 }}>→</span>{f}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  </aside>
+);
+
+const EXAMPLES = ['count rows per table', 'the 10 most recent records', 'rows added in the last 7 days'];
 
 const PostgresExplorerPage: React.FC = () => {
   const { serverId: rawServerId, database: rawDatabase } = useParams<{ serverId: string; database?: string }>();
@@ -67,31 +312,49 @@ const PostgresExplorerPage: React.FC = () => {
   const serverId = rawServerId ? decodeURIComponent(rawServerId) : '';
   const database = rawDatabase ? decodeURIComponent(rawDatabase) : '';
 
-  const [serverName, setServerName] = useState<string>('');
+  const [serverName, setServerName] = useState('');
   const [databases, setDatabases] = useState<string[]>([]);
   const [schema, setSchema] = useState<SchemaGroup[]>([]);
   const [tableInfo, setTableInfo] = useState<TableInfo | null>(null);
+  const [schemaOpen, setSchemaOpen] = useState(true);
+  const [tableLoading, setTableLoading] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // NL->SQL state
+  // NL -> SQL
   const [prompt, setPrompt] = useState('');
+  const [model, setModel] = useState('gemini-2.5-flash');
+  const [maxIterations, setMaxIterations] = useState(3);
   const [generating, setGenerating] = useState(false);
   const [sql, setSql] = useState('');
-  const [sqlResult, setSqlResult] = useState<SqlResult | null>(null);
   const [sqlWriteNotice, setSqlWriteNotice] = useState<string | null>(null);
-  const [running, setRunning] = useState(false);
 
-  // schema_context handed to the NL->SQL agent.
+  // Execution / results
+  const [runState, setRunState] = useState<RunState>('idle');
+  const [running, setRunning] = useState(false);
+  const [tab, setTab] = useState<'results' | 'plan' | 'messages'>('results');
+  const [sqlResult, setSqlResult] = useState<SqlResult | null>(null);
+  const [plan, setPlan] = useState('');
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [meta, setMeta] = useState('');
+
+  // Insights
+  const [insight, setInsight] = useState<Insight | null>(null);
+  const [analyzing, setAnalyzing] = useState(false);
+
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
   const schemaContext = useMemo(
-    () =>
-      schema
-        .flatMap((g) => g.tables.map((t) => `${g.schema}.${t.name}`))
-        .join('\n'),
+    () => schema.flatMap((g) => g.tables.map((t) => `${g.schema}.${t.name}`)).join('\n'),
     [schema],
   );
+  const selectedRowEstimate = useMemo(() => {
+    if (!tableInfo) return null;
+    const g = schema.find((s) => s.schema === tableInfo.schema);
+    return g?.tables.find((t) => t.name === tableInfo.table)?.rowEstimate ?? null;
+  }, [schema, tableInfo]);
 
-  // Resolve server name + database list; if no database in URL, redirect to the first one.
+  // Resolve server name + database list; redirect to first db if none in URL.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -128,167 +391,276 @@ const PostgresExplorerPage: React.FC = () => {
     return () => { cancelled = true; };
   }, [serverId, database, navigate]);
 
+  const resetResults = () => { setRunState('idle'); setSqlResult(null); setPlan(''); setMessages([]); setInsight(null); };
+
   const openTable = useCallback(async (schemaName: string, table: string) => {
     try {
       setError(null);
+      setTableLoading(true);
       const token = await getAuthenticatedToken();
       const info = await getPgTableInfo(token, serverId, database, schemaName, table);
       setTableInfo(info);
+      setSchemaOpen(true);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setTableLoading(false);
     }
   }, [serverId, database]);
+
+  const insertAtCaret = useCallback((snippet: string) => {
+    const ta = taRef.current;
+    if (!ta) { setSql((s) => s + snippet); return; }
+    const start = ta.selectionStart ?? sql.length;
+    const end = ta.selectionEnd ?? sql.length;
+    setSql(sql.slice(0, start) + snippet + sql.slice(end));
+    requestAnimationFrame(() => { ta.focus(); const p = start + snippet.length; ta.setSelectionRange(p, p); });
+  }, [sql]);
+
+  const queryTable = useCallback(() => {
+    if (!tableInfo) return;
+    const cols = tableInfo.columns.slice(0, 6).map((c) => c.name).join(', ') || '*';
+    setSql(`SELECT ${cols}\nFROM ${tableInfo.schema}.${tableInfo.table}\nLIMIT 100;`);
+    resetResults();
+    requestAnimationFrame(() => taRef.current?.focus());
+  }, [tableInfo]);
 
   const generate = useCallback(async () => {
     if (!prompt.trim()) return;
     try {
       setGenerating(true);
       setError(null);
-      setSqlResult(null);
       setSqlWriteNotice(null);
+      resetResults();
       const token = await getAuthenticatedToken();
       const out = await pgNl2Sql(token, {
-        server_id: serverId,
-        database,
-        schema_context: schemaContext,
-        user_input: prompt,
+        server_id: serverId, database, schema_context: schemaContext,
+        user_input: prompt, model, max_iterations: maxIterations,
       });
       setSql(out.generated_code || '');
       if (out.is_write_action) {
         setSqlWriteNotice('Write/DDL detected — not executed. Review before running manually.');
       } else if (out.query_result && typeof out.query_result === 'object' && 'columns' in out.query_result) {
-        setSqlResult(out.query_result as SqlResult);
+        const res = out.query_result as SqlResult;
+        setSqlResult(res);
+        setRunState('done');
+        setTab('results');
+        setMeta(`${res.rows.length} row${res.rows.length === 1 ? '' : 's'}`);
+        setMessages([{ t: now(), kind: 'ok', msg: `Generated query returned ${res.rows.length} rows` }]);
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setGenerating(false);
     }
-  }, [prompt, serverId, database, schemaContext]);
+  }, [prompt, serverId, database, schemaContext, model, maxIterations]);
 
   const runSql = useCallback(async () => {
     if (!sql.trim()) return;
+    setRunning(true);
+    setError(null);
+    setRunState('running');
+    setTab('results');
+    setInsight(null);
+    const t0 = performance.now();
     try {
-      setRunning(true);
-      setError(null);
       const token = await getAuthenticatedToken();
-      const out = await pgExecute(token, serverId, database, sql);
-      setSqlResult(out as SqlResult);
+      const out = await pgExecute(token, serverId, database, sql) as SqlResult;
+      const ms = Math.round(performance.now() - t0);
+      setSqlResult(out);
       setSqlWriteNotice(null);
+      setRunState('done');
+      setMeta(`${out.rows.length} row${out.rows.length === 1 ? '' : 's'} · ${ms} ms`);
+      setMessages([{ t: now(), kind: 'ok', msg: `Query OK — ${out.rows.length} rows in ${ms} ms` }]);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+      setRunState('done');
+      setTab('messages');
+      setMessages([{ t: now(), kind: 'err', msg }]);
     } finally {
       setRunning(false);
     }
   }, [sql, serverId, database]);
 
-  const switchDatabase = (db: string) =>
+  const explain = useCallback(async () => {
+    if (!sql.trim()) return;
+    setRunning(true);
+    setError(null);
+    setRunState('running');
+    setTab('plan');
+    try {
+      const token = await getAuthenticatedToken();
+      const out = await pgExecute(token, serverId, database, `EXPLAIN ${sql}`) as SqlResult;
+      setPlan(out.rows.map((r) => cellText(r[0])).join('\n'));
+      setRunState('done');
+      setMessages([{ t: now(), kind: 'ok', msg: 'Explain plan generated' }]);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+      setRunState('done');
+      setTab('messages');
+      setMessages([{ t: now(), kind: 'err', msg }]);
+    } finally {
+      setRunning(false);
+    }
+  }, [sql, serverId, database]);
+
+  const analyze = useCallback(async () => {
+    if (!sqlResult) return;
+    try {
+      setAnalyzing(true);
+      const token = await getAuthenticatedToken();
+      const out = await pgAnalyze(token, { columns: sqlResult.columns, rows: sqlResult.rows.slice(0, 200), user_input: prompt });
+      setInsight(out);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setAnalyzing(false);
+    }
+  }, [sqlResult, prompt]);
+
+  const followup = useCallback((f: string) => {
+    setPrompt(f);
+    document.getElementById('pg-nl-prompt')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    (document.getElementById('pg-nl-prompt') as HTMLTextAreaElement | null)?.focus();
+  }, []);
+
+  const switchDatabase = (db: string) => {
+    setTableInfo(null);
+    resetResults();
     navigate(`/postgres/${encodeURIComponent(serverId)}/${encodeURIComponent(db)}`);
+  };
+
+  const onEditorKey = (e: React.KeyboardEvent) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') { e.preventDefault(); if (!running) runSql(); }
+  };
 
   return (
-    <AppLayout accountName={serverName || 'PostgreSQL'} accountId={serverId} databaseName={database}>
-      <div style={{ display: 'flex', height: '100%', background: 'var(--bg)' }}>
-        {/* Left: database picker + schema/tables */}
-        <div style={{ width: 280, borderRight: '1px solid var(--border)', overflow: 'auto', padding: 14, flexShrink: 0 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
-            <span className="qa-chip accent" style={{ fontSize: 11 }}>PostgreSQL</span>
-            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12.5, color: 'var(--muted)' }}>{serverName}</span>
-          </div>
-          <label style={{ fontSize: 11, color: 'var(--muted)', display: 'block', marginBottom: 4 }}>Database</label>
-          <select
-            value={database}
-            onChange={(e) => switchDatabase(e.target.value)}
-            style={{ width: '100%', marginBottom: 16, padding: '6px 8px', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'var(--panel)', color: 'var(--fg)', fontFamily: 'var(--font-mono)', fontSize: 12.5 }}
-          >
-            {databases.map((d) => <option key={d} value={d}>{d}</option>)}
-          </select>
-
-          {schema.map((g) => (
-            <div key={g.schema} style={{ marginBottom: 14 }}>
-              <div style={{ fontSize: 11, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 4 }}>{g.schema}</div>
-              {g.tables.map((t) => (
-                <button
-                  key={t.name}
-                  onClick={() => openTable(g.schema, t.name)}
-                  style={{
-                    display: 'flex', justifyContent: 'space-between', width: '100%', textAlign: 'left',
-                    padding: '5px 8px', border: 'none', borderRadius: 'var(--radius-sm)', cursor: 'pointer',
-                    background: tableInfo?.table === t.name && tableInfo?.schema === g.schema ? 'var(--accent-soft)' : 'transparent',
-                    color: 'var(--fg)', fontFamily: 'var(--font-mono)', fontSize: 12.5,
-                  }}
-                >
-                  <span>{t.name}</span>
-                  <span style={{ color: 'var(--muted)' }}>{t.rowEstimate}</span>
-                </button>
-              ))}
-            </div>
-          ))}
-        </div>
-
-        {/* Right: detail + NL->SQL */}
-        <div style={{ flex: 1, overflow: 'auto', padding: 20 }}>
-          {error && (
-            <div style={{ color: 'var(--status-err)', fontSize: 13, marginBottom: 14, fontFamily: 'var(--font-body)' }}>Error: {error}</div>
-          )}
-          {loading && <div style={{ color: 'var(--muted)', fontSize: 13 }}>Loading…</div>}
-
-          {/* NL -> SQL */}
-          <div className="qa-card" style={{ padding: 16, marginBottom: 20 }}>
-            <div style={{ fontFamily: 'var(--font-display)', fontSize: 15, marginBottom: 8 }}>Ask in natural language</div>
-            <textarea
-              value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
-              placeholder="e.g. list the 10 most recent patients"
-              rows={2}
-              style={{ width: '100%', padding: 8, borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'var(--panel)', color: 'var(--fg)', fontFamily: 'var(--font-body)', fontSize: 13, resize: 'vertical' }}
-            />
-            <div style={{ marginTop: 8, display: 'flex', gap: 8 }}>
-              <button className="qa-btn primary" disabled={generating || !prompt.trim()} onClick={generate}>
-                {generating ? 'Generating…' : 'Generate SQL'}
-              </button>
-              {sql && (
-                <button className="qa-btn" disabled={running} onClick={runSql}>
-                  {running ? 'Running…' : 'Run'}
-                </button>
-              )}
-            </div>
-            {sql && (
-              <pre style={{ marginTop: 12, padding: 12, background: 'var(--soft)', borderRadius: 'var(--radius-sm)', fontFamily: 'var(--font-mono)', fontSize: 12.5, color: 'var(--fg)', whiteSpace: 'pre-wrap', overflow: 'auto' }}>{sql}</pre>
-            )}
-            {sqlWriteNotice && (
-              <div className="qa-chip warn" style={{ marginTop: 8 }}>{sqlWriteNotice}</div>
-            )}
-            {sqlResult && (
-              <div style={{ marginTop: 12 }}><ResultTable columns={sqlResult.columns} rows={sqlResult.rows} /></div>
-            )}
-          </div>
-
-          {/* Table detail */}
-          {tableInfo && (
-            <div className="qa-card" style={{ padding: 16 }}>
-              <div style={{ fontFamily: 'var(--font-display)', fontSize: 15, marginBottom: 4 }}>
-                {tableInfo.schema}.{tableInfo.table}
+    <AppLayout
+      accountName={serverName || 'PostgreSQL'}
+      accountId={serverId}
+      databaseName={database}
+      pgSchema={schema}
+      activePgTable={tableInfo ? `${tableInfo.schema}.${tableInfo.table}` : undefined}
+      onPgTableSelect={openTable}
+      pgDatabases={databases}
+      onSwitchPgDatabase={switchDatabase}
+    >
+      <div style={{ display: 'flex', height: '100%', overflow: 'hidden', background: 'var(--bg)', fontFamily: 'var(--font-body)', color: 'var(--fg)' }} onKeyDown={onEditorKey}>
+        {/* ── Middle + right rail (table tree + db switch now live in the app sidebar) ── */}
+        <div style={{ flex: 1, display: 'flex', minHeight: 0, minWidth: 0 }}>
+          <div style={{ flex: 1, overflowY: 'auto', padding: '18px 22px 26px', display: 'flex', flexDirection: 'column', gap: 14, minWidth: 0 }}>
+            {error && (
+              <div style={{ background: 'color-mix(in oklch, var(--status-err) 10%, var(--bg))', border: '1px solid color-mix(in oklch, var(--status-err) 30%, var(--border))', color: 'var(--status-err)', padding: '10px 14px', borderRadius: 'var(--radius-md)', fontSize: 13 }}>
+                <strong>Error: </strong>{error}
               </div>
-              <div style={{ fontSize: 12, color: 'var(--muted)', marginBottom: 12 }}>
-                {tableInfo.columns.length} columns · indexes: {tableInfo.indexes.join(', ') || 'none'}
+            )}
+
+            {/* Breadcrumb */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', fontFamily: 'var(--font-mono)', fontSize: 11.5, color: 'var(--muted)' }}>
+              {dbIcon}{database}
+              {tableInfo && <><span>›</span><span className="qa-chip accent" style={{ fontSize: 11 }}>{tableInfo.schema}.{tableInfo.table}</span></>}
+            </div>
+
+            {/* Schema card */}
+            {loading && !tableInfo && <div style={{ fontSize: 12.5, color: 'var(--muted)' }}>Loading schema…</div>}
+            {tableLoading && <div style={{ fontSize: 12.5, color: 'var(--muted)' }}>Loading table metadata…</div>}
+            {!tableLoading && tableInfo && (
+              <SchemaCard info={tableInfo} rowEstimate={selectedRowEstimate} open={schemaOpen}
+                onToggle={() => setSchemaOpen((o) => !o)} onInsert={insertAtCaret} onQueryTable={queryTable} />
+            )}
+            {!tableLoading && tableInfo?.sample.error && (
+              <div className="qa-chip" style={{ fontSize: 11.5 }}>Sample data unavailable — {tableInfo.sample.error}</div>
+            )}
+
+            {/* NL generator */}
+            <div className="qa-card" style={{ padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 11 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 11.5, color: 'var(--muted)' }}>
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4"><path d="M4 8h.01M8 8h.01M12 8h.01" /><rect x="2" y="3" width="12" height="10" rx="2" /></svg>
+                Ask in plain English
               </div>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 16 }}>
-                {tableInfo.columns.map((c) => (
-                  <span key={c.name} className="qa-chip" style={{ fontFamily: 'var(--font-mono)', fontSize: 11.5 }}>
-                    {c.name} <span style={{ color: 'var(--muted)' }}>{c.type}{c.nullable ? '?' : ''}</span>
-                  </span>
+              <textarea id="pg-nl-prompt" value={prompt} onChange={(e) => setPrompt(e.target.value)} rows={2}
+                onKeyDown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') { e.preventDefault(); if (!generating && prompt.trim()) generate(); } }}
+                placeholder="Describe the data you want…"
+                style={{ padding: '4px 2px', border: 'none', background: 'transparent', color: 'var(--fg)', fontFamily: 'var(--font-body)', fontSize: 15, resize: 'vertical', outline: 'none', lineHeight: 1.5 }} disabled={generating} />
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+                <button className="qa-btn primary" style={{ height: 34 }} disabled={generating || !prompt.trim()} onClick={generate}>
+                  {generating ? <><Spinner /> Generating…</> : <><SparkIcon /> Generate query</>}
+                </button>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12, color: 'var(--muted)' }}>
+                  <span title="More iterations let the agent self-correct by re-generating and re-testing. Max 10.">Iterations:</span>
+                  <input type="range" min={1} max={10} value={maxIterations} onChange={(e) => setMaxIterations(+e.target.value)} disabled={generating} style={{ width: 90, accentColor: 'var(--accent)' }} />
+                  <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--accent)', width: 12 }}>{maxIterations}</span>
+                </div>
+                <select value={model} onChange={(e) => setModel(e.target.value)} className="qa-btn" style={{ appearance: 'auto', height: 30, color: 'var(--fg)' }}>
+                  <option value="gemini-2.5-flash">gemini-2.5-flash</option>
+                  <option value="gemini-2.5-pro">gemini-2.5-pro</option>
+                </select>
+              </div>
+              <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                <span style={{ fontSize: 11, color: 'var(--muted)', alignSelf: 'center' }}>Try:</span>
+                {EXAMPLES.map((ex) => (
+                  <button key={ex} className="qa-chip" style={{ cursor: 'pointer', lineHeight: '20px' }} onClick={() => setPrompt(ex)} title={ex}>{ex}</button>
                 ))}
               </div>
-              <div style={{ fontSize: 12, color: 'var(--muted)', marginBottom: 6 }}>Sample rows</div>
-              {tableInfo.sample.error ? (
-                <div className="qa-chip warn" style={{ fontSize: 11.5 }}>
-                  Sample unavailable — {tableInfo.sample.error}
-                </div>
-              ) : (
-                <ResultTable columns={tableInfo.sample.columns} rows={tableInfo.sample.rows} />
-              )}
             </div>
-          )}
+
+            {sqlWriteNotice && <div className="qa-chip" style={{ borderColor: 'var(--status-warn)', color: 'var(--status-warn)' }}>{sqlWriteNotice}</div>}
+
+            {/* SQL editor */}
+            {sql ? (
+              <SqlEditor sql={sql} onChange={setSql} taRef={taRef} onRun={runSql} onExplain={explain} running={running} />
+            ) : (
+              <div style={{ textAlign: 'center', color: 'var(--muted)', padding: '28px 0', border: '1.5px dashed var(--border)', borderRadius: 'var(--radius-md)', fontSize: 13 }}>
+                Generate a query above, click a column to build one, or “Query table”.
+              </div>
+            )}
+
+            {/* Results card */}
+            {runState !== 'idle' && (
+              <div className="qa-card ws-anim" style={{ padding: 0, overflow: 'hidden' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '0 10px', borderBottom: '1px solid var(--border)' }}>
+                  {([['results', `Results${runState === 'done' && sqlResult ? ` · ${sqlResult.rows.length}` : ''}`], ['plan', 'Query plan'], ['messages', 'Messages']] as const).map(([k, l]) => (
+                    <button key={k} onClick={() => setTab(k)} style={{ border: 'none', background: 'transparent', cursor: 'pointer', fontFamily: 'inherit', padding: '10px 12px', fontSize: 12.5, fontWeight: tab === k ? 500 : 400, color: tab === k ? 'var(--fg)' : 'var(--muted)', borderBottom: tab === k ? '2px solid var(--accent)' : '2px solid transparent', marginBottom: -1 }}>{l}</button>
+                  ))}
+                  {runState === 'done' && meta && (
+                    <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--muted)', fontFamily: 'var(--font-mono)' }}>{meta}</span>
+                  )}
+                </div>
+                <div style={{ maxHeight: 340, overflow: 'auto' }}>
+                  {runState === 'running' && (
+                    <div style={{ minHeight: 140, display: 'grid', placeItems: 'center', color: 'var(--muted)', fontSize: 12.5 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}><Spinner size={15} /> Executing on {database}…</div>
+                    </div>
+                  )}
+                  {runState === 'done' && tab === 'results' && (
+                    sqlResult ? <ResultsGrid columns={sqlResult.columns} rows={sqlResult.rows} />
+                      : <div style={{ padding: 16, color: 'var(--muted)', fontSize: 12.5 }}>No result set. See the Messages tab.</div>
+                  )}
+                  {runState === 'done' && tab === 'plan' && (
+                    plan ? <pre className="ws-plan" dangerouslySetInnerHTML={{ __html: highlightPlan(plan) }} />
+                      : <div style={{ padding: 16, color: 'var(--muted)', fontSize: 12.5 }}>Click “Explain” to generate a query plan.</div>
+                  )}
+                  {runState === 'done' && tab === 'messages' && (
+                    <div style={{ padding: '12px 16px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+                      {messages.length === 0 && <span style={{ color: 'var(--muted)', fontSize: 12 }}>No messages.</span>}
+                      {messages.map((m, i) => (
+                        <div key={i} style={{ display: 'flex', gap: 10, alignItems: 'baseline', fontFamily: 'var(--font-mono)', fontSize: 11.5 }}>
+                          <span style={{ color: 'var(--muted)' }}>{m.t}</span>
+                          <span style={{ width: 5, height: 5, borderRadius: 99, background: m.kind === 'ok' ? 'var(--status-ok)' : 'var(--status-err)', alignSelf: 'center', flexShrink: 0 }} />
+                          <span style={{ color: m.kind === 'ok' ? 'var(--fg)' : 'var(--status-err)' }}>{m.msg}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Right insights rail */}
+          <InsightsPanel hasResult={!!sqlResult} insight={insight} analyzing={analyzing} onAnalyze={analyze} onFollowup={followup} />
         </div>
       </div>
     </AppLayout>

--- a/frontend/pages/PostgresExplorerPage.tsx
+++ b/frontend/pages/PostgresExplorerPage.tsx
@@ -1,7 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { createPortal } from 'react-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import AppLayout from '../components/AppLayout';
 import AgentVerdict from '../components/AgentVerdict';
+import SavedQueriesPanel from '../components/SavedQueriesPanel';
+import SaveQueryDialog from '../components/SaveQueryDialog';
+import ShareQueryDialog from '../components/ShareQueryDialog';
+import { SavedQuery } from '../types';
+import { msalInstance } from '../authConfig';
+import { getSavedQueries, saveQuery, updateSavedQuery, deleteSavedQuery } from '../services/userDataService';
 import {
   getAuthenticatedToken,
   getPgDatabases,
@@ -188,8 +195,9 @@ const SqlEditor: React.FC<{
   taRef: React.RefObject<HTMLTextAreaElement | null>;
   onRun: () => void;
   onExplain: () => void;
+  onSave: () => void;
   running: boolean;
-}> = ({ sql, onChange, taRef, onRun, onExplain, running }) => {
+}> = ({ sql, onChange, taRef, onRun, onExplain, onSave, running }) => {
   const [copied, setCopied] = useState(false);
   const copy = () => { navigator.clipboard?.writeText(sql); setCopied(true); setTimeout(() => setCopied(false), 1500); };
   return (
@@ -203,6 +211,10 @@ const SqlEditor: React.FC<{
         <button className="ws-copy" onClick={copy} style={{ color: copied ? '#8fce9e' : undefined }}>{copied ? '✓ copied' : 'copy'}</button>
       </div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10 }}>
+        <button className="qa-btn" style={{ height: 30, gap: 6 }} disabled={!sql.trim()} onClick={onSave} title="Save this query to your saved queries">
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4"><path d="M3 2h8l3 3v9H3z" /><path d="M6 2v4h4M6 14v-4h5v4" /></svg>
+          Save
+        </button>
         <button className="qa-btn" style={{ height: 30, gap: 6 }} disabled={running || !sql.trim()} onClick={onExplain} title="Run EXPLAIN to show the query plan without executing the query">
           <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4"><path d="M2 13h12M4 11V7M7 11V4M10 11V8M13 11V5" /></svg>
           Explain
@@ -368,6 +380,16 @@ const PostgresExplorerPage: React.FC = () => {
   const [insight, setInsight] = useState<Insight | null>(null);
   const [analyzing, setAnalyzing] = useState(false);
 
+  // Saved queries (engine=pg)
+  const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
+  const [loadingSaved, setLoadingSaved] = useState(false);
+  const [savedPanelOpen, setSavedPanelOpen] = useState(false);
+  const [saveDialog, setSaveDialog] = useState<{ isOpen: boolean; data?: Partial<SavedQuery> & { prompt: string; code: string } }>({ isOpen: false });
+  const [shareDialog, setShareDialog] = useState<{ isOpen: boolean; query?: SavedQuery }>({ isOpen: false });
+  const [savingQuery, setSavingQuery] = useState(false);
+  const currentUserEmail = msalInstance.getAllAccounts()[0]?.username || 'dev.user@example.com';
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const taRef = useRef<HTMLTextAreaElement>(null);
 
   const selectedInfos = useMemo(
@@ -516,8 +538,8 @@ const PostgresExplorerPage: React.FC = () => {
     }
   }, [prompt, serverId, database, schemaContext, model, maxIterations]);
 
-  const runSql = useCallback(async () => {
-    if (!sql.trim()) return;
+  const execSql = useCallback(async (sqlText: string) => {
+    if (!sqlText.trim()) return;
     setRunning(true);
     setError(null);
     setRunState('running');
@@ -526,7 +548,7 @@ const PostgresExplorerPage: React.FC = () => {
     const t0 = performance.now();
     try {
       const token = await getAuthenticatedToken();
-      const out = await pgExecute(token, serverId, database, sql) as SqlResult;
+      const out = await pgExecute(token, serverId, database, sqlText) as SqlResult;
       const ms = Math.round(performance.now() - t0);
       setSqlResult(out);
       setSqlWriteNotice(null);
@@ -542,7 +564,9 @@ const PostgresExplorerPage: React.FC = () => {
     } finally {
       setRunning(false);
     }
-  }, [sql, serverId, database]);
+  }, [serverId, database]);
+
+  const runSql = useCallback(() => execSql(sql), [execSql, sql]);
 
   const explain = useCallback(async () => {
     if (!sql.trim()) return;
@@ -585,6 +609,68 @@ const PostgresExplorerPage: React.FC = () => {
     setPrompt(f);
     document.getElementById('pg-nl-prompt')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
     (document.getElementById('pg-nl-prompt') as HTMLTextAreaElement | null)?.focus();
+  }, []);
+
+  // --- Saved queries (engine=pg) ---
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingSaved(true);
+    getSavedQueries('pg')
+      .then((qs) => { if (!cancelled) setSavedQueries(qs); })
+      .catch(() => { /* non-critical */ })
+      .finally(() => { if (!cancelled) setLoadingSaved(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Open the panel when deep-linked with ?panel=saved (from the profile menu).
+  useEffect(() => {
+    if (searchParams.get('panel') === 'saved') {
+      setSavedPanelOpen(true);
+      searchParams.delete('panel');
+      setSearchParams(searchParams, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
+
+  const openSaveDialog = useCallback(() => {
+    if (!sql.trim()) return;
+    setSaveDialog({ isOpen: true, data: { prompt, code: sql } });
+  }, [sql, prompt]);
+
+  const handleSaveOrUpdate = useCallback(async (data: Pick<SavedQuery, 'name' | 'prompt' | 'code'> | SavedQuery) => {
+    setSavingQuery(true);
+    try {
+      if ('id' in data) {
+        const updated = await updateSavedQuery(data as SavedQuery);
+        setSavedQueries((prev) => prev.map((q) => (q.id === updated.id ? updated : q)));
+      } else {
+        const created = await saveQuery({ ...(data as Pick<SavedQuery, 'name' | 'prompt' | 'code'>), engine: 'pg' });
+        setSavedQueries((prev) => [...prev, created]);
+      }
+      setSaveDialog({ isOpen: false });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSavingQuery(false);
+    }
+  }, []);
+
+  const handleDeleteSaved = useCallback(async (id: string) => {
+    const prev = savedQueries;
+    setSavedQueries((qs) => qs.filter((q) => q.id !== id));
+    try { await deleteSavedQuery(id); } catch { setSavedQueries(prev); }
+  }, [savedQueries]);
+
+  const loadSaved = useCallback((q: SavedQuery) => {
+    setPrompt(q.prompt);
+    setSql(q.code);
+    resetResults();
+    setSavedPanelOpen(false);
+  }, []);
+
+  const handleUpdateSharing = useCallback(async (q: SavedQuery) => {
+    setSavedQueries((prev) => prev.map((x) => (x.id === q.id ? q : x)));
+    setShareDialog({ isOpen: false });
+    try { await updateSavedQuery(q); } catch (e) { setError(e instanceof Error ? e.message : String(e)); }
   }, []);
 
   const switchDatabase = (db: string) => {
@@ -686,7 +772,7 @@ const PostgresExplorerPage: React.FC = () => {
 
             {/* SQL editor */}
             {sql ? (
-              <SqlEditor sql={sql} onChange={setSql} taRef={taRef} onRun={runSql} onExplain={explain} running={running} />
+              <SqlEditor sql={sql} onChange={setSql} taRef={taRef} onRun={runSql} onExplain={explain} onSave={openSaveDialog} running={running} />
             ) : (
               <div style={{ textAlign: 'center', color: 'var(--muted)', padding: '28px 0', border: '1.5px dashed var(--border)', borderRadius: 'var(--radius-md)', fontSize: 13 }}>
                 Generate a query above, click a column to build one, or “Query table”.
@@ -745,6 +831,43 @@ const PostgresExplorerPage: React.FC = () => {
           <InsightsPanel hasResult={!!sqlResult} insight={insight} analyzing={analyzing} onAnalyze={analyze} onFollowup={followup} />
         </div>
       </div>
+
+      {savedPanelOpen && createPortal(
+        <SavedQueriesPanel
+          onClose={() => setSavedPanelOpen(false)}
+          queries={savedQueries}
+          onLoad={loadSaved}
+          onLoadAndRun={(q) => { loadSaved(q); execSql(q.code); }}
+          onEdit={(q) => setSaveDialog({ isOpen: true, data: q })}
+          onDelete={handleDeleteSaved}
+          onShare={(q) => setShareDialog({ isOpen: true, query: q })}
+          isLoading={loadingSaved}
+          dbReady={!loading && !!database}
+          currentUserEmail={currentUserEmail}
+        />,
+        document.body,
+      )}
+
+      {saveDialog.isOpen && createPortal(
+        <SaveQueryDialog
+          isOpen={saveDialog.isOpen}
+          onClose={() => setSaveDialog({ isOpen: false })}
+          onSave={handleSaveOrUpdate}
+          isSaving={savingQuery}
+          initialData={saveDialog.data!}
+        />,
+        document.body,
+      )}
+
+      {shareDialog.isOpen && shareDialog.query && createPortal(
+        <ShareQueryDialog
+          isOpen={shareDialog.isOpen}
+          onClose={() => setShareDialog({ isOpen: false })}
+          onSave={handleUpdateSharing}
+          query={shareDialog.query}
+        />,
+        document.body,
+      )}
     </AppLayout>
   );
 };

--- a/frontend/pages/PostgresExplorerPage.tsx
+++ b/frontend/pages/PostgresExplorerPage.tsx
@@ -21,7 +21,7 @@ interface TableInfo {
   table: string;
   columns: { name: string; type: string; nullable: boolean }[];
   indexes: string[];
-  sample: { columns: string[]; rows: any[][] };
+  sample: { columns: string[]; rows: any[][]; error?: string };
 }
 interface SqlResult {
   columns: string[];
@@ -280,7 +280,13 @@ const PostgresExplorerPage: React.FC = () => {
                 ))}
               </div>
               <div style={{ fontSize: 12, color: 'var(--muted)', marginBottom: 6 }}>Sample rows</div>
-              <ResultTable columns={tableInfo.sample.columns} rows={tableInfo.sample.rows} />
+              {tableInfo.sample.error ? (
+                <div className="qa-chip warn" style={{ fontSize: 11.5 }}>
+                  Sample unavailable — {tableInfo.sample.error}
+                </div>
+              ) : (
+                <ResultTable columns={tableInfo.sample.columns} rows={tableInfo.sample.rows} />
+              )}
             </div>
           )}
         </div>

--- a/frontend/pages/PostgresExplorerPage.tsx
+++ b/frontend/pages/PostgresExplorerPage.tsx
@@ -189,11 +189,7 @@ const SqlEditor: React.FC<{
   onExplain: () => void;
   running: boolean;
 }> = ({ sql, onChange, taRef, onRun, onExplain, running }) => {
-  const preRef = useRef<HTMLPreElement>(null);
   const [copied, setCopied] = useState(false);
-  const onScroll = (e: React.UIEvent<HTMLTextAreaElement>) => {
-    if (preRef.current) { preRef.current.scrollTop = e.currentTarget.scrollTop; preRef.current.scrollLeft = e.currentTarget.scrollLeft; }
-  };
   const copy = () => { navigator.clipboard?.writeText(sql); setCopied(true); setTimeout(() => setCopied(false), 1500); };
   return (
     <div className="qa-card" style={{ padding: '10px 14px 12px' }}>
@@ -201,12 +197,12 @@ const SqlEditor: React.FC<{
         <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg)' }}>// generated SQL</span>
       </div>
       <div className="ws-editor">
-        <pre className="hl" ref={preRef} aria-hidden="true" dangerouslySetInnerHTML={{ __html: highlightSQL(sql) + '\n' }} />
-        <textarea ref={taRef} value={sql} spellCheck={false} onScroll={onScroll} onChange={(e) => onChange(e.target.value)} />
+        <pre className="hl" aria-hidden="true" dangerouslySetInnerHTML={{ __html: highlightSQL(sql) + '\n' }} />
+        <textarea ref={taRef} value={sql} spellCheck={false} onChange={(e) => onChange(e.target.value)} />
         <button className="ws-copy" onClick={copy} style={{ color: copied ? '#8fce9e' : undefined }}>{copied ? '✓ copied' : 'copy'}</button>
       </div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10 }}>
-        <button className="qa-btn" style={{ height: 30, gap: 6 }} disabled={running || !sql.trim()} onClick={onExplain}>
+        <button className="qa-btn" style={{ height: 30, gap: 6 }} disabled={running || !sql.trim()} onClick={onExplain} title="Run EXPLAIN to show the query plan without executing the query">
           <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4"><path d="M2 13h12M4 11V7M7 11V4M10 11V8M13 11V5" /></svg>
           Explain
         </button>
@@ -247,8 +243,32 @@ const InsightsPanel: React.FC<{
   analyzing: boolean;
   onAnalyze: () => void;
   onFollowup: (f: string) => void;
-}> = ({ hasResult, insight, analyzing, onAnalyze, onFollowup }) => (
-  <aside className="ws-insights">
+}> = ({ hasResult, insight, analyzing, onAnalyze, onFollowup }) => {
+  const [width, setWidth] = useState(316);
+  const drag = useRef<{ startX: number; startW: number } | null>(null);
+  const onResizeStart = (e: React.PointerEvent) => {
+    e.preventDefault();
+    drag.current = { startX: e.clientX, startW: width };
+    const onMove = (ev: PointerEvent) => {
+      if (!drag.current) return;
+      // Panel is docked right, so dragging left (smaller clientX) widens it.
+      setWidth(Math.min(640, Math.max(240, drag.current.startW + (drag.current.startX - ev.clientX))));
+    };
+    const onUp = () => {
+      drag.current = null;
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  };
+  return (
+  <aside className="ws-insights" style={{ width, position: 'relative' }}>
+    <div
+      onPointerDown={onResizeStart}
+      title="Drag to resize"
+      style={{ position: 'absolute', top: 0, left: -3, width: 6, height: '100%', cursor: 'col-resize', zIndex: 2 }}
+    />
     <div className="ws-ins-hd">
       <SparkIcon stroke="var(--accent)" />
       <span className="t">Insights</span>
@@ -302,7 +322,8 @@ const InsightsPanel: React.FC<{
       )}
     </div>
   </aside>
-);
+  );
+};
 
 const EXAMPLES = ['count rows per table', 'the 10 most recent records', 'rows added in the last 7 days'];
 
@@ -315,7 +336,10 @@ const PostgresExplorerPage: React.FC = () => {
   const [serverName, setServerName] = useState('');
   const [databases, setDatabases] = useState<string[]>([]);
   const [schema, setSchema] = useState<SchemaGroup[]>([]);
-  const [tableInfo, setTableInfo] = useState<TableInfo | null>(null);
+  // Multi-select: keys are "schema.table" (in selection order); infos holds the
+  // fetched column/FK metadata per selected table.
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  const [infos, setInfos] = useState<Record<string, TableInfo>>({});
   const [schemaOpen, setSchemaOpen] = useState(true);
   const [tableLoading, setTableLoading] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -344,15 +368,39 @@ const PostgresExplorerPage: React.FC = () => {
 
   const taRef = useRef<HTMLTextAreaElement>(null);
 
-  const schemaContext = useMemo(
-    () => schema.flatMap((g) => g.tables.map((t) => `${g.schema}.${t.name}`)).join('\n'),
+  const selectedInfos = useMemo(
+    () => selectedKeys.map((k) => infos[k]).filter(Boolean) as TableInfo[],
+    [selectedKeys, infos],
+  );
+
+  // Ground the NL->SQL agent in the selected tables' real columns + FK links so
+  // it writes correct joins; fall back to bare table names when nothing is picked.
+  const schemaContext = useMemo(() => {
+    if (selectedInfos.length === 0) {
+      return schema.flatMap((g) => g.tables.map((t) => `${g.schema}.${t.name}`)).join('\n');
+    }
+    return selectedInfos
+      .map((t) => {
+        const cols = t.columns
+          .map((c) => {
+            const tags = [c.pk && 'PK', c.fk && `FK -> ${c.fk}`, !c.nullable && 'NOT NULL']
+              .filter(Boolean)
+              .join(', ');
+            return `  - ${c.name} ${c.type}${tags ? ` [${tags}]` : ''}`;
+          })
+          .join('\n');
+        return `${t.schema}.${t.table}\n${cols}`;
+      })
+      .join('\n\n');
+  }, [selectedInfos, schema]);
+
+  const rowEstimateFor = useCallback(
+    (info: TableInfo) => {
+      const g = schema.find((s) => s.schema === info.schema);
+      return g?.tables.find((t) => t.name === info.table)?.rowEstimate ?? null;
+    },
     [schema],
   );
-  const selectedRowEstimate = useMemo(() => {
-    if (!tableInfo) return null;
-    const g = schema.find((s) => s.schema === tableInfo.schema);
-    return g?.tables.find((t) => t.name === tableInfo.table)?.rowEstimate ?? null;
-  }, [schema, tableInfo]);
 
   // Resolve server name + database list; redirect to first db if none in URL.
   useEffect(() => {
@@ -393,20 +441,31 @@ const PostgresExplorerPage: React.FC = () => {
 
   const resetResults = () => { setRunState('idle'); setSqlResult(null); setPlan(''); setMessages([]); setInsight(null); };
 
-  const openTable = useCallback(async (schemaName: string, table: string) => {
+  const openTable = useCallback(async (
+    schemaName: string, table: string, ev?: { ctrlKey?: boolean; metaKey?: boolean },
+  ) => {
+    const key = `${schemaName}.${table}`;
+    const multi = !!(ev?.ctrlKey || ev?.metaKey);
+    // Cmd/Ctrl-click an already-selected table -> deselect it.
+    if (multi && selectedKeys.includes(key)) {
+      setSelectedKeys((ks) => ks.filter((k) => k !== key));
+      return;
+    }
+    setSelectedKeys((ks) => (multi ? [...ks, key] : [key]));
+    setSchemaOpen(true);
+    if (infos[key]) return; // metadata already fetched
     try {
       setError(null);
       setTableLoading(true);
       const token = await getAuthenticatedToken();
       const info = await getPgTableInfo(token, serverId, database, schemaName, table);
-      setTableInfo(info);
-      setSchemaOpen(true);
+      setInfos((m) => ({ ...m, [key]: info }));
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setTableLoading(false);
     }
-  }, [serverId, database]);
+  }, [serverId, database, selectedKeys, infos]);
 
   const insertAtCaret = useCallback((snippet: string) => {
     const ta = taRef.current;
@@ -417,13 +476,12 @@ const PostgresExplorerPage: React.FC = () => {
     requestAnimationFrame(() => { ta.focus(); const p = start + snippet.length; ta.setSelectionRange(p, p); });
   }, [sql]);
 
-  const queryTable = useCallback(() => {
-    if (!tableInfo) return;
-    const cols = tableInfo.columns.slice(0, 6).map((c) => c.name).join(', ') || '*';
-    setSql(`SELECT ${cols}\nFROM ${tableInfo.schema}.${tableInfo.table}\nLIMIT 100;`);
+  const queryTable = useCallback((info: TableInfo) => {
+    const cols = info.columns.slice(0, 6).map((c) => c.name).join(', ') || '*';
+    setSql(`SELECT ${cols}\nFROM ${info.schema}.${info.table}\nLIMIT 100;`);
     resetResults();
     requestAnimationFrame(() => taRef.current?.focus());
-  }, [tableInfo]);
+  }, []);
 
   const generate = useCallback(async () => {
     if (!prompt.trim()) return;
@@ -527,7 +585,8 @@ const PostgresExplorerPage: React.FC = () => {
   }, []);
 
   const switchDatabase = (db: string) => {
-    setTableInfo(null);
+    setSelectedKeys([]);
+    setInfos({});
     resetResults();
     navigate(`/postgres/${encodeURIComponent(serverId)}/${encodeURIComponent(db)}`);
   };
@@ -542,37 +601,51 @@ const PostgresExplorerPage: React.FC = () => {
       accountId={serverId}
       databaseName={database}
       pgSchema={schema}
-      activePgTable={tableInfo ? `${tableInfo.schema}.${tableInfo.table}` : undefined}
+      activePgTables={selectedKeys}
       onPgTableSelect={openTable}
-      pgDatabases={databases}
-      onSwitchPgDatabase={switchDatabase}
     >
       <div style={{ display: 'flex', height: '100%', overflow: 'hidden', background: 'var(--bg)', fontFamily: 'var(--font-body)', color: 'var(--fg)' }} onKeyDown={onEditorKey}>
         {/* ── Middle + right rail (table tree + db switch now live in the app sidebar) ── */}
         <div style={{ flex: 1, display: 'flex', minHeight: 0, minWidth: 0 }}>
-          <div style={{ flex: 1, overflowY: 'auto', padding: '18px 22px 26px', display: 'flex', flexDirection: 'column', gap: 14, minWidth: 0 }}>
+          <div className="pg-workspace-mid" style={{ flex: 1, overflowY: 'auto', minHeight: 0, padding: '18px 22px 26px', display: 'flex', flexDirection: 'column', gap: 14, minWidth: 0 }}>
             {error && (
               <div style={{ background: 'color-mix(in oklch, var(--status-err) 10%, var(--bg))', border: '1px solid color-mix(in oklch, var(--status-err) 30%, var(--border))', color: 'var(--status-err)', padding: '10px 14px', borderRadius: 'var(--radius-md)', fontSize: 13 }}>
                 <strong>Error: </strong>{error}
               </div>
             )}
 
-            {/* Breadcrumb */}
+            {/* Scope row: database selector + breadcrumb */}
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', fontFamily: 'var(--font-mono)', fontSize: 11.5, color: 'var(--muted)' }}>
-              {dbIcon}{database}
-              {tableInfo && <><span>›</span><span className="qa-chip accent" style={{ fontSize: 11 }}>{tableInfo.schema}.{tableInfo.table}</span></>}
+              <span style={{ color: 'var(--muted)', display: 'flex' }}>{dbIcon}</span>
+              <select
+                value={database}
+                onChange={(e) => switchDatabase(e.target.value)}
+                title="Switch database"
+                style={{ padding: '4px 8px', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)', background: 'var(--panel)', color: 'var(--fg)', fontFamily: 'var(--font-mono)', fontSize: 12, cursor: 'pointer', outline: 'none' }}
+              >
+                {databases.map((d) => <option key={d} value={d}>{d}</option>)}
+              </select>
+              {selectedKeys.length > 0 && <span>›</span>}
+              {selectedKeys.map((k) => (
+                <span key={k} className="qa-chip accent" style={{ fontSize: 11 }}>{k}</span>
+              ))}
+              {selectedKeys.length > 1 && (
+                <span style={{ fontSize: 11 }}>· {selectedKeys.length} tables — ⌘/Ctrl-click a table to add or remove</span>
+              )}
             </div>
 
-            {/* Schema card */}
-            {loading && !tableInfo && <div style={{ fontSize: 12.5, color: 'var(--muted)' }}>Loading schema…</div>}
+            {/* Schema cards (one per selected table) */}
+            {loading && selectedKeys.length === 0 && <div style={{ fontSize: 12.5, color: 'var(--muted)' }}>Loading schema…</div>}
+            {selectedInfos.map((info) => (
+              <React.Fragment key={`${info.schema}.${info.table}`}>
+                <SchemaCard info={info} rowEstimate={rowEstimateFor(info)} open={schemaOpen}
+                  onToggle={() => setSchemaOpen((o) => !o)} onInsert={insertAtCaret} onQueryTable={() => queryTable(info)} />
+                {info.sample.error && (
+                  <div className="qa-chip" style={{ fontSize: 11.5 }}>Sample data unavailable — {info.sample.error}</div>
+                )}
+              </React.Fragment>
+            ))}
             {tableLoading && <div style={{ fontSize: 12.5, color: 'var(--muted)' }}>Loading table metadata…</div>}
-            {!tableLoading && tableInfo && (
-              <SchemaCard info={tableInfo} rowEstimate={selectedRowEstimate} open={schemaOpen}
-                onToggle={() => setSchemaOpen((o) => !o)} onInsert={insertAtCaret} onQueryTable={queryTable} />
-            )}
-            {!tableLoading && tableInfo?.sample.error && (
-              <div className="qa-chip" style={{ fontSize: 11.5 }}>Sample data unavailable — {tableInfo.sample.error}</div>
-            )}
 
             {/* NL generator */}
             <div className="qa-card" style={{ padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 11 }}>
@@ -621,14 +694,18 @@ const PostgresExplorerPage: React.FC = () => {
             {runState !== 'idle' && (
               <div className="qa-card ws-anim" style={{ padding: 0, overflow: 'hidden' }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '0 10px', borderBottom: '1px solid var(--border)' }}>
-                  {([['results', `Results${runState === 'done' && sqlResult ? ` · ${sqlResult.rows.length}` : ''}`], ['plan', 'Query plan'], ['messages', 'Messages']] as const).map(([k, l]) => (
-                    <button key={k} onClick={() => setTab(k)} style={{ border: 'none', background: 'transparent', cursor: 'pointer', fontFamily: 'inherit', padding: '10px 12px', fontSize: 12.5, fontWeight: tab === k ? 500 : 400, color: tab === k ? 'var(--fg)' : 'var(--muted)', borderBottom: tab === k ? '2px solid var(--accent)' : '2px solid transparent', marginBottom: -1 }}>{l}</button>
+                  {([
+                    ['results', `Results${runState === 'done' && sqlResult ? ` · ${sqlResult.rows.length}` : ''}`, 'Rows returned by the query'],
+                    ['plan', 'Query plan', 'The PostgreSQL EXPLAIN plan — how the query would be executed'],
+                    ['messages', 'Messages', 'Execution log: status, timing and any errors'],
+                  ] as const).map(([k, l, tip]) => (
+                    <button key={k} onClick={() => setTab(k)} title={tip} style={{ border: 'none', background: 'transparent', cursor: 'pointer', fontFamily: 'inherit', padding: '10px 12px', fontSize: 12.5, fontWeight: tab === k ? 500 : 400, color: tab === k ? 'var(--fg)' : 'var(--muted)', borderBottom: tab === k ? '2px solid var(--accent)' : '2px solid transparent', marginBottom: -1 }}>{l}</button>
                   ))}
                   {runState === 'done' && meta && (
                     <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--muted)', fontFamily: 'var(--font-mono)' }}>{meta}</span>
                   )}
                 </div>
-                <div style={{ maxHeight: 340, overflow: 'auto' }}>
+                <div style={{ maxHeight: '60vh', overflow: 'auto' }}>
                   {runState === 'running' && (
                     <div style={{ minHeight: 140, display: 'grid', placeItems: 'center', color: 'var(--muted)', fontSize: 12.5 }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}><Spinner size={15} /> Executing on {database}…</div>

--- a/frontend/pages/PostgresWorkspacePage.tsx
+++ b/frontend/pages/PostgresWorkspacePage.tsx
@@ -340,7 +340,7 @@ const InsightsPanel: React.FC<{
 
 const EXAMPLES = ['count rows per table', 'the 10 most recent records', 'rows added in the last 7 days'];
 
-const PostgresExplorerPage: React.FC = () => {
+const PostgresWorkspacePage: React.FC = () => {
   const { serverId: rawServerId, database: rawDatabase } = useParams<{ serverId: string; database?: string }>();
   const navigate = useNavigate();
   const serverId = rawServerId ? decodeURIComponent(rawServerId) : '';
@@ -872,4 +872,4 @@ const PostgresExplorerPage: React.FC = () => {
   );
 };
 
-export default PostgresExplorerPage;
+export default PostgresWorkspacePage;

--- a/frontend/pages/PostgresWorkspacePage.tsx
+++ b/frontend/pages/PostgresWorkspacePage.tsx
@@ -134,7 +134,9 @@ const SchemaCard: React.FC<{
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3"><rect x="2" y="3" width="12" height="10" rx="1.5" /><path d="M2 6.5h12M6 6.5V13" /></svg>
         </span>
         <span style={{ fontFamily: 'var(--font-mono)', fontSize: 13.5, fontWeight: 500 }}>{info.schema}.{info.table}</span>
-        {rowEstimate != null && <span className="qa-tag">~{rowEstimate.toLocaleString()} rows</span>}
+        {rowEstimate != null && (rowEstimate >= 0
+          ? <span className="qa-tag">~{rowEstimate.toLocaleString()} rows</span>
+          : <span className="qa-tag" title="Row count unknown — table not analyzed yet (run ANALYZE)">rows: —</span>)}
         <span className="qa-tag">{info.columns.length} cols</span>
         <div style={{ marginLeft: 'auto', display: 'flex', gap: 7, alignItems: 'center' }}>
           <button className="qa-btn primary" style={{ height: 27, gap: 6 }} onClick={onQueryTable}>

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -2110,7 +2110,6 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                         onSetIntermediateContext={handleSetIntermediateContext}
                         intermediateContext={intermediateContext}
                         onAnalyze={handleAnalyzeQuery}
-                        onFollowup={handleAnalysisFollowup}
                         isAnalyzing={isAnalyzing}
                         analysisResult={analysisResult}
                         analysisError={analysisError}
@@ -2288,9 +2287,27 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
 
       {/* AI analysis: trigger button (moved here from the results toolbar) + result */}
       {analysisResult ? (
-        <div className="qa-card animate-fade-in" style={{ padding: '10px 12px' }}>
-          <div style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--accent)', marginBottom: 6 }}>Analysis</div>
-          <div style={{ fontSize: 12.5, lineHeight: 1.55, color: 'var(--fg)' }}>{analysisResult.insight}</div>
+        <div className="qa-card animate-fade-in" style={{ padding: '10px 12px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <div>
+            <div style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--accent)', marginBottom: 6 }}>Analysis</div>
+            <div style={{ fontSize: 12.5, lineHeight: 1.55, color: 'var(--fg)' }}>{analysisResult.insight}</div>
+          </div>
+          {analysisResult.followups && analysisResult.followups.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <div style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)', fontWeight: 500 }}>Follow-ups</div>
+              {analysisResult.followups.map((f, i) => (
+                <button
+                  key={i}
+                  onClick={() => handleAnalysisFollowup(f)}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', padding: '6px 9px', borderRadius: 7, border: '1px solid var(--border)', background: 'var(--panel)', font: 'inherit', fontSize: 12, color: 'var(--fg)', cursor: 'pointer' }}
+                  onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--soft)'; }}
+                  onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--panel)'; }}
+                >
+                  <span style={{ color: 'var(--accent)', marginRight: 6 }}>→</span>{f}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       ) : resultIsAnalyzable ? (
         <div className="qa-card animate-fade-in" style={{ padding: '12px', display: 'flex', flexDirection: 'column', gap: 10 }}>
@@ -2637,7 +2654,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                     <button onClick={() => setExplanation(null)} className="qa-btn" style={{ fontSize: 11, padding: '2px 8px' }} title="Dismiss">Dismiss</button>
                   </div>
                 )}
-                <QueryResult isExecuting={isExecuting} executionError={executionError} executionResult={executionResult} onDebug={handleDebugQuery} isDebugging={isDebugging} debuggingResult={debuggingResult} debugError={debugError} sourceCollection={querySourceCollection} onSetIntermediateContext={handleSetIntermediateContext} intermediateContext={intermediateContext} onAnalyze={handleAnalyzeQuery} onFollowup={handleAnalysisFollowup} isAnalyzing={isAnalyzing} analysisResult={analysisResult} analysisError={analysisError} onEvaluateWrite={handleEvaluateWrite} isEvaluatingWrite={isEvaluatingWrite} writeEvaluationResult={writeEvaluationResult} writeEvaluationError={writeEvaluationError} />
+                <QueryResult isExecuting={isExecuting} executionError={executionError} executionResult={executionResult} onDebug={handleDebugQuery} isDebugging={isDebugging} debuggingResult={debuggingResult} debugError={debugError} sourceCollection={querySourceCollection} onSetIntermediateContext={handleSetIntermediateContext} intermediateContext={intermediateContext} onAnalyze={handleAnalyzeQuery} isAnalyzing={isAnalyzing} analysisResult={analysisResult} analysisError={analysisError} onEvaluateWrite={handleEvaluateWrite} isEvaluatingWrite={isEvaluatingWrite} writeEvaluationResult={writeEvaluationResult} writeEvaluationError={writeEvaluationError} />
               </div>
             ) : (
               <div style={{ textAlign: 'center', color: 'var(--muted)', padding: '32px 0', border: '1.5px dashed var(--border)', borderRadius: 'var(--radius-md)', fontSize: 13 }}>

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -1295,6 +1295,14 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
     setIsSavedQueriesPanelOpen(false);
   };
 
+  const handleSeedCollectionQuery = useCallback((code: string) => {
+    setUserInput('Preview documents');
+    setLastSuccessfulPrompt('');
+    setEditableCode(code);
+    setCodeHistory([code]);
+    setHistoryIndex(0);
+  }, []);
+
   const handleLoadAndRunSavedQuery = (query: SavedQuery) => {
     clearQueryState();
     setUserInput(query.prompt);
@@ -1726,6 +1734,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                                     // Deselect this collection
                                     setSelectedCollections(prev => prev.filter(c => c !== colName));
                                   }}
+                                  onSeedQuery={handleSeedCollectionQuery}
                                 />
                               ) : (
                                 <div className="py-4 text-center text-red-500 text-sm">Failed to load details.</div>
@@ -2447,7 +2456,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                     {isColLoading ? (
                       <div style={{ padding: '12px 14px', fontSize: 12, color: 'var(--muted)' }}>Loading schema…</div>
                     ) : info ? (
-                      <CollectionActionPanel info={info} onClose={() => setSelectedCollections(prev => prev.filter(c => c !== colName))} />
+                      <CollectionActionPanel info={info} onClose={() => setSelectedCollections(prev => prev.filter(c => c !== colName))} onSeedQuery={handleSeedCollectionQuery} />
                     ) : (
                       <div style={{ padding: '12px 14px', fontSize: 12, color: 'var(--status-err)' }}>Failed to load schema.</div>
                     )}

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { createPortal } from 'react-dom';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { parseQueryForHandover } from '../utils/queryHandover';
-import { generateMongoQuery, debugMongoQuery, analyzeQueryResult, inferSchemaRelationships, evaluateWriteResult, getAvailableModels } from '../services/geminiService';
+import { generateMongoQuery, debugMongoQuery, analyzeQueryResult, explainMongoQuery, inferSchemaRelationships, evaluateWriteResult, getAvailableModels } from '../services/geminiService';
 import { getAzureCosmosAccounts, getDatabasesForAccount, runMongoQuery, getCollectionInfo, clearSystemCache } from '../services/dbService';
 import { getSavedQueries, saveQuery, updateSavedQuery, deleteSavedQuery } from '../services/userDataService';
 import { generateIpynbContent, downloadFile } from '../services/notebookService';
@@ -508,6 +508,8 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
   const [isAnalyzing, setIsAnalyzing] = useState<boolean>(false);
   const [analysisResult, setAnalysisResult] = useState<AnalysisResult | null>(null);
   const [analysisError, setAnalysisError] = useState<string | null>(null);
+  const [explanation, setExplanation] = useState<string | null>(null);
+  const [isExplaining, setIsExplaining] = useState<boolean>(false);
 
   // State for write evaluation
   const [isEvaluatingWrite, setIsEvaluatingWrite] = useState<boolean>(false);
@@ -1019,6 +1021,23 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
       setIsAnalyzing(false);
     }
   }, [selectedModel]);
+
+  const handleExplainQuery = useCallback(async () => {
+    if (!editableCode) return;
+    setIsExplaining(true);
+    setExplanation(null);
+    try {
+      const res = await explainMongoQuery(editableCode, selectedModel);
+      setExplanation(res.explanation);
+    } catch (e) {
+      setExplanation(e instanceof Error ? e.message : 'Failed to explain the query.');
+    } finally {
+      setIsExplaining(false);
+    }
+  }, [editableCode, selectedModel]);
+
+  // Clear a stale explanation whenever the query code changes.
+  useEffect(() => { setExplanation(null); }, [editableCode]);
 
   const handleEvaluateWrite = useCallback(async () => {
     if (!editableCode || !executionResult || !lastSuccessfulPrompt || !selectedAccountId || !connectedDbInfo) return;
@@ -2052,8 +2071,17 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                         historyCount={codeHistory.length}
                         historyIndex={historyIndex}
                         onNavigateHistory={handleNavigateHistory}
+                        onExplain={handleExplainQuery}
+                        isExplaining={isExplaining}
                       />
                       <AgentVerdict isValid={_queryResult?.is_valid} explanation={_queryResult?.explanation} />
+                      {explanation && (
+                        <div className="qa-card" style={{ padding: '10px 14px', display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+                          <span className="qa-chip accent" style={{ flexShrink: 0 }}>Explanation</span>
+                          <span style={{ fontSize: 12.5, color: 'var(--fg)', lineHeight: 1.55, flex: 1 }}>{explanation}</span>
+                          <button onClick={() => setExplanation(null)} className="qa-btn" style={{ fontSize: 11, padding: '2px 8px' }} title="Dismiss">Dismiss</button>
+                        </div>
+                      )}
                       <QueryResult
                         isExecuting={isExecuting}
                         executionError={executionError}
@@ -2560,8 +2588,15 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
           {(!isLoading && !error && !isDemoModeForResultsStep && !isDemoModeForDebugStep && !isDemoModeForContextActiveStep && !isDemoModeForRunStep && !isDemoModeForSaveStep) && (
             editableCode ? (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-                <QueryDisplay code={editableCode} onCodeChange={setEditableCode} onRunQuery={handleRunQuery} onSaveQuery={handleOpenSaveDialog} isExecuting={isExecuting} historyCount={codeHistory.length} historyIndex={historyIndex} onNavigateHistory={handleNavigateHistory} isTransferable={!!handover} onOpenInExplorer={handleOpenInExplorer} canWrite={can('data:write')} />
+                <QueryDisplay code={editableCode} onCodeChange={setEditableCode} onRunQuery={handleRunQuery} onSaveQuery={handleOpenSaveDialog} isExecuting={isExecuting} historyCount={codeHistory.length} historyIndex={historyIndex} onNavigateHistory={handleNavigateHistory} isTransferable={!!handover} onOpenInExplorer={handleOpenInExplorer} canWrite={can('data:write')} onExplain={handleExplainQuery} isExplaining={isExplaining} />
                 <AgentVerdict isValid={_queryResult?.is_valid} explanation={_queryResult?.explanation} />
+                {explanation && (
+                  <div className="qa-card" style={{ padding: '10px 14px', display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+                    <span className="qa-chip accent" style={{ flexShrink: 0 }}>Explanation</span>
+                    <span style={{ fontSize: 12.5, color: 'var(--fg)', lineHeight: 1.55, flex: 1 }}>{explanation}</span>
+                    <button onClick={() => setExplanation(null)} className="qa-btn" style={{ fontSize: 11, padding: '2px 8px' }} title="Dismiss">Dismiss</button>
+                  </div>
+                )}
                 <QueryResult isExecuting={isExecuting} executionError={executionError} executionResult={executionResult} onDebug={handleDebugQuery} isDebugging={isDebugging} debuggingResult={debuggingResult} debugError={debugError} sourceCollection={querySourceCollection} onSetIntermediateContext={handleSetIntermediateContext} intermediateContext={intermediateContext} onAnalyze={handleAnalyzeQuery} isAnalyzing={isAnalyzing} analysisResult={analysisResult} analysisError={analysisError} onEvaluateWrite={handleEvaluateWrite} isEvaluatingWrite={isEvaluatingWrite} writeEvaluationResult={writeEvaluationResult} writeEvaluationError={writeEvaluationError} />
               </div>
             ) : (

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -10,6 +10,7 @@ import { QueryResultData, DbInfo, CollectionInfo, CosmosDBAccount, SelectedResou
 import { mockECommerceDbInfo, mockCollectionInfoMap, mockFindUsersQuery, mockUserFindResult, mockSavedQueries } from '../services/mockData';
 import { getAuthErrorMessage, isAuthenticationExpiredError } from '../utils/authErrorHandler';
 import QueryDisplay from '../components/QueryDisplay';
+import AgentVerdict from '../components/AgentVerdict';
 import { useRoles } from '../hooks/useRoles';
 import QueryResult from '../components/QueryResult';
 import Loader from '../components/Loader';
@@ -2052,6 +2053,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                         historyIndex={historyIndex}
                         onNavigateHistory={handleNavigateHistory}
                       />
+                      <AgentVerdict isValid={_queryResult?.is_valid} explanation={_queryResult?.explanation} />
                       <QueryResult
                         isExecuting={isExecuting}
                         executionError={executionError}
@@ -2559,6 +2561,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
             editableCode ? (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
                 <QueryDisplay code={editableCode} onCodeChange={setEditableCode} onRunQuery={handleRunQuery} onSaveQuery={handleOpenSaveDialog} isExecuting={isExecuting} historyCount={codeHistory.length} historyIndex={historyIndex} onNavigateHistory={handleNavigateHistory} isTransferable={!!handover} onOpenInExplorer={handleOpenInExplorer} canWrite={can('data:write')} />
+                <AgentVerdict isValid={_queryResult?.is_valid} explanation={_queryResult?.explanation} />
                 <QueryResult isExecuting={isExecuting} executionError={executionError} executionResult={executionResult} onDebug={handleDebugQuery} isDebugging={isDebugging} debuggingResult={debuggingResult} debugError={debugError} sourceCollection={querySourceCollection} onSetIntermediateContext={handleSetIntermediateContext} intermediateContext={intermediateContext} onAnalyze={handleAnalyzeQuery} isAnalyzing={isAnalyzing} analysisResult={analysisResult} analysisError={analysisError} onEvaluateWrite={handleEvaluateWrite} isEvaluatingWrite={isEvaluatingWrite} writeEvaluationResult={writeEvaluationResult} writeEvaluationError={writeEvaluationError} />
               </div>
             ) : (

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -2287,27 +2287,9 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
 
       {/* AI analysis: trigger button (moved here from the results toolbar) + result */}
       {analysisResult ? (
-        <div className="qa-card animate-fade-in" style={{ padding: '10px 12px', display: 'flex', flexDirection: 'column', gap: 10 }}>
-          <div>
-            <div style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--accent)', marginBottom: 6 }}>Analysis</div>
-            <div style={{ fontSize: 12.5, lineHeight: 1.55, color: 'var(--fg)' }}>{analysisResult.insight}</div>
-          </div>
-          {analysisResult.followups && analysisResult.followups.length > 0 && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-              <div style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--muted)', fontWeight: 500 }}>Follow-ups</div>
-              {analysisResult.followups.map((f, i) => (
-                <button
-                  key={i}
-                  onClick={() => handleAnalysisFollowup(f)}
-                  style={{ display: 'block', width: '100%', textAlign: 'left', padding: '6px 9px', borderRadius: 7, border: '1px solid var(--border)', background: 'var(--panel)', font: 'inherit', fontSize: 12, color: 'var(--fg)', cursor: 'pointer' }}
-                  onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--soft)'; }}
-                  onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--panel)'; }}
-                >
-                  <span style={{ color: 'var(--accent)', marginRight: 6 }}>→</span>{f}
-                </button>
-              ))}
-            </div>
-          )}
+        <div className="qa-card animate-fade-in" style={{ padding: '10px 12px' }}>
+          <div style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--accent)', marginBottom: 6 }}>Summary</div>
+          <div style={{ fontSize: 12.5, lineHeight: 1.55, color: 'var(--fg)' }}>{analysisResult.insight}</div>
         </div>
       ) : resultIsAnalyzable ? (
         <div className="qa-card animate-fade-in" style={{ padding: '12px', display: 'flex', flexDirection: 'column', gap: 10 }}>
@@ -2355,17 +2337,31 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
         </div>
       )}
 
+      {/* Suggested follow-ups + notebook, anchored to the bottom (matches the PG Insights panel) */}
+      <div style={{ marginTop: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {analysisResult && analysisResult.followups && analysisResult.followups.length > 0 && (
+        <div>
+          <div style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.07em', color: 'var(--muted)', fontWeight: 500, marginBottom: 3 }}>Suggested follow-ups</div>
+          {analysisResult.followups.map((f, i) => (
+            <button key={i} className="ws-sug" onClick={() => handleAnalysisFollowup(f)}>
+              <span style={{ color: 'var(--accent)', marginRight: 6 }}>→</span>{f}
+            </button>
+          ))}
+        </div>
+      )}
+
       {/* Notebook shortcut */}
       <button
         onClick={() => setIsNotebookPanelOpen(true)}
         className="qa-btn"
-        style={{ width: '100%', justifyContent: 'center', marginTop: 'auto' }}
+        style={{ width: '100%', justifyContent: 'center' }}
       >
         <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
           <path d="M4 2h8a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1zM6 6h4M6 9h4M6 12h2"/>
         </svg>
         View notebook
       </button>
+      </div>
     </aside>
   );
 

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -1039,6 +1039,13 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
   // Clear a stale explanation whenever the query code changes.
   useEffect(() => { setExplanation(null); }, [editableCode]);
 
+  const handleAnalysisFollowup = useCallback((prompt: string) => {
+    setUserInput(prompt);
+    const primaryContext = selectedCollections.length > 0 ? collectionDetailsMap[selectedCollections[0]] : undefined;
+    setLastSuccessfulPrompt(prompt);
+    handleGenerateQuery(prompt, primaryContext);
+  }, [selectedCollections, collectionDetailsMap, handleGenerateQuery]);
+
   const handleEvaluateWrite = useCallback(async () => {
     if (!editableCode || !executionResult || !lastSuccessfulPrompt || !selectedAccountId || !connectedDbInfo) return;
 
@@ -2094,6 +2101,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                         onSetIntermediateContext={handleSetIntermediateContext}
                         intermediateContext={intermediateContext}
                         onAnalyze={handleAnalyzeQuery}
+                        onFollowup={handleAnalysisFollowup}
                         isAnalyzing={isAnalyzing}
                         analysisResult={analysisResult}
                         analysisError={analysisError}
@@ -2597,7 +2605,7 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
                     <button onClick={() => setExplanation(null)} className="qa-btn" style={{ fontSize: 11, padding: '2px 8px' }} title="Dismiss">Dismiss</button>
                   </div>
                 )}
-                <QueryResult isExecuting={isExecuting} executionError={executionError} executionResult={executionResult} onDebug={handleDebugQuery} isDebugging={isDebugging} debuggingResult={debuggingResult} debugError={debugError} sourceCollection={querySourceCollection} onSetIntermediateContext={handleSetIntermediateContext} intermediateContext={intermediateContext} onAnalyze={handleAnalyzeQuery} isAnalyzing={isAnalyzing} analysisResult={analysisResult} analysisError={analysisError} onEvaluateWrite={handleEvaluateWrite} isEvaluatingWrite={isEvaluatingWrite} writeEvaluationResult={writeEvaluationResult} writeEvaluationError={writeEvaluationError} />
+                <QueryResult isExecuting={isExecuting} executionError={executionError} executionResult={executionResult} onDebug={handleDebugQuery} isDebugging={isDebugging} debuggingResult={debuggingResult} debugError={debugError} sourceCollection={querySourceCollection} onSetIntermediateContext={handleSetIntermediateContext} intermediateContext={intermediateContext} onAnalyze={handleAnalyzeQuery} onFollowup={handleAnalysisFollowup} isAnalyzing={isAnalyzing} analysisResult={analysisResult} analysisError={analysisError} onEvaluateWrite={handleEvaluateWrite} isEvaluatingWrite={isEvaluatingWrite} writeEvaluationResult={writeEvaluationResult} writeEvaluationError={writeEvaluationError} />
               </div>
             ) : (
               <div style={{ textAlign: 'center', color: 'var(--muted)', padding: '32px 0', border: '1.5px dashed var(--border)', borderRadius: 'var(--radius-md)', fontSize: 13 }}>

--- a/frontend/pages/QueryGeneratorPage.tsx
+++ b/frontend/pages/QueryGeneratorPage.tsx
@@ -2266,6 +2266,9 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
   }
 
   // ── Embedded: connected — 2-column workspace layout ──────────────────
+  const resultIsAnalyzable = Array.isArray(executionResult) && executionResult.length > 0
+    && typeof executionResult[0] === 'object' && executionResult[0] !== null;
+
   const insightsRail = (
     <aside style={{
       width: 300, flexShrink: 0,
@@ -2283,12 +2286,32 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
         <span className="qa-chip" style={{ marginLeft: 'auto', fontSize: 10 }}>auto</span>
       </div>
 
-      {/* Analysis result */}
-      {analysisResult && (
+      {/* AI analysis: trigger button (moved here from the results toolbar) + result */}
+      {analysisResult ? (
         <div className="qa-card animate-fade-in" style={{ padding: '10px 12px' }}>
           <div style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--accent)', marginBottom: 6 }}>Analysis</div>
           <div style={{ fontSize: 12.5, lineHeight: 1.55, color: 'var(--fg)' }}>{analysisResult.insight}</div>
         </div>
+      ) : resultIsAnalyzable ? (
+        <div className="qa-card animate-fade-in" style={{ padding: '12px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <div style={{ fontSize: 12, color: 'var(--muted)', lineHeight: 1.5 }}>Results ready. Analyze them for patterns, anomalies and suggested follow-ups.</div>
+          <button
+            id="tutorial-analyze-button"
+            className="qa-btn primary"
+            style={{ width: '100%', justifyContent: 'center' }}
+            disabled={isAnalyzing}
+            onClick={() => handleAnalyzeQuery(executionResult)}
+          >
+            {isAnalyzing ? (
+              <><svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" style={{ animation: 'qp-spin 0.7s linear infinite' }}><path d="M8 2a6 6 0 1 0 6 6" /></svg> Analyzing…</>
+            ) : (
+              <><svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M8 1.5l1.4 3.8L13 6.5l-3.6 1.2L8 11.5 6.6 7.7 3 6.5l3.6-1.2z" /></svg> Analyze results</>
+            )}
+          </button>
+        </div>
+      ) : null}
+      {analysisError && (
+        <div className="qa-card" style={{ padding: '10px 12px', color: 'var(--status-err)', fontSize: 12 }}>{analysisError}</div>
       )}
 
       {/* Debug result */}
@@ -2308,10 +2331,10 @@ const QueryGeneratorPage: React.FC<QueryGeneratorPageProps> = ({ name, email, on
       )}
 
       {/* Empty state */}
-      {!analysisResult && !debuggingResult && !writeEvaluationResult && (
+      {!analysisResult && !resultIsAnalyzable && !debuggingResult && !writeEvaluationResult && (
         <div style={{ background: 'var(--soft)', border: '1px dashed var(--border)', borderRadius: 'var(--radius-md)', padding: '12px 14px' }}>
           <div style={{ fontSize: 11, color: 'var(--muted)', marginBottom: 6 }}>Run a query to see AI insights</div>
-          <div style={{ fontSize: 12, color: 'var(--muted)', lineHeight: 1.5 }}>After executing, use "Analyze" on the results to get patterns, anomalies, and follow-up suggestions.</div>
+          <div style={{ fontSize: 12, color: 'var(--muted)', lineHeight: 1.5 }}>After executing, use "Analyze results" here to get patterns, anomalies, and follow-up suggestions.</div>
         </div>
       )}
 

--- a/frontend/router.tsx
+++ b/frontend/router.tsx
@@ -37,6 +37,14 @@ export const router = createBrowserRouter([
     ),
   },
   {
+    path: "/postgres-audit/:serverId",
+    element: (
+      <ProtectedRoute>
+        <AuditPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
     path: "/analytics",
     element: (
       <ProtectedRoute>

--- a/frontend/router.tsx
+++ b/frontend/router.tsx
@@ -4,6 +4,7 @@ import HubPage from './pages/HubPage';
 import QueryGeneratorPageWrapper from './pages/QueryGeneratorPageWrapper';
 import DataExplorerPageWrapper from './pages/DataExplorerPageWrapper';
 import PostgresWorkspacePage from './pages/PostgresWorkspacePage';
+import PostgresDataExplorerPage from './pages/PostgresDataExplorerPage';
 import AnalyticsPageWrapper from './pages/AnalyticsPageWrapper';
 import NotFoundPage from './pages/NotFoundPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
@@ -88,6 +89,14 @@ export const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <PostgresWorkspacePage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: "/postgres-explorer/:serverId/:database",
+    element: (
+      <ProtectedRoute>
+        <PostgresDataExplorerPage />
       </ProtectedRoute>
     ),
   },

--- a/frontend/router.tsx
+++ b/frontend/router.tsx
@@ -3,7 +3,7 @@ import LoginPage from './pages/LoginPage';
 import HubPage from './pages/HubPage';
 import QueryGeneratorPageWrapper from './pages/QueryGeneratorPageWrapper';
 import DataExplorerPageWrapper from './pages/DataExplorerPageWrapper';
-import PostgresExplorerPage from './pages/PostgresExplorerPage';
+import PostgresWorkspacePage from './pages/PostgresWorkspacePage';
 import AnalyticsPageWrapper from './pages/AnalyticsPageWrapper';
 import NotFoundPage from './pages/NotFoundPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
@@ -79,7 +79,7 @@ export const router = createBrowserRouter([
     path: "/postgres/:serverId",
     element: (
       <ProtectedRoute>
-        <PostgresExplorerPage />
+        <PostgresWorkspacePage />
       </ProtectedRoute>
     ),
   },
@@ -87,7 +87,7 @@ export const router = createBrowserRouter([
     path: "/postgres/:serverId/:database",
     element: (
       <ProtectedRoute>
-        <PostgresExplorerPage />
+        <PostgresWorkspacePage />
       </ProtectedRoute>
     ),
   },

--- a/frontend/router.tsx
+++ b/frontend/router.tsx
@@ -93,6 +93,14 @@ export const router = createBrowserRouter([
     ),
   },
   {
+    path: "/postgres-explorer/:serverId",
+    element: (
+      <ProtectedRoute>
+        <PostgresDataExplorerPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
     path: "/postgres-explorer/:serverId/:database",
     element: (
       <ProtectedRoute>

--- a/frontend/router.tsx
+++ b/frontend/router.tsx
@@ -3,6 +3,7 @@ import LoginPage from './pages/LoginPage';
 import HubPage from './pages/HubPage';
 import QueryGeneratorPageWrapper from './pages/QueryGeneratorPageWrapper';
 import DataExplorerPageWrapper from './pages/DataExplorerPageWrapper';
+import PostgresExplorerPage from './pages/PostgresExplorerPage';
 import AnalyticsPageWrapper from './pages/AnalyticsPageWrapper';
 import NotFoundPage from './pages/NotFoundPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
@@ -71,6 +72,22 @@ export const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <DataExplorerPageWrapper />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: "/postgres/:serverId",
+    element: (
+      <ProtectedRoute>
+        <PostgresExplorerPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: "/postgres/:serverId/:database",
+    element: (
+      <ProtectedRoute>
+        <PostgresExplorerPage />
       </ProtectedRoute>
     ),
   },

--- a/frontend/services/dbService.ts
+++ b/frontend/services/dbService.ts
@@ -858,3 +858,57 @@ export async function removeUserRole(oid: string, assignmentId: string): Promise
   });
   if (!response.ok) throw new Error('Failed to remove role');
 }
+
+// --- PostgreSQL (Azure Flexible Server) client ---------------------------
+// These mirror the Cosmos helpers but take the bearer token explicitly so they
+// stay trivially testable; callers acquire it via getAuthenticatedToken().
+
+export type DbEngine = 'cosmos' | 'postgres';
+
+export interface PostgresServer { name: string; id: string; fqdn: string; }
+
+export async function listPostgresServers(token: string): Promise<PostgresServer[]> {
+  if (!USE_MSAL_AUTH) return []; // dev/mock mode: no Azure PG discovery
+  const res = await fetch(`${API_BASE_URL}/postgres/servers`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`postgres/servers ${res.status}`);
+  return res.json();
+}
+
+async function _pgPost(token: string, path: string, body: unknown) {
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`${path} ${res.status}`);
+  return res.json();
+}
+
+export async function getPgDatabases(token: string, serverId: string): Promise<string[]> {
+  return _pgPost(token, '/postgres/databases', { server_id: serverId });
+}
+
+export async function getPgSchema(token: string, serverId: string, database: string) {
+  return _pgPost(token, '/postgres/schema', { server_id: serverId, database });
+}
+
+export async function getPgTableInfo(
+  token: string, serverId: string, database: string, schemaName: string, table: string,
+) {
+  return _pgPost(token, '/postgres/table_info', {
+    server_id: serverId, database, schema_name: schemaName, table,
+  });
+}
+
+export async function pgNl2Sql(token: string, body: {
+  server_id: string; database: string; schema_context: string;
+  user_input: string; model?: string; max_iterations?: number;
+}) {
+  return _pgPost(token, '/postgres/nl2sql', body);
+}
+
+export async function pgExecute(token: string, serverId: string, database: string, sql: string) {
+  return _pgPost(token, '/postgres/execute', { server_id: serverId, database, sql });
+}

--- a/frontend/services/dbService.ts
+++ b/frontend/services/dbService.ts
@@ -913,6 +913,12 @@ export async function pgExecute(token: string, serverId: string, database: strin
   return _pgPost(token, '/postgres/execute', { server_id: serverId, database, sql });
 }
 
+export async function pgAnalyze(token: string, body: {
+  columns: string[]; rows: unknown[][]; user_input?: string; model?: string;
+}): Promise<{ summary: string; points: string[]; followups: string[] }> {
+  return _pgPost(token, '/postgres/analyze', body);
+}
+
 // --- PostgreSQL access provisioning (admin only) ---
 export async function pgListAccess(token: string, serverId: string): Promise<string[]> {
   return _pgPost(token, '/postgres/access', { server_id: serverId });

--- a/frontend/services/dbService.ts
+++ b/frontend/services/dbService.ts
@@ -880,9 +880,9 @@ export async function listPostgresServers(token: string): Promise<PostgresServer
   return data;
 }
 
-async function _pgPost(token: string, path: string, body: unknown) {
+async function _pgPost(token: string, path: string, body: unknown, method: string = 'POST') {
   const res = await fetch(`${API_BASE_URL}${path}`, {
-    method: 'POST',
+    method,
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify(body),
   });
@@ -949,4 +949,50 @@ export async function pgGrantAccess(token: string, serverId: string, userEmail: 
 
 export async function pgRevokeAccess(token: string, serverId: string, userEmail: string) {
   return _pgPost(token, '/postgres/revoke', { server_id: serverId, user_email: userEmail });
+}
+
+// --- PostgreSQL data explorer (row browse + CRUD) ---
+export interface PgFilter { column: string; op: string; value?: unknown }
+export interface PgSort { column: string; dir: 'asc' | 'desc' }
+
+export async function getPgRows(token: string, args: {
+  serverId: string; database: string; schema: string; table: string;
+  filters?: PgFilter[]; sort?: PgSort | null; limit?: number; offset?: number;
+}): Promise<{ columns: string[]; rows: unknown[][]; total: number; pk: string[] }> {
+  return _pgPost(token, '/postgres/rows', {
+    server_id: args.serverId, database: args.database,
+    schema_name: args.schema, table: args.table,
+    filters: args.filters ?? [], sort: args.sort ?? null,
+    limit: args.limit ?? 50, offset: args.offset ?? 0,
+  });
+}
+
+export async function pgInsertRow(token: string, args: {
+  serverId: string; database: string; schema: string; table: string;
+  values: Record<string, unknown>;
+}): Promise<{ columns: string[]; rows: unknown[][] }> {
+  return _pgPost(token, '/postgres/row', {
+    server_id: args.serverId, database: args.database,
+    schema_name: args.schema, table: args.table, values: args.values,
+  });
+}
+
+export async function pgUpdateRow(token: string, args: {
+  serverId: string; database: string; schema: string; table: string;
+  pk: Record<string, unknown>; values: Record<string, unknown>;
+}): Promise<{ columns: string[]; rows: unknown[][] }> {
+  return _pgPost(token, '/postgres/row', {
+    server_id: args.serverId, database: args.database,
+    schema_name: args.schema, table: args.table, pk: args.pk, values: args.values,
+  }, 'PATCH');
+}
+
+export async function pgDeleteRow(token: string, args: {
+  serverId: string; database: string; schema: string; table: string;
+  pk: Record<string, unknown>;
+}): Promise<{ columns: string[]; rows: unknown[][] }> {
+  return _pgPost(token, '/postgres/row', {
+    server_id: args.serverId, database: args.database,
+    schema_name: args.schema, table: args.table, pk: args.pk,
+  }, 'DELETE');
 }

--- a/frontend/services/dbService.ts
+++ b/frontend/services/dbService.ts
@@ -939,7 +939,9 @@ export async function pgAnalyze(token: string, body: {
 }
 
 // --- PostgreSQL access provisioning (admin only) ---
-export async function pgListAccess(token: string, serverId: string): Promise<string[]> {
+export interface PgAccessEntry { email: string; write: boolean }
+
+export async function pgListAccess(token: string, serverId: string): Promise<PgAccessEntry[]> {
   return _pgPost(token, '/postgres/access', { server_id: serverId });
 }
 
@@ -949,6 +951,14 @@ export async function pgGrantAccess(token: string, serverId: string, userEmail: 
 
 export async function pgRevokeAccess(token: string, serverId: string, userEmail: string) {
   return _pgPost(token, '/postgres/revoke', { server_id: serverId, user_email: userEmail });
+}
+
+export async function pgGrantWrite(token: string, serverId: string, userEmail: string) {
+  return _pgPost(token, '/postgres/grant_write', { server_id: serverId, user_email: userEmail });
+}
+
+export async function pgRevokeWrite(token: string, serverId: string, userEmail: string) {
+  return _pgPost(token, '/postgres/revoke_write', { server_id: serverId, user_email: userEmail });
 }
 
 // --- PostgreSQL data explorer (row browse + CRUD) ---

--- a/frontend/services/dbService.ts
+++ b/frontend/services/dbService.ts
@@ -912,3 +912,16 @@ export async function pgNl2Sql(token: string, body: {
 export async function pgExecute(token: string, serverId: string, database: string, sql: string) {
   return _pgPost(token, '/postgres/execute', { server_id: serverId, database, sql });
 }
+
+// --- PostgreSQL access provisioning (admin only) ---
+export async function pgListAccess(token: string, serverId: string): Promise<string[]> {
+  return _pgPost(token, '/postgres/access', { server_id: serverId });
+}
+
+export async function pgGrantAccess(token: string, serverId: string, userEmail: string) {
+  return _pgPost(token, '/postgres/grant', { server_id: serverId, user_email: userEmail });
+}
+
+export async function pgRevokeAccess(token: string, serverId: string, userEmail: string) {
+  return _pgPost(token, '/postgres/revoke', { server_id: serverId, user_email: userEmail });
+}

--- a/frontend/services/dbService.ts
+++ b/frontend/services/dbService.ts
@@ -869,11 +869,15 @@ export interface PostgresServer { name: string; id: string; fqdn: string; }
 
 export async function listPostgresServers(token: string): Promise<PostgresServer[]> {
   if (!USE_MSAL_AUTH) return []; // dev/mock mode: no Azure PG discovery
+  const cached = _getCached<PostgresServer[]>('pg_servers');
+  if (cached) return cached;
   const res = await fetch(`${API_BASE_URL}/postgres/servers`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) throw new Error(`postgres/servers ${res.status}`);
-  return res.json();
+  const data: PostgresServer[] = await res.json();
+  _setCached('pg_servers', data);
+  return data;
 }
 
 async function _pgPost(token: string, path: string, body: unknown) {
@@ -882,16 +886,31 @@ async function _pgPost(token: string, path: string, body: unknown) {
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error(`${path} ${res.status}`);
+  if (!res.ok) {
+    // Surface the backend's error detail (e.g. the real Postgres message)
+    // instead of a bare status code.
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.detail || `${path} ${res.status}`);
+  }
   return res.json();
 }
 
 export async function getPgDatabases(token: string, serverId: string): Promise<string[]> {
-  return _pgPost(token, '/postgres/databases', { server_id: serverId });
+  const key = `pg_dbs:${serverId}`;
+  const cached = _getCached<string[]>(key);
+  if (cached) return cached;
+  const data = await _pgPost(token, '/postgres/databases', { server_id: serverId }) as string[];
+  _setCached(key, data);
+  return data;
 }
 
 export async function getPgSchema(token: string, serverId: string, database: string) {
-  return _pgPost(token, '/postgres/schema', { server_id: serverId, database });
+  const key = `pg_schema:${serverId}:${database}`;
+  const cached = _getCached<unknown>(key);
+  if (cached) return cached;
+  const data = await _pgPost(token, '/postgres/schema', { server_id: serverId, database });
+  _setCached(key, data);
+  return data;
 }
 
 export async function getPgTableInfo(

--- a/frontend/services/geminiService.ts
+++ b/frontend/services/geminiService.ts
@@ -147,6 +147,27 @@ export const debugMongoQuery = async (query: string, errorMessage: string, model
 };
 
 /**
+ * Asks the backend for a plain-English explanation of what a Mongo query does.
+ */
+export const explainMongoQuery = async (code: string, model: string = 'gemini-2.5-flash'): Promise<{ explanation: string }> => {
+    if (!USE_MSAL_AUTH) {
+        await mockDelay(600);
+        return Promise.resolve({ explanation: 'This query returns documents from the selected collection (mock explanation).' });
+    }
+    const token = await getAuthenticatedToken();
+    const response = await fetch(`${API_BASE_URL}/query/explain`, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: code, model }),
+    });
+    if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err.detail || err.message || 'Failed to explain the query.');
+    }
+    return response.json();
+};
+
+/**
  * Sends a query result to the backend to be analyzed by an AI model.
  * The AI will return insights and a suggested visualization.
  * @param queryResult The data returned from a successful query execution.

--- a/frontend/services/geminiService.ts
+++ b/frontend/services/geminiService.ts
@@ -124,9 +124,11 @@ export const debugMongoQuery = async (query: string, errorMessage: string, model
 
     console.log("Sending failed query to backend for debugging...");
 
+    const token = await getAuthenticatedToken();
     const response = await fetch(`${API_BASE_URL}/query/debug`, {
         method: 'POST',
         headers: {
+            'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json',
         },
         body: JSON.stringify({
@@ -189,9 +191,10 @@ export const analyzeQueryResult = async (queryResult: any, model: string = 'gemi
 
     console.log("Sending query result to backend for analysis...");
 
+    const token = await getAuthenticatedToken();
     const response = await fetch(`${API_BASE_URL}/query/analyze`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({ query_result: queryResult, model }),
     });
 

--- a/frontend/services/userDataService.ts
+++ b/frontend/services/userDataService.ts
@@ -43,16 +43,18 @@ const getAccessToken = async (): Promise<string> => {
  * Fetches the user's saved queries from the backend.
  * This includes queries they own and queries shared with them.
  */
-export const getSavedQueries = async (): Promise<SavedQuery[]> => {
+export const getSavedQueries = async (engine?: 'cosmos' | 'pg'): Promise<SavedQuery[]> => {
     if (!USE_MSAL_AUTH) {
         console.log("DEV MODE: Returning mock saved queries.");
         await mockDelay(800);
         // The mock data is already structured for sharing.
-        return Promise.resolve(mockSavedQueries);
+        const all = mockSavedQueries;
+        return Promise.resolve(engine ? all.filter(q => (q.engine ?? 'cosmos') === engine) : all);
     }
 
     const token = await getAccessToken();
-    const response = await fetch(`${API_BASE_URL}/user/queries`, {
+    const url = engine ? `${API_BASE_URL}/user/queries?engine=${engine}` : `${API_BASE_URL}/user/queries`;
+    const response = await fetch(url, {
         headers: { 'Authorization': `Bearer ${token}` },
     });
     if (!response.ok) {
@@ -65,7 +67,7 @@ export const getSavedQueries = async (): Promise<SavedQuery[]> => {
  * Saves a new query to the backend.
  * @param queryData The data for the new query (name, prompt, code).
  */
-export const saveQuery = async (queryData: Pick<SavedQuery, 'name' | 'prompt' | 'code'>): Promise<SavedQuery> => {
+export const saveQuery = async (queryData: Pick<SavedQuery, 'name' | 'prompt' | 'code'> & { engine?: 'cosmos' | 'pg' }): Promise<SavedQuery> => {
     if (!USE_MSAL_AUTH) {
         console.log("DEV MODE: Mock saving query.", queryData);
         await mockDelay(500);

--- a/frontend/src/design-tokens.css
+++ b/frontend/src/design-tokens.css
@@ -210,3 +210,128 @@ html.dark {
 }
 .ad-row:last-child { border-bottom: none; }
 .ad-row:hover { background: var(--soft); }
+
+/* ── PostgreSQL Query Workspace ─────────────────────────────── */
+
+@keyframes ws-spin { to { transform: rotate(360deg); } }
+@keyframes ws-fade { from { opacity: 0; transform: translateY(3px); } to { opacity: 1; transform: none; } }
+.ws-anim { animation: ws-fade 0.2s ease; }
+
+/* small monospace metadata tag */
+.qa-tag {
+  display: inline-flex; align-items: center;
+  height: 18px; padding: 0 6px; border-radius: 4px;
+  background: var(--soft); color: var(--muted);
+  font-family: var(--font-mono); font-size: 10px; font-weight: 500;
+  white-space: nowrap;
+}
+.qa-iconbtn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 27px; height: 27px; border-radius: var(--radius-sm);
+  border: 1px solid var(--border); background: var(--panel);
+  color: var(--muted); cursor: pointer;
+}
+.qa-iconbtn:hover { background: var(--soft); color: var(--fg); }
+
+/* table quick-switch chips */
+.ws-chips { display: flex; flex-wrap: wrap; gap: 7px; }
+.ws-chip {
+  height: 28px; padding: 0 12px; border-radius: 99px;
+  border: 1px solid var(--border); background: var(--panel);
+  font-family: var(--font-mono); font-size: 12px; color: var(--fg);
+  cursor: pointer; display: inline-flex; align-items: center; gap: 6px;
+}
+.ws-chip:hover { background: var(--soft); }
+.ws-chip.on {
+  background: var(--accent-soft);
+  border-color: color-mix(in oklch, var(--accent) 32%, transparent);
+}
+.ws-chip .cc { font-family: var(--font-mono); font-size: 10px; color: var(--muted); }
+.ws-chip.on .cc { color: var(--accent); }
+
+/* schema card two-column body */
+.ws-schemacard { display: grid; grid-template-columns: 1.15fr 1fr; gap: 0; }
+.ws-scol { padding: 12px 14px; min-width: 0; }
+.ws-scol + .ws-scol { border-left: 1px solid var(--border); }
+.ws-sec-h {
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.07em;
+  color: var(--muted); font-weight: 500;
+  display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px;
+}
+.ws-sec-h .n { font-family: var(--font-mono); color: color-mix(in oklch, var(--muted) 80%, transparent); }
+.ws-col { display: flex; align-items: center; gap: 8px; padding: 3px 6px; border-radius: 6px; cursor: pointer; }
+.ws-col:hover { background: var(--soft); }
+.ws-col:hover .ws-col-add { opacity: 1; }
+.ws-col-name { font-family: var(--font-mono); font-size: 12px; color: var(--fg); }
+.ws-col-name.fk { color: #2f6df0; }
+.ws-col-type { font-family: var(--font-mono); font-size: 10.5px; color: var(--muted); }
+.ws-col-add { opacity: 0; color: var(--muted); flex-shrink: 0; transition: opacity 0.1s; }
+.ws-nn { width: 6px; height: 6px; border-radius: 99px; flex-shrink: 0; }
+.ws-nn.on { background: color-mix(in oklch, var(--muted) 55%, transparent); }
+.ws-nn.off { border: 1px solid color-mix(in oklch, var(--muted) 45%, transparent); }
+.ws-keybadge {
+  font-family: var(--font-mono); font-size: 8.5px; font-weight: 600; letter-spacing: 0.03em;
+  padding: 1px 3px; border-radius: 3px; flex-shrink: 0; width: 19px; text-align: center;
+}
+.ws-keybadge.pk { background: color-mix(in oklch, #c98d42 22%, var(--panel)); color: #9a6a1e; }
+.ws-keybadge.fk { background: color-mix(in oklch, #2f6df0 16%, var(--panel)); color: #2f6df0; }
+.ws-keybadge.none { background: transparent; color: transparent; }
+.ws-idx { display: flex; align-items: baseline; gap: 8px; padding: 3px 6px; border-radius: 6px; }
+.ws-idx:hover { background: var(--soft); }
+.ws-idx-name { font-family: var(--font-mono); font-size: 11px; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ws-idx-cols { font-family: var(--font-mono); font-size: 9.5px; color: var(--muted); margin-left: auto; white-space: nowrap; flex-shrink: 0; }
+.ws-idx-kind { font-size: 8px; font-weight: 600; letter-spacing: 0.04em; padding: 1px 4px; border-radius: 3px; background: var(--soft); color: var(--muted); flex-shrink: 0; }
+.ws-idx-kind.uniq { background: color-mix(in oklch, #3a8c5f 15%, var(--panel)); color: #3a8c5f; }
+.ws-idx-kind.gin { background: color-mix(in oklch, #7a5ae0 16%, var(--panel)); color: #7a5ae0; }
+.ws-fk { display: flex; align-items: center; gap: 7px; padding: 3px 6px; border-radius: 6px; font-family: var(--font-mono); font-size: 11px; }
+.ws-fk .src { color: var(--fg); }
+.ws-fk .arr { color: var(--muted); }
+.ws-fk .dst { color: #2f6df0; }
+
+/* dark SQL editor with syntax-highlight overlay */
+.ws-editor { position: relative; min-height: 130px; overflow: auto; background: #0f0e0d; border-radius: 8px; }
+.ws-editor .hl, .ws-editor textarea {
+  margin: 0; padding: 12px 14px;
+  font-family: var(--font-mono); font-size: 12px; line-height: 1.65; letter-spacing: 0;
+  tab-size: 2; white-space: pre-wrap; overflow-wrap: break-word; word-break: break-word;
+  border: 0; box-sizing: border-box; width: 100%; min-height: 130px;
+}
+.ws-editor .hl { position: absolute; inset: 0; pointer-events: none; color: #c8c4bc; }
+.ws-editor textarea { position: relative; background: transparent; color: transparent; caret-color: #e0956e; resize: vertical; outline: none; display: block; }
+.ws-editor::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.18); }
+.ws-copy {
+  position: absolute; top: 8px; right: 8px; padding: 3px 9px; border-radius: 4px; cursor: pointer;
+  background: rgba(255, 255, 255, 0.07); border: 1px solid rgba(255, 255, 255, 0.12);
+  color: #8a8580; font-size: 11px; font-family: var(--font-mono);
+}
+.ws-copy:hover { color: #c8c4bc; }
+.tk-kw { color: #e0956e; }
+.tk-fn { color: #6fb3d9; }
+.tk-st { color: #9ece9e; }
+.tk-nm { color: #c9a6e0; }
+.tk-cm { color: #6b6660; font-style: italic; }
+.tk-pu { color: #8a8580; }
+
+/* results grid */
+.ws-grid { width: 100%; border-collapse: collapse; }
+.ws-grid thead th { position: sticky; top: 0; z-index: 1; background: var(--panel); text-align: left; padding: 7px 12px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); font-weight: 500; white-space: nowrap; border-bottom: 1px solid var(--border); }
+.ws-grid tbody td { padding: 6px 12px; font-family: var(--font-mono); font-size: 11.5px; border-bottom: 1px solid var(--border); white-space: nowrap; color: var(--fg); }
+.ws-grid tbody tr:hover td { background: var(--soft); }
+.ws-grid tbody tr:last-child td { border-bottom: none; }
+.ws-grid .rownum { color: var(--muted); text-align: right; width: 34px; user-select: none; }
+.ws-grid .null { color: var(--muted); font-style: italic; }
+
+/* query plan */
+.ws-plan { margin: 0; padding: 14px 16px; font-family: var(--font-mono); font-size: 11.5px; line-height: 1.7; white-space: pre; overflow-x: auto; color: var(--fg); }
+.ws-plan .pn { color: #a3542f; font-weight: 500; }
+.ws-plan .pc { color: var(--muted); }
+.ws-plan .pv { color: #2f6df0; }
+
+/* right insights rail */
+.ws-insights { width: 316px; flex-shrink: 0; border-left: 1px solid var(--border); background: var(--bg); display: flex; flex-direction: column; min-height: 0; }
+.ws-ins-hd { display: flex; align-items: center; gap: 8px; padding: 15px 16px 13px; }
+.ws-ins-hd .t { font-size: 14px; font-weight: 500; }
+.ws-ins-body { flex: 1; overflow-y: auto; padding: 0 16px 12px; }
+.ws-ins-foot { padding: 12px 16px; border-top: 1px solid var(--border); flex-shrink: 0; }
+.ws-sug { display: block; width: 100%; text-align: left; padding: 7px 10px; border-radius: 7px; border: 1px solid var(--border); background: var(--panel); font: inherit; font-size: 12px; color: var(--fg); cursor: pointer; margin-top: 6px; }
+.ws-sug:hover { background: var(--soft); }

--- a/frontend/src/design-tokens.css
+++ b/frontend/src/design-tokens.css
@@ -233,6 +233,11 @@ html.dark {
 }
 .qa-iconbtn:hover { background: var(--soft); color: var(--fg); }
 
+/* Middle column is a flex column with a bounded height; without this its cards
+   would shrink to fit (tiny/unreadable) instead of overflowing. Keep their
+   natural height so the column scrolls. */
+.pg-workspace-mid > * { flex-shrink: 0; }
+
 /* table quick-switch chips */
 .ws-chips { display: flex; flex-wrap: wrap; gap: 7px; }
 .ws-chip {
@@ -288,17 +293,23 @@ html.dark {
 .ws-fk .arr { color: var(--muted); }
 .ws-fk .dst { color: #2f6df0; }
 
-/* dark SQL editor with syntax-highlight overlay */
-.ws-editor { position: relative; min-height: 130px; overflow: auto; background: #0f0e0d; border-radius: 8px; }
+/* dark SQL editor: highlight <pre> sits in normal flow and defines the height
+   (grows with content); the transparent <textarea> overlays it exactly. The
+   whole editor grows inside the scrollable column instead of scrolling itself,
+   so the two layers can never desync. */
+.ws-editor { position: relative; min-height: 130px; background: #0f0e0d; border-radius: 8px; }
 .ws-editor .hl, .ws-editor textarea {
   margin: 0; padding: 12px 14px;
   font-family: var(--font-mono); font-size: 12px; line-height: 1.65; letter-spacing: 0;
   tab-size: 2; white-space: pre-wrap; overflow-wrap: break-word; word-break: break-word;
   border: 0; box-sizing: border-box; width: 100%; min-height: 130px;
 }
-.ws-editor .hl { position: absolute; inset: 0; pointer-events: none; color: #c8c4bc; }
-.ws-editor textarea { position: relative; background: transparent; color: transparent; caret-color: #e0956e; resize: vertical; outline: none; display: block; }
-.ws-editor::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.18); }
+.ws-editor .hl { position: relative; pointer-events: none; color: #c8c4bc; }
+.ws-editor textarea {
+  position: absolute; inset: 0; height: 100%;
+  background: transparent; color: transparent; caret-color: #e0956e;
+  resize: none; overflow: hidden; outline: none; display: block;
+}
 .ws-copy {
   position: absolute; top: 8px; right: 8px; padding: 3px 9px; border-radius: 4px; cursor: pointer;
   background: rgba(255, 255, 255, 0.07); border: 1px solid rgba(255, 255, 255, 0.12);

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -122,6 +122,7 @@ export interface SavedQuery {
     name: string;
     prompt: string;
     code: string;
+    engine?: 'cosmos' | 'pg'; // absent on legacy rows => cosmos
     // New fields for sharing and collaboration
     ownerEmail: string;
     sharedWith: string[];

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -98,6 +98,7 @@ export interface AnalysisResult {
     chartType: ChartJSType;
     chartData: ChartJSData;
     chartOptions?: ChartJSOptions;
+    followups?: string[];
 }
 
 /**

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -20,3 +20,27 @@ resource "google_vpc_access_connector" "querypal" {
 
   depends_on = [google_project_service.vpcaccess]
 }
+
+# Static egress IP so Cloud Run's public traffic (Azure Cosmos/Postgres public
+# endpoints behind IP firewalls) leaves from ONE stable address to allowlist.
+# Requires the Cloud Run service to use vpc-egress=all-traffic (set via gcloud —
+# the services are deployed outside Terraform).
+resource "google_compute_address" "querypal_egress" {
+  name   = "querypal-egress-ip"
+  region = var.region
+}
+
+resource "google_compute_router" "querypal" {
+  name    = "querypal-router"
+  region  = var.region
+  network = var.vpc_network
+}
+
+resource "google_compute_router_nat" "querypal" {
+  name                               = "querypal-nat"
+  router                             = google_compute_router.querypal.name
+  region                             = var.region
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  nat_ips                            = [google_compute_address.querypal_egress.self_link]
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}


### PR DESCRIPTION
Release: dev → production.

## Highlights

### PostgreSQL data explorer, audit & access management (#49)
- New **PostgreSQL Data Explorer**: grid over a table with typed cells, PK/FK badges, per-column filter builder, sort, pagination, FK navigation, and a create/edit/delete row drawer (natural PKs, array/JSON input, inline errors).
- Parameterized, PK-scoped, identifier-whitelisted row CRUD endpoints; DB errors surfaced as 400.
- **PostgreSQL-aware audit log**: dedicated PG audit route/shell, real before/after update diffs, row/table terminology, connection-context-preserving switching.
- **Self-service PostgreSQL write access** (opt-in `pg_write_all_data`) + roles/permissions reference on the admin page; friendly IP-whitelist guidance on firewall timeouts.
- Nav/Hub polish: Audit in sidebar, Admin in profile menu, PG Explorer on the Hub card, connection-chip database switcher, loading states.
- Fixes: CORS `PATCH` for row updates; `/audit/recent` null `document_id`.

### Infrastructure (#48)
- Static egress IP + Cloud NAT for stable outbound addressing.

## Notes
- Requires PostgreSQL 14+ (`pg_read_all_data` / `pg_write_all_data`).
- Row writes require both an Analyst/Admin app role and per-server PostgreSQL write access (Entra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
