### PR TITLE
docs: document local dev workflows and fix compose for local run

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,32 @@ QueryPal lets you query, explore, and manage **Azure Cosmos DB (MongoDB API)** u
 
 ## Quick Start
 
+First, fill in your environment:
+
 ```bash
 cp backend/.env.example backend/.env
-# Fill in backend/.env — see docs/DEVELOPMENT.md for all variables
+# Fill in backend/.env — Azure app creds, ARM_SCOPE, GEMINI_API_KEY are required.
+# DB_* are optional; leave blank to run without Postgres-backed features.
+```
+
+For the frontend, create `frontend/.env` with your local redirect URI (must be
+registered as a SPA redirect URI on the Azure app registration):
+
+```bash
+echo 'VITE_AZURE_REDIRECT_URI=http://localhost:5173/' > frontend/.env
+```
+
+Then pick one of the two workflows below.
+
+For dev without Azure, set `USE_MSAL_AUTH = false` in `frontend/app.config.ts` to use mock data (no backend or Azure needed).
+
+### Option A — Docker Compose (production-parity)
+
+Builds the deployable images (nginx-served frontend + uvicorn backend). Use this
+to verify what actually ships to Cloud Run. **There is no hot-reload — every code
+change requires `--build`.**
+
+```bash
 docker-compose up --build
 ```
 
@@ -66,7 +89,45 @@ docker-compose up --build
 - Backend API: http://localhost:8000
 - API docs: http://localhost:8000/docs
 
-For dev without Azure, set `USE_MSAL_AUTH = false` in `frontend/app.config.ts` to use mock data.
+The frontend's `VITE_*` values are baked in at build time via `build.args` in
+`docker-compose.yml`, not read from `frontend/.env`.
+
+### Option B — Hot-reload split workflow (day-to-day dev)
+
+Two terminals, each hot-reloading on save. This is the recommended loop for
+active development.
+
+```bash
+# Terminal 1 — backend (reads backend/.env)
+cd backend
+uvicorn main:app --reload --env-file .env
+
+# Terminal 2 — frontend (reads frontend/.env)
+cd frontend
+npm install
+npm run dev
+```
+
+- Frontend: http://localhost:5173
+- Backend API: http://localhost:8000
+
+### Connecting to Postgres (Cloud SQL)
+
+Postgres-backed features (saved queries, audit trails, QueryArgus persistence,
+admin role management) need a connection to the Cloud SQL instance. Run the
+Cloud SQL Auth Proxy in a separate terminal:
+
+```bash
+cloud-sql-proxy \
+  --address 0.0.0.0 \
+  --credentials-file=/path/to/proxy-key.json \
+  <project>:<region>:<instance>
+```
+
+Then set the DB host in `backend/.env`:
+
+- **Hot-reload (Option B):** `DB_HOST=127.0.0.1` — the backend runs on your host, same as the proxy.
+- **Docker Compose (Option A):** `DB_HOST=host.docker.internal` — inside the container `127.0.0.1` is the container itself, so it must reach the proxy on the host via Docker's host alias. This also requires the proxy to bind `--address 0.0.0.0` (the default `127.0.0.1` won't accept connections from the container).
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,25 @@
+# Copy to backend/.env and fill in. Required values are marked; the rest are
+# optional locally (features degrade gracefully when unset).
+
+# --- Azure Entra ID (required for real auth; USE_MSAL_AUTH=true in app.config.ts) ---
+AZURE_TENANT_ID=
+AZURE_CLIENT_ID=
+AZURE_CLIENT_SECRET=
+ARM_SCOPE=https://management.azure.com/.default
+
+# --- Google Gemini (required for query generation / analysis) ---
+GEMINI_API_KEY=
+
+# --- PostgreSQL metadata store (optional locally; no Postgres service in docker-compose) ---
+# Leave blank to run without saved queries / audit / argus persistence.
+DB_USER=
+DB_PASS=
+DB_NAME=
+DB_HOST=
+DB_PORT=5432
+
+# --- Admin role management (optional; only needed for the Admin users UI) ---
+PG_ADMIN_LOGIN=
+
+# --- Misc (optional) ---
+# ENVIRONMENT=production   # enables strict CORS; leave unset for permissive dev CORS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,17 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        # Baked into the bundle at build time (Vite). Empty ENV in the Dockerfile
+        # would otherwise override frontend/.env and blank the redirect URI.
+        VITE_AZURE_REDIRECT_URI: http://localhost:5173/
+        VITE_API_BASE_URL: http://localhost:8000
     ports:
-      - "5173:80"
+      - "5173:4000"
+    environment:
+      # nginx proxies /api/ to the backend; localhost inside the container is the
+      # frontend itself, so point at the compose service name.
+      - BACKEND_URL=http://backend:8000
     restart: unless-stopped
 
   backend:


### PR DESCRIPTION
## Summary

Getting QueryPal running locally from the README failed at several points. This documents both local workflows and fixes the compose file so a clean `docker-compose up --build` actually works.

## Changes

- **README** — split Quick Start into two workflows:
  - **Option A — Docker Compose** (production-parity, no hot-reload)
  - **Option B — Hot-reload split workflow** (`uvicorn --reload` + `npm run dev`)
  - Added a Cloud SQL Proxy section documenting the `DB_HOST` split: `127.0.0.1` for hot-reload vs `host.docker.internal` (+ proxy `--address 0.0.0.0`) for Docker Compose, since the container's `127.0.0.1` is itself, not the host.
- **docker-compose.yml** — fixes for local run:
  - frontend port `5173:80` → `5173:4000` (nginx listens on 4000)
  - pass `VITE_AZURE_REDIRECT_URI` / `VITE_API_BASE_URL` as `build.args` (empty ENV was blanking the redirect URI at build time)
  - set `BACKEND_URL=http://backend:8000` for the nginx `/api/` proxy
- **backend/.env.example** — new template so the README's `cp backend/.env.example backend/.env` step works.
- Removed legacy/misleading local env files (untracked, not in this diff).

## Test plan

- `docker-compose up --build` → frontend reachable at http://localhost:5173, backend at http://localhost:8000, MSAL login succeeds (redirect URI baked in).
- Hot-reload workflow verified with Cloud SQL Proxy on `127.0.0.1:5432`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)