### PR TITLE
release: PG prod connectivity hotfix + admin table polish

### DIFF
--- a/.github/workflows/google-cloudrun-docker.yml
+++ b/.github/workflows/google-cloudrun-docker.yml
@@ -87,7 +87,9 @@ jobs:
             --service-account=${{ env.CLOUD_RUN_SA_NAME }}@${{ env.PROJECT_ID }}.iam.gserviceaccount.com
             --add-cloudsql-instances=${{ env.PROJECT_ID }}:${{ env.REGION }}:querypal-db
             --vpc-connector=${{ env.VPC_CONNECTOR }}
-            --vpc-egress=private-ranges-only
+            # all-traffic so public endpoints (Azure Cosmos/Postgres) exit via the
+            # static NAT egress IP that's allowlisted on their firewalls.
+            --vpc-egress=all-traffic
             --ingress=internal
             --allow-unauthenticated
 

--- a/.github/workflows/google-cloudrun-docker.yml
+++ b/.github/workflows/google-cloudrun-docker.yml
@@ -73,6 +73,9 @@ jobs:
             ARM_SCOPE=https://management.azure.com/.default
             DB_NAME=querypal
             DB_UNIX_SOCKET=/cloudsql/${{ env.PROJECT_ID }}:${{ env.REGION }}:querypal-db
+            # Entra DISPLAY NAME of the backend SP (a permanent PG Entra admin).
+            # Used for SP-admin grant/revoke/list; PG rejects appId/objectId here.
+            PG_ADMIN_LOGIN=Mongo AI Assistant
           # Sensitive values are read directly from Secret Manager at runtime.
           # Secret must exist before first deploy (created by terraform/secrets.tf).
           secrets: |

--- a/frontend/pages/AdminPage.tsx
+++ b/frontend/pages/AdminPage.tsx
@@ -292,10 +292,10 @@ export default function AdminPage() {
                   <td style={{ padding: '10px 10px' }}>
                     <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
                       {u.roles.length === 0 && (
-                        <span className="qa-chip" style={{ color: 'var(--muted)', fontSize: 11 }}>Viewer (default)</span>
+                        <span className="qa-chip" style={{ color: 'var(--muted)', fontSize: 11, whiteSpace: 'nowrap' }}>Viewer (default)</span>
                       )}
                       {u.roles.map((r) => (
-                        <span key={r.assignment_id} className="qa-chip" style={{ display: 'flex', alignItems: 'center', gap: 4, color: chipColor[r.role_name] ?? 'var(--fg)' }}>
+                        <span key={r.assignment_id} className="qa-chip" style={{ display: 'flex', alignItems: 'center', gap: 4, whiteSpace: 'nowrap', color: chipColor[r.role_name] ?? 'var(--fg)' }}>
                           {r.role_name}
                           <button
                             onClick={() => handleRemove(u.oid, r.assignment_id)}
@@ -334,11 +334,11 @@ export default function AdminPage() {
                   </td>
 
                   {pgServers.length > 0 && (
-                    <td style={{ padding: '10px 10px', minWidth: 120 }}>
+                    <td style={{ padding: '10px 10px', whiteSpace: 'nowrap', width: 1 }}>
                       {pgAccessLoading ? (
                         <span style={{ fontSize: 11.5, color: 'var(--muted)' }}>Checking…</span>
                       ) : pgAccess.has(u.email.toLowerCase()) ? (
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                           <span className="qa-chip ok" style={{ fontSize: 11 }}>● read</span>
                           {pgWrite.has(u.email.toLowerCase()) ? (
                             <>


### PR DESCRIPTION
## Release notes

Hotfix release addressing production PostgreSQL connectivity regressions from the last release, plus an admin UI polish.

### Fixes
- **Cloud Run backend egress → `all-traffic`** — the backend deploy hardcoded `--vpc-egress=private-ranges-only`, so traffic to Azure PostgreSQL (a public endpoint) bypassed the static NAT egress IP (`34.14.98.80`, allowlisted on the Azure firewall) and timed out. Now routes through the static IP like the frontend.
- **`PG_ADMIN_LOGIN` deployed** — the role-management page failed with `PostgreSQL connection failed: 'PG_ADMIN_LOGIN'` (a `KeyError`) because the env var was never in the deploy config. Set to the backend SP's Entra display name.
- **Admin users-table wrapping** — `Viewer (default)` / role chips no longer split across two lines; the PostgreSQL column shrinks to its content instead of squeezing neighbouring columns.

### Note
The live production service was already hotfixed for the two backend config issues via `gcloud run services update`. This release makes them durable in the deploy workflow so they survive future releases; the frontend wrapping fix ships with this deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)