### PR TITLE
Release: NL2SQL hallucination guards + table display fixes

### DIFF
--- a/backend/services/pg_react_agent_service.py
+++ b/backend/services/pg_react_agent_service.py
@@ -18,6 +18,9 @@ from services.pg_sql_utils import (
     _enrich_schema_context_from_db,
     _normalize_categorical_literals,
     _schema_context_has_columns,
+    _validate_sql_columns,
+    _validate_sql_operators,
+    _validate_sql_references,
 )
 from services.pg_query_service import execute_sql, is_write_sql
 
@@ -55,6 +58,8 @@ Rules:
 5. When joining tables, follow FK relationships listed in the schema; alias tables a, b, c… in join order.
 6. Interpret "with a <column>" as column IS NOT NULL; "without a <column>" as column IS NULL.
 7. Normalize string literal values to lowercase (e.g. status = 'active', not 'Active').
+8. To match a concept (e.g. 'heart failure'), find the column whose sample values (-- values: ...) contain it and use col = 'value'. For text/varchar columns never use @>, ->, ->>, ARRAY[], or LIKE — use plain = equality.
+9. For categorical array columns, prefer 'value' = ANY(col) instead of col @> ARRAY['value'].
 """
 
 EVALUATE_PROMPT = """You are a database QA reviewer for a generated PostgreSQL query.
@@ -91,7 +96,9 @@ class _State(TypedDict, total=False):
 
 def _generate(state: _State):
     schema_context = state["schema_context"]
-    if not _schema_context_has_columns(schema_context):
+    # Always enrich on the first call to add sample values; on retries the
+    # enriched schema (with values hints) is already in state.
+    if state.get("iterations", 0) == 0 or not _schema_context_has_columns(schema_context):
         schema_context = _enrich_schema_context_from_db(
             state.get("conn"), schema_context
         )
@@ -121,6 +128,8 @@ def _generate(state: _State):
         "generated_query": sql,
         "is_write_action": is_write_sql(sql),
         "iterations": state.get("iterations", 0) + 1,
+        # Persist enriched schema so _evaluate can validate table/column refs
+        "schema_context": schema_context,
     }
 
 
@@ -134,6 +143,28 @@ def _execute(state: _State):
 
 
 def _evaluate(state: _State):
+    # Validate table references before calling the LLM — catches hallucinated
+    # table names immediately and injects the correct schema into the critique.
+    schema_violation = _validate_sql_references(
+        state.get("generated_query", ""), state.get("schema_context", "")
+    )
+    if schema_violation:
+        return {"is_valid": False, "evaluation": schema_violation}
+
+    # Validate column references — catches hallucinated column names.
+    col_violation = _validate_sql_columns(
+        state.get("generated_query", ""), state.get("schema_context", "")
+    )
+    if col_violation:
+        return {"is_valid": False, "evaluation": col_violation}
+
+    # Catch JSON/array operators applied to plain text/varchar columns.
+    op_violation = _validate_sql_operators(
+        state.get("generated_query", ""), state.get("schema_context", "")
+    )
+    if op_violation:
+        return {"is_valid": False, "evaluation": op_violation}
+
     raw = state.get("query_result")
     result_str = str(raw)[:2000]
     prompt = EVALUATE_PROMPT.format(

--- a/backend/services/pg_react_agent_service.py
+++ b/backend/services/pg_react_agent_service.py
@@ -98,7 +98,9 @@ def _generate(state: _State):
     schema_context = state["schema_context"]
     # Always enrich on the first call to add sample values; on retries the
     # enriched schema (with values hints) is already in state.
-    if state.get("iterations", 0) == 0 or not _schema_context_has_columns(schema_context):
+    if state.get("iterations", 0) == 0 or not _schema_context_has_columns(
+        schema_context
+    ):
         schema_context = _enrich_schema_context_from_db(
             state.get("conn"), schema_context
         )

--- a/backend/services/pg_react_agent_service.py
+++ b/backend/services/pg_react_agent_service.py
@@ -17,7 +17,6 @@ from services.gemini_service import extract_python_code, thinking_config_for
 from services.pg_sql_utils import (
     _enrich_schema_context_from_db,
     _normalize_categorical_literals,
-    _schema_context_has_columns,
     _validate_sql_columns,
     _validate_sql_operators,
     _validate_sql_references,
@@ -58,7 +57,7 @@ Rules:
 5. When joining tables, follow FK relationships listed in the schema; alias tables a, b, c… in join order.
 6. Interpret "with a <column>" as column IS NOT NULL; "without a <column>" as column IS NULL.
 7. Normalize string literal values to lowercase (e.g. status = 'active', not 'Active').
-8. To match a concept (e.g. 'heart failure'), find the column whose sample values (-- values: ...) contain it and use col = 'value'. For text/varchar columns never use @>, ->, ->>, ARRAY[], or LIKE — use plain = equality.
+8. To match a concept (e.g. 'heart failure'), find the column whose sample values (-- values: ...) contain it and use col = 'value'. For text/varchar columns never use @>, ->, ->> or ARRAY[] — they are not JSON or arrays. Prefer = over LIKE when the value matches a listed sample value; keep LIKE for genuine substring search.
 9. For categorical array columns, prefer 'value' = ANY(col) instead of col @> ARRAY['value'].
 """
 
@@ -96,11 +95,10 @@ class _State(TypedDict, total=False):
 
 def _generate(state: _State):
     schema_context = state["schema_context"]
-    # Always enrich on the first call to add sample values; on retries the
-    # enriched schema (with values hints) is already in state.
-    if state.get("iterations", 0) == 0 or not _schema_context_has_columns(
-        schema_context
-    ):
+    # Enrich once, on the first call, to add sample values. Retries reuse the
+    # result via state — including the raw fallback when enrichment failed, so a
+    # broken connection can't re-trigger the expensive probe every iteration.
+    if state.get("iterations", 0) == 0:
         schema_context = _enrich_schema_context_from_db(
             state.get("conn"), schema_context
         )
@@ -145,29 +143,26 @@ def _execute(state: _State):
 
 
 def _evaluate(state: _State):
-    # Validate table references before calling the LLM — catches hallucinated
-    # table names immediately and injects the correct schema into the critique.
-    schema_violation = _validate_sql_references(
-        state.get("generated_query", ""), state.get("schema_context", "")
-    )
-    if schema_violation:
-        return {"is_valid": False, "evaluation": schema_violation}
-
-    # Validate column references — catches hallucinated column names.
-    col_violation = _validate_sql_columns(
-        state.get("generated_query", ""), state.get("schema_context", "")
-    )
-    if col_violation:
-        return {"is_valid": False, "evaluation": col_violation}
-
-    # Catch JSON/array operators applied to plain text/varchar columns.
-    op_violation = _validate_sql_operators(
-        state.get("generated_query", ""), state.get("schema_context", "")
-    )
-    if op_violation:
-        return {"is_valid": False, "evaluation": op_violation}
-
     raw = state.get("query_result")
+
+    # Postgres already rejects hallucinated tables/columns and bad operators when
+    # the query runs, so a successful execution needs no static check — running
+    # one anyway only risks a false positive on valid SQL (CTEs, derived-table
+    # aliases, EXTRACT(... FROM col)). Only check when there is no verdict from
+    # the database: execution errored, or it was skipped for a write/DDL. The
+    # checks add a schema-aware critique the raw driver error doesn't give.
+    if state.get("is_write_action") or (isinstance(raw, dict) and "error" in raw):
+        for check in (
+            _validate_sql_references,
+            _validate_sql_columns,
+            _validate_sql_operators,
+        ):
+            violation = check(
+                state.get("generated_query", ""), state.get("schema_context", "")
+            )
+            if violation:
+                return {"is_valid": False, "evaluation": violation}
+
     result_str = str(raw)[:2000]
     prompt = EVALUATE_PROMPT.format(
         user_input=state["user_input"],

--- a/backend/services/pg_sql_utils.py
+++ b/backend/services/pg_sql_utils.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import difflib
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -35,10 +36,20 @@ _TEXT_SAMPLE_TYPES = frozenset(
 )
 # Maximum distinct values to include as hints; columns with more are skipped
 _MAX_SAMPLE_VALUES = 20
+# Cap on rows scanned per column when sampling distinct values, to bound the
+# cost of probing unindexed text columns on wide/large schemas
+_SAMPLE_SCAN_ROW_CAP = 5000
 
 
-def _enrich_schema_context_from_db(conn, schema_context: str) -> str:
-    """Build detailed schema context using information_schema for listed tables."""
+def _enrich_schema_context_from_db(
+    conn, schema_context: str, failed_flag: list[bool] | None = None
+) -> str:
+    """Build detailed schema context using information_schema for listed tables.
+
+    When enrichment raises and falls back to the raw context, ``failed_flag``
+    (if provided) is appended with True so callers can avoid retrying the
+    (expensive) enrichment on every subsequent iteration.
+    """
     refs = _extract_table_refs(schema_context)
     if not refs:
         return schema_context
@@ -94,6 +105,8 @@ def _enrich_schema_context_from_db(conn, schema_context: str) -> str:
             type(e).__name__,
             e,
         )
+        if failed_flag is not None:
+            failed_flag.append(True)
         return schema_context
 
     enriched = "\n\n".join(blocks) if blocks else schema_context
@@ -108,18 +121,24 @@ def _sample_values_hint(conn, schema: str, table: str, col: str) -> str:
 
     Opens its own cursor per probe. On non-autocommit connections a failed query
     aborts the transaction, so we rollback to keep the enrichment loop running.
+    Distinct-values are sampled from a capped subset of rows (not the whole
+    table) so an unindexed column doesn't force a full scan on every call.
     """
     try:
         with conn.cursor() as cur:
             cur.execute(
-                f'SELECT DISTINCT "{col}" FROM "{schema}"."{table}" '
-                f'WHERE "{col}" IS NOT NULL LIMIT %s',
-                (_MAX_SAMPLE_VALUES + 1,),
+                f'SELECT DISTINCT "{col}" FROM ('
+                f'  SELECT "{col}" FROM "{schema}"."{table}" '
+                f'  WHERE "{col}" IS NOT NULL LIMIT %s'
+                f") sample LIMIT %s",
+                (_SAMPLE_SCAN_ROW_CAP, _MAX_SAMPLE_VALUES + 1),
             )
             vals = [str(r[0]) for r in cur.fetchall()]
         if len(vals) > _MAX_SAMPLE_VALUES:
             return ""
-        vals_str = ", ".join(f"'{v}'" for v in sorted(vals))
+        vals_str = ", ".join(
+            f"'{v.replace(chr(39), chr(39) * 2)}'" for v in sorted(vals)
+        )
         return f" -- values: {vals_str}"
     except Exception:
         if not getattr(conn, "autocommit", True):
@@ -244,7 +263,8 @@ def _extract_values_from_schema_line(line: str) -> set[str]:
     m = re.search(r"--\s*(?:values|enum-values)\s*:\s*(.+)$", line, re.IGNORECASE)
     if not m:
         return set()
-    raw_values = re.findall(r"'([^']*)'", m.group(1))
+    raw_values = re.findall(r"'((?:[^']|'')*)'", m.group(1))
+    raw_values = [v.replace("''", "'") for v in raw_values]
     return {v.strip().lower() for v in raw_values if v.strip()}
 
 
@@ -253,7 +273,8 @@ def _extract_raw_values_from_schema_line(line: str) -> list[str]:
     m = re.search(r"--\s*(?:values|enum-values)\s*:\s*(.+)$", line, re.IGNORECASE)
     if not m:
         return []
-    return [v.strip() for v in re.findall(r"'([^']*)'", m.group(1)) if v.strip()]
+    raw_values = re.findall(r"'((?:[^']|'')*)'", m.group(1))
+    return [v.replace("''", "'").strip() for v in raw_values if v.strip()]
 
 
 def _tokenize_ident(text: str) -> set[str]:
@@ -391,7 +412,7 @@ def _validate_sql_references(sql: str, schema_context: str) -> str | None:
 
     sql_no_comments = re.sub(r"--[^\n]*", "", sql)
     table_matches = re.findall(
-        r"(?:FROM|JOIN)\s+([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)?)",
+        r"(?:FROM|JOIN)\s+(?:LATERAL\s+)?([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)?)",
         sql_no_comments,
         re.IGNORECASE,
     )

--- a/backend/services/pg_sql_utils.py
+++ b/backend/services/pg_sql_utils.py
@@ -2,7 +2,6 @@
 
 import logging
 import re
-import difflib
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -25,11 +24,6 @@ def _extract_table_refs(schema_context: str) -> list[tuple[str, str]]:
     return refs
 
 
-def _schema_context_has_columns(schema_context: str) -> bool:
-    parsed = _parse_schema_context(schema_context)
-    return any(meta.get("columns") for meta in parsed.values())
-
-
 # data_type values from information_schema that warrant sampling distinct values
 _TEXT_SAMPLE_TYPES = frozenset(
     {"character varying", "text", "character", "user-defined", "name", "citext"}
@@ -41,15 +35,8 @@ _MAX_SAMPLE_VALUES = 20
 _SAMPLE_SCAN_ROW_CAP = 5000
 
 
-def _enrich_schema_context_from_db(
-    conn, schema_context: str, failed_flag: list[bool] | None = None
-) -> str:
-    """Build detailed schema context using information_schema for listed tables.
-
-    When enrichment raises and falls back to the raw context, ``failed_flag``
-    (if provided) is appended with True so callers can avoid retrying the
-    (expensive) enrichment on every subsequent iteration.
-    """
+def _enrich_schema_context_from_db(conn, schema_context: str) -> str:
+    """Build detailed schema context using information_schema for listed tables."""
     refs = _extract_table_refs(schema_context)
     if not refs:
         return schema_context
@@ -105,8 +92,6 @@ def _enrich_schema_context_from_db(
             type(e).__name__,
             e,
         )
-        if failed_flag is not None:
-            failed_flag.append(True)
         return schema_context
 
     enriched = "\n\n".join(blocks) if blocks else schema_context
@@ -397,6 +382,25 @@ def _suggest_columns_for_unknown_refs(
     return suggestions
 
 
+# SQL constructs that put a bare keyword inside a function call, e.g.
+# EXTRACT(YEAR FROM col) — the FROM there is not a table reference.
+_KEYWORD_ARG_CALLS = re.compile(
+    r"\b(?:EXTRACT|TRIM|SUBSTRING|POSITION|OVERLAY)\s*\((?:[^()]|\([^()]*\))*\)",
+    re.IGNORECASE,
+)
+# CTEs, derived tables and LATERAL introduce relation scopes that are not in the
+# schema and whose projected columns are unknowable to a regex.
+_OPAQUE_SCOPE = re.compile(r"\bWITH\b|(?:FROM|JOIN)\s*(?:LATERAL\s*)?\(", re.IGNORECASE)
+
+
+def _strip_sql_noise(sql: str) -> str:
+    """Blank comments, string literals and keyword-argument function calls so
+    identifier regexes don't match inside them."""
+    sql = re.sub(r"--[^\n]*", "", sql)
+    sql = re.sub(r"'(?:[^']|'')*'", "''", sql)
+    return _KEYWORD_ARG_CALLS.sub(" ", sql)
+
+
 def _validate_sql_references(sql: str, schema_context: str) -> str | None:
     """Check that every FROM/JOIN table in the SQL exists in schema_context.
 
@@ -407,13 +411,19 @@ def _validate_sql_references(sql: str, schema_context: str) -> str | None:
     if not refs:
         return None
 
+    sql_clean = _strip_sql_noise(sql)
+    # A CTE or derived table is a legal relation that is not in the schema.
+    # Rather than guess at its name and shape, abstain — Postgres still rejects
+    # genuinely bad references when the query runs.
+    if _OPAQUE_SCOPE.search(sql_clean):
+        return None
+
     known_qualified = {f"{s}.{t}".lower() for s, t in refs}
     known_unqualified = {t.lower() for _, t in refs}
 
-    sql_no_comments = re.sub(r"--[^\n]*", "", sql)
     table_matches = re.findall(
-        r"(?:FROM|JOIN)\s+(?:LATERAL\s+)?([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)?)",
-        sql_no_comments,
+        r"(?:FROM|JOIN)\s+([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)?)",
+        sql_clean,
         re.IGNORECASE,
     )
 
@@ -448,6 +458,12 @@ def _validate_sql_columns(sql: str, schema_context: str) -> str | None:
     if not tables:
         return None
 
+    sql_clean = _strip_sql_noise(sql)
+    # A CTE or derived table projects column names of its own choosing, which no
+    # schema lists. Abstain rather than report them as hallucinated.
+    if _OPAQUE_SCOPE.search(sql_clean):
+        return None
+
     all_columns: set[str] = set()
     all_table_names: set[str] = set()
     value_hints: dict[str, set[str]] = {}
@@ -460,10 +476,12 @@ def _validate_sql_columns(sql: str, schema_context: str) -> str | None:
     if not all_columns:
         return None
 
+    # Suggestions need the original literals, so they read the comment-stripped
+    # SQL rather than the fully blanked copy.
     sql_no_comments = re.sub(r"--[^\n]*", "", sql)
     dotted_refs = re.findall(
         r"\b[A-Za-z_][\w]*\.([A-Za-z_][\w]*)\b",
-        sql_no_comments,
+        sql_clean,
     )
     unknown = [
         col

--- a/backend/services/pg_sql_utils.py
+++ b/backend/services/pg_sql_utils.py
@@ -29,6 +29,14 @@ def _schema_context_has_columns(schema_context: str) -> bool:
     return any(meta.get("columns") for meta in parsed.values())
 
 
+# data_type values from information_schema that warrant sampling distinct values
+_TEXT_SAMPLE_TYPES = frozenset(
+    {"character varying", "text", "character", "user-defined", "name", "citext"}
+)
+# Maximum distinct values to include as hints; columns with more are skipped
+_MAX_SAMPLE_VALUES = 20
+
+
 def _enrich_schema_context_from_db(conn, schema_context: str) -> str:
     """Build detailed schema context using information_schema for listed tables."""
     refs = _extract_table_refs(schema_context)
@@ -75,13 +83,45 @@ def _enrich_schema_context_from_db(conn, schema_context: str) -> str:
                     if nullable == "NO":
                         tags.append("NOT NULL")
                     tag_str = f" [{', '.join(tags)}]" if tags else ""
-                    lines.append(f"  - {col} {dtype}{tag_str}")
+                    col_line = f"  - {col} {dtype}{tag_str}"
+                    if dtype.lower() in _TEXT_SAMPLE_TYPES:
+                        col_line += _sample_values_hint(conn, schema, table, col)
+                    lines.append(col_line)
                 blocks.append("\n".join(lines))
     except Exception as e:
-        logger.warning("schema enrichment failed: %s", e)
+        logger.warning("schema enrichment failed (%s), falling back to raw context: %s", type(e).__name__, e)
         return schema_context
 
-    return "\n\n".join(blocks) if blocks else schema_context
+    enriched = "\n\n".join(blocks) if blocks else schema_context
+    logger.info("schema enrichment complete: %d table(s), %d chars", len(blocks), len(enriched))
+    return enriched
+
+
+def _sample_values_hint(conn, schema: str, table: str, col: str) -> str:
+    """Return ' -- values: ...' hint when the column has low cardinality, else ''.
+
+    Opens its own cursor per probe. On non-autocommit connections a failed query
+    aborts the transaction, so we rollback to keep the enrichment loop running.
+    """
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                f'SELECT DISTINCT "{col}" FROM "{schema}"."{table}" '
+                f'WHERE "{col}" IS NOT NULL LIMIT %s',
+                (_MAX_SAMPLE_VALUES + 1,),
+            )
+            vals = [str(r[0]) for r in cur.fetchall()]
+        if len(vals) > _MAX_SAMPLE_VALUES:
+            return ""
+        vals_str = ", ".join(f"'{v}'" for v in sorted(vals))
+        return f" -- values: {vals_str}"
+    except Exception:
+        if not getattr(conn, "autocommit", True):
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+        return ""
 
 
 def _parse_schema_context(schema_context: str) -> dict[str, dict[str, Any]]:
@@ -126,6 +166,8 @@ def _parse_schema_context(schema_context: str) -> dict[str, dict[str, Any]]:
                 "column_types": col_types,
                 "pk": pk_cols,
                 "fks": [],
+                "value_hints": {},
+                "value_hints_raw": {},
             }
             current = full
             continue
@@ -144,13 +186,18 @@ def _parse_schema_context(schema_context: str) -> dict[str, dict[str, Any]]:
                     "column_types": {},
                     "pk": [],
                     "fks": [],
+                    "value_hints": {},
+                    "value_hints_raw": {},
                 },
             )
             current = full
             continue
 
         if current and line.startswith("-"):
-            m_col = re.match(r"^-\s*([A-Za-z_][\w]*)(?:\s+([^\[]+))?", line)
+            m_col = re.match(
+                r"^-\s*([A-Za-z_][\w]*)(?:\s+(.+?))?(?:\s+\[[^\]]*\])?(?:\s*--.*)?$",
+                line,
+            )
             if not m_col:
                 continue
             col = m_col.group(1)
@@ -161,6 +208,12 @@ def _parse_schema_context(schema_context: str) -> dict[str, dict[str, Any]]:
             dtype = (m_col.group(2) or "").strip().lower()
             if dtype:
                 tables[current]["column_types"][low] = dtype
+            hinted_values = _extract_values_from_schema_line(line)
+            if hinted_values:
+                tables[current]["value_hints"][low] = hinted_values
+            raw_hinted_values = _extract_raw_values_from_schema_line(line)
+            if raw_hinted_values:
+                tables[current]["value_hints_raw"][low] = raw_hinted_values
             if "[" in line and "PK" in line and low not in tables[current]["pk"]:
                 tables[current]["pk"].append(low)
             m_fk = re.search(r"FK\s*->\s*([A-Za-z_][\w]*)\.([A-Za-z_][\w]*)", line)
@@ -177,6 +230,317 @@ def _parse_schema_context(schema_context: str) -> dict[str, dict[str, Any]]:
     return tables
 
 
+def _extract_values_from_schema_line(line: str) -> set[str]:
+    """Extract low-cardinality value hints from schema lines.
+
+    Supports both "-- values: ..." and "-- enum-values: ..." decorations.
+    """
+    m = re.search(r"--\s*(?:values|enum-values)\s*:\s*(.+)$", line, re.IGNORECASE)
+    if not m:
+        return set()
+    raw_values = re.findall(r"'([^']*)'", m.group(1))
+    return {v.strip().lower() for v in raw_values if v.strip()}
+
+
+def _extract_raw_values_from_schema_line(line: str) -> list[str]:
+    """Extract hinted values preserving original case and separators."""
+    m = re.search(r"--\s*(?:values|enum-values)\s*:\s*(.+)$", line, re.IGNORECASE)
+    if not m:
+        return []
+    return [v.strip() for v in re.findall(r"'([^']*)'", m.group(1)) if v.strip()]
+
+
+def _tokenize_ident(text: str) -> set[str]:
+    parts = re.split(r"[^a-z0-9]+", text.lower())
+    return {p for p in parts if p}
+
+
+def _snake_literal(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+def _value_key(value: str) -> str:
+    """Canonical key to compare value variants (space/hyphen/underscore/case)."""
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+def _canonicalize_literal_for_column(
+    value: str,
+    col: str,
+    col_types: dict[str, str],
+    value_hints_raw: dict[str, list[str]],
+) -> str:
+    """Pick literal format from hinted values first, then fallback by column type."""
+    clean = value.strip()
+    low_col = col.lower()
+    hinted = value_hints_raw.get(low_col, [])
+
+    if hinted:
+        for candidate in hinted:
+            if candidate.lower() == clean.lower():
+                return candidate
+        key = _value_key(clean)
+        for candidate in hinted:
+            if _value_key(candidate) == key:
+                return candidate
+
+    normalized = clean.lower()
+    col_type = (col_types.get(low_col) or "").lower()
+    if "enum" in col_type or "user-defined" in col_type:
+        return _snake_literal(normalized)
+    return normalized
+
+
+def _choose_best_column_candidate(
+    unknown: str,
+    literal: str,
+    all_columns: set[str],
+    value_hints: dict[str, set[str]],
+) -> str | None:
+    """Pick the most likely real column for an unknown categorical bucket name."""
+    unknown_tokens = _tokenize_ident(unknown)
+    literal_tokens = _tokenize_ident(literal)
+    literal_variants = {
+        literal.strip().lower(),
+        _snake_literal(literal),
+    }
+
+    best_col = None
+    best_score = -1
+    for candidate in sorted(all_columns):
+        if candidate.lower() == unknown.lower():
+            continue
+        score = len(unknown_tokens.intersection(_tokenize_ident(candidate)))
+        score += len(literal_tokens.intersection(_tokenize_ident(candidate)))
+
+        hinted = value_hints.get(candidate.lower(), set())
+        if hinted and any(v in hinted for v in literal_variants):
+            score += 5
+
+        if score > best_score:
+            best_score = score
+            best_col = candidate
+
+    if best_col and best_score > 0:
+        return best_col
+    return None
+
+
+def _suggest_columns_for_unknown_refs(
+    unknown_columns: list[str],
+    all_columns: set[str],
+    value_hints: dict[str, set[str]],
+    sql: str,
+) -> list[str]:
+    """Suggest likely intended columns using lexical and value-hint matching."""
+    suggestions: list[str] = []
+    literals = re.findall(r"'([^']+)'", sql)
+    literal_tokens = set()
+    literal_variants = set()
+    for lit in literals:
+        literal_tokens.update(_tokenize_ident(lit))
+        literal_variants.add(lit.strip().lower())
+        literal_variants.add(_snake_literal(lit))
+
+    combined_literal = " ".join(literals) if literals else ""
+    for unknown in unknown_columns:
+        best_col = _choose_best_column_candidate(
+            unknown, combined_literal, all_columns, value_hints
+        )
+
+        if best_col:
+            hinted = value_hints.get(best_col.lower(), set())
+            if hinted:
+                suggestions.append(
+                    f"Unknown column {unknown!r} likely maps to {best_col!r} "
+                    f"(hint values: {sorted(hinted)})."
+                )
+            else:
+                suggestions.append(
+                    f"Unknown column {unknown!r} likely maps to {best_col!r}."
+                )
+
+    for lit in literals:
+        snake = _snake_literal(lit)
+        if snake and snake != lit.strip().lower():
+            suggestions.append(
+                f"If this is an enum value, prefer snake_case literal {snake!r} over {lit!r}."
+            )
+
+    return suggestions
+
+
+def _validate_sql_references(sql: str, schema_context: str) -> str | None:
+    """Check that every FROM/JOIN table in the SQL exists in schema_context.
+
+    Returns a correction message string when unknown tables are found, or None
+    when all references are valid (or when the schema has no info to check).
+    """
+    refs = _extract_table_refs(schema_context)
+    if not refs:
+        return None
+
+    known_qualified = {f"{s}.{t}".lower() for s, t in refs}
+    known_unqualified = {t.lower() for _, t in refs}
+
+    sql_no_comments = re.sub(r"--[^\n]*", "", sql)
+    table_matches = re.findall(
+        r"(?:FROM|JOIN)\s+([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)?)",
+        sql_no_comments,
+        re.IGNORECASE,
+    )
+
+    unknown = []
+    for ref in table_matches:
+        low = ref.lower()
+        if "." in low:
+            if low not in known_qualified:
+                unknown.append(ref)
+        else:
+            if low not in known_unqualified:
+                unknown.append(ref)
+
+    if not unknown:
+        return None
+
+    available = sorted(f"{s}.{t}" for s, t in refs)
+    return (
+        f"The SQL references table(s) not present in the schema: {unknown}. "
+        f"Available tables are: {available}. "
+        "Rewrite the query using only these exact table and schema names."
+    )
+
+
+def _validate_sql_columns(sql: str, schema_context: str) -> str | None:
+    """Check that alias.column references in the SQL exist in the schema.
+
+    Returns a correction message when unknown columns are found, or None when
+    all references are valid (or there is not enough schema info to check).
+    """
+    tables = _parse_schema_context(schema_context)
+    if not tables:
+        return None
+
+    all_columns: set[str] = set()
+    all_table_names: set[str] = set()
+    value_hints: dict[str, set[str]] = {}
+    for meta in tables.values():
+        all_columns.update(meta.get("columns", set()))
+        all_table_names.add(meta["table"].lower())
+        for col, hinted in meta.get("value_hints", {}).items():
+            value_hints.setdefault(col.lower(), set()).update(hinted)
+
+    if not all_columns:
+        return None
+
+    sql_no_comments = re.sub(r"--[^\n]*", "", sql)
+    dotted_refs = re.findall(
+        r"\b[A-Za-z_][\w]*\.([A-Za-z_][\w]*)\b",
+        sql_no_comments,
+    )
+    unknown = [
+        col
+        for col in dotted_refs
+        if col.lower() not in all_columns and col.lower() not in all_table_names
+    ]
+    if not unknown:
+        return None
+
+    unknown_unique = sorted(set(unknown), key=str.lower)
+    suggestions = _suggest_columns_for_unknown_refs(
+        unknown_unique, all_columns, value_hints, sql_no_comments
+    )
+    suggestion_text = (
+        " " + " ".join(suggestions)
+        if suggestions
+        else ""
+    )
+
+    return (
+        f"The SQL references column(s) not present in any schema-listed table: {unknown_unique}. "
+        f"Available columns are: {sorted(all_columns)}. "
+        "Rewrite the query using only these exact column names, and avoid inventing "
+        "JSON bucket columns for categorical fields; use real columns with = comparisons."
+        f"{suggestion_text}"
+    )
+
+
+def _validate_sql_operators(sql: str, schema_context: str) -> str | None:
+    """Catch JSON/array operators used on plain text columns.
+
+    Returns a correction message if @>, ->, or ->> is applied to a
+    text/varchar column (where = should be used instead), or None when valid.
+    """
+    tables = _parse_schema_context(schema_context)
+    if not tables:
+        return None
+
+    plain_text_cols: dict[str, str] = {}
+    for meta in tables.values():
+        col_types = meta.get("column_types", {})
+        for col in meta.get("columns", set()):
+            dtype = col_types.get(col, "")
+            d = dtype.lower()
+            is_text = any(
+                t in d
+                for t in ("char", "text", "citext", "enum", "name", "user-defined")
+            )
+            is_json_or_array = any(t in d for t in ("json", "[]", "array"))
+            if is_text and not is_json_or_array:
+                plain_text_cols[col.lower()] = dtype
+
+    if not plain_text_cols:
+        return None
+
+    sql_no_comments = re.sub(r"--[^\n]*", "", sql)
+    mismatches = re.findall(
+        r"\b[A-Za-z_][\w]*\.([A-Za-z_][\w]*)\s*(@>|->|->>)",
+        sql_no_comments,
+        re.IGNORECASE,
+    )
+    json_op_violations = [
+        f"{col!r} (type: {plain_text_cols[col.lower()]!r}) with operator {op!r}"
+        for col, op in mismatches
+        if col.lower() in plain_text_cols
+    ]
+
+    any_all_mismatches = re.findall(
+        r"'([^']+)'\s*=\s*(ANY|ALL)\s*\(\s*(?:[A-Za-z_][\w]*\.)?([A-Za-z_][\w]*)\s*\)",
+        sql_no_comments,
+        re.IGNORECASE,
+    )
+    any_all_violations = []
+    for lit, op, col in any_all_mismatches:
+        low = col.lower()
+        if low not in plain_text_cols:
+            continue
+        col_type = plain_text_cols[low].lower()
+        normalized_lit = lit.strip().lower()
+        if "enum" in col_type or "user-defined" in col_type:
+            normalized_lit = _snake_literal(normalized_lit)
+        any_all_violations.append(
+            f"{col!r} (type: {plain_text_cols[low]!r}) with {op.upper()} expects an array; "
+            f"use {col} = '{normalized_lit}'"
+        )
+
+    if not json_op_violations and not any_all_violations:
+        return None
+
+    parts: list[str] = []
+    if json_op_violations:
+        parts.append(
+            "Operator mismatch — plain text column(s) used with JSON/array operator: "
+            f"{json_op_violations}. Use = for equality on text/varchar columns, "
+            "e.g. WHERE col = 'value'."
+        )
+    if any_all_violations:
+        parts.append(
+            "ANY/ALL mismatch — non-array categorical column(s) used with ANY/ALL: "
+            f"{any_all_violations}. Use = for scalar columns; reserve ANY/ALL for array columns."
+        )
+    return " ".join(parts)
+
+
 def _type_is_string_like(dtype: str | None) -> bool:
     if not dtype:
         return True
@@ -191,6 +555,7 @@ def _type_is_string_like(dtype: str | None) -> bool:
             "citext",
             "xml",
             "enum",
+            "user-defined",
         )
     )
 
@@ -204,14 +569,40 @@ def _normalize_categorical_literals(sql: str, schema_context: str) -> str:
     if not tables:
         return sql
 
+    all_columns: set[str] = set()
+    value_hints: dict[str, set[str]] = {}
+    value_hints_raw: dict[str, list[str]] = {}
+    col_types: dict[str, str] = {}
+    for meta in tables.values():
+        for col in meta.get("column_order", []):
+            low = col.lower()
+            all_columns.add(low)
+            if low not in col_types:
+                col_types[low] = (meta.get("column_types", {}).get(low) or "").lower()
+            hinted = meta.get("value_hints", {}).get(low, set())
+            if hinted:
+                value_hints.setdefault(low, set()).update(hinted)
+            hinted_raw = meta.get("value_hints_raw", {}).get(low, [])
+            if hinted_raw and low not in value_hints_raw:
+                value_hints_raw[low] = hinted_raw
+
     string_like_cols: set[str] = set()
     for meta in tables.values():
-        col_types = meta.get("column_types", {})
+        meta_col_types = meta.get("column_types", {})
         for col in meta.get("column_order", []):
-            dtype = (col_types.get(col) or "").lower()
+            dtype = (meta_col_types.get(col) or "").lower()
             if any(
                 token in dtype
-                for token in ("char", "text", "json", "uuid", "citext", "xml", "enum")
+                for token in (
+                    "char",
+                    "text",
+                    "json",
+                    "uuid",
+                    "citext",
+                    "xml",
+                    "enum",
+                    "user-defined",
+                )
             ):
                 string_like_cols.add(col.lower())
 
@@ -229,6 +620,76 @@ def _normalize_categorical_literals(sql: str, schema_context: str) -> str:
             return match.group(0)
         if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_\- ]*", value.strip()):
             return match.group(0)
-        return f"{prefix}{value.strip().lower()}{suffix}"
+        normalized_value = _canonicalize_literal_for_column(
+            value, col, col_types, value_hints_raw
+        )
+        return f"{prefix}{normalized_value}{suffix}"
 
-    return pattern.sub(_repl, sql)
+    normalized = pattern.sub(_repl, sql)
+
+    pattern_any_all = re.compile(
+        r"(')([^']+)('\s*=\s*(?:ANY|ALL)\s*\(\s*(?:[A-Za-z_][\w]*\.)?([A-Za-z_][\w]*)\s*\))",
+        flags=re.IGNORECASE,
+    )
+
+    def _repl_any_all(match: re.Match[str]) -> str:
+        quote1, value, suffix, col = match.groups()
+        if col.lower() not in string_like_cols:
+            return match.group(0)
+        if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_\- ]*", value.strip()):
+            return match.group(0)
+        normalized_value = _canonicalize_literal_for_column(
+            value, col, col_types, value_hints_raw
+        )
+        return f"{quote1}{normalized_value}{suffix}"
+
+    normalized = pattern_any_all.sub(_repl_any_all, normalized)
+
+    pattern_array_contains = re.compile(
+        r"\b((?:[A-Za-z_][\w]*\.)?)([A-Za-z_][\w]*)\s*@>\s*ARRAY\s*\[\s*'([^']+)'\s*\]",
+        flags=re.IGNORECASE,
+    )
+
+    def _repl_array_contains(match: re.Match[str]) -> str:
+        prefix, col, literal = match.groups()
+        low = col.lower()
+        if low not in all_columns:
+            return match.group(0)
+
+        col_type = col_types.get(low, "")
+        if not any(t in col_type for t in ("[]", "array")):
+            return match.group(0)
+
+        normalized_value = _canonicalize_literal_for_column(
+            literal, col, col_types, value_hints_raw
+        )
+
+        return f"'{normalized_value}' = ANY({prefix}{col})"
+
+    normalized = pattern_array_contains.sub(_repl_array_contains, normalized)
+
+    pattern_bucket = re.compile(
+        r"\b((?:[A-Za-z_][\w]*\.)?)([A-Za-z_][\w]*)\s*->>\s*'([^']+)'\s+IS\s+NOT\s+NULL\b",
+        flags=re.IGNORECASE,
+    )
+
+    def _repl_bucket(match: re.Match[str]) -> str:
+        prefix, col, literal = match.groups()
+        low = col.lower()
+        target_col = low
+        if low in all_columns:
+            dtype = col_types.get(low, "")
+            if any(t in dtype for t in ("json", "[]", "array")):
+                return match.group(0)
+        else:
+            guessed = _choose_best_column_candidate(col, literal, all_columns, value_hints)
+            if not guessed:
+                return match.group(0)
+            target_col = guessed
+
+        normalized_value = _canonicalize_literal_for_column(
+            literal, target_col, col_types, value_hints_raw
+        )
+        return f"{prefix}{target_col} = '{normalized_value}'"
+
+    return pattern_bucket.sub(_repl_bucket, normalized)

--- a/backend/services/pg_sql_utils.py
+++ b/backend/services/pg_sql_utils.py
@@ -89,11 +89,17 @@ def _enrich_schema_context_from_db(conn, schema_context: str) -> str:
                     lines.append(col_line)
                 blocks.append("\n".join(lines))
     except Exception as e:
-        logger.warning("schema enrichment failed (%s), falling back to raw context: %s", type(e).__name__, e)
+        logger.warning(
+            "schema enrichment failed (%s), falling back to raw context: %s",
+            type(e).__name__,
+            e,
+        )
         return schema_context
 
     enriched = "\n\n".join(blocks) if blocks else schema_context
-    logger.info("schema enrichment complete: %d table(s), %d chars", len(blocks), len(enriched))
+    logger.info(
+        "schema enrichment complete: %d table(s), %d chars", len(blocks), len(enriched)
+    )
     return enriched
 
 
@@ -450,11 +456,7 @@ def _validate_sql_columns(sql: str, schema_context: str) -> str | None:
     suggestions = _suggest_columns_for_unknown_refs(
         unknown_unique, all_columns, value_hints, sql_no_comments
     )
-    suggestion_text = (
-        " " + " ".join(suggestions)
-        if suggestions
-        else ""
-    )
+    suggestion_text = " " + " ".join(suggestions) if suggestions else ""
 
     return (
         f"The SQL references column(s) not present in any schema-listed table: {unknown_unique}. "
@@ -682,7 +684,9 @@ def _normalize_categorical_literals(sql: str, schema_context: str) -> str:
             if any(t in dtype for t in ("json", "[]", "array")):
                 return match.group(0)
         else:
-            guessed = _choose_best_column_candidate(col, literal, all_columns, value_hints)
+            guessed = _choose_best_column_candidate(
+                col, literal, all_columns, value_hints
+            )
             if not guessed:
                 return match.group(0)
             target_col = guessed

--- a/backend/tests/test_pg_react_agent_service.py
+++ b/backend/tests/test_pg_react_agent_service.py
@@ -230,3 +230,59 @@ def test_invalid_query_retries_with_llm_on_second_iteration():
     retry_prompt = gen_content.call_args_list[2].kwargs["contents"]
     assert "Use accounts only; remove orders join." in retry_prompt
     assert "JOIN public.orders" in retry_prompt
+
+
+def test_hallucinated_table_names_are_caught_and_corrected():
+    """_evaluate short-circuits with a correction when the SQL references tables
+    that are not listed in the schema context."""
+    conn = MagicMock()
+    schema_context = (
+        "public.patients\n"
+        "  - patient_id integer [PK, NOT NULL]\n"
+        "  - name text\n\n"
+        "public.diagnoses\n"
+        "  - diagnosis_id integer [PK, NOT NULL]\n"
+        "  - patient_id integer [FK -> patients.patient_id]\n"
+        "  - diagnosis_name text"
+    )
+    hallucinated_sql = (
+        "SELECT a.* FROM patient AS a "
+        "JOIN patient_pathology AS b ON a.patient_id = b.patient_id "
+        "JOIN pathology AS c ON b.pathology_id = c.pathology_id "
+        "WHERE c.pathology_name = 'heart failure' LIMIT 50"
+    )
+    corrected_sql = (
+        "SELECT a.* FROM public.patients AS a "
+        "JOIN public.diagnoses AS b ON a.patient_id = b.patient_id "
+        "WHERE b.diagnosis_name = 'heart failure' LIMIT 50"
+    )
+
+    with (
+        patch.object(
+            agent.client.models,
+            "generate_content",
+            side_effect=[
+                _gen_response(hallucinated_sql),
+                _gen_response(corrected_sql),
+                _eval_ok_response(),
+            ],
+        ) as gen_content,
+        patch.object(
+            agent, "execute_sql", return_value={"columns": [], "rows": []}
+        ) as exec_sql,
+    ):
+        out = agent.run_sql_generator(
+            user_input="Show me all patients with a heart failure pathology.",
+            database="appdb",
+            schema_context=schema_context,
+            conn=conn,
+            max_iterations=3,
+        )
+
+    assert out["is_valid"] is True
+    assert out["generated_code"] == corrected_sql
+    retry_prompt = gen_content.call_args_list[1].kwargs["contents"]
+    assert "public.patients" in retry_prompt
+    assert "public.diagnoses" in retry_prompt
+    assert "patient_pathology" in retry_prompt
+

--- a/backend/tests/test_pg_react_agent_service.py
+++ b/backend/tests/test_pg_react_agent_service.py
@@ -118,17 +118,19 @@ def test_llm_fallback_normalizes_string_like_column_literals():
     conn = MagicMock()
     gen = _gen_response("SELECT * FROM public.orders WHERE order_status = 'Paid'")
     eval_resp = _eval_ok_response()
+    schema = "public.orders\n  - order_status text"
 
     with (
         patch.object(
             agent.client.models, "generate_content", side_effect=[gen, eval_resp]
         ),
         patch.object(agent, "execute_sql", return_value={"columns": [], "rows": []}),
+        patch.object(agent, "_enrich_schema_context_from_db", return_value=schema),
     ):
         out = agent.run_sql_generator(
             user_input="show all orders",
             database="appdb",
-            schema_context="public.orders\n  - order_status text",
+            schema_context=schema,
             conn=conn,
             max_iterations=1,
         )
@@ -143,17 +145,19 @@ def test_llm_fallback_does_not_normalize_non_string_columns():
     conn = MagicMock()
     gen = _gen_response("SELECT * FROM public.orders WHERE total_amount = 'Paid'")
     eval_resp = _eval_ok_response()
+    schema = "public.orders\n  - total_amount numeric"
 
     with (
         patch.object(
             agent.client.models, "generate_content", side_effect=[gen, eval_resp]
         ),
         patch.object(agent, "execute_sql", return_value={"columns": [], "rows": []}),
+        patch.object(agent, "_enrich_schema_context_from_db", return_value=schema),
     ):
         out = agent.run_sql_generator(
             user_input="show all orders",
             database="appdb",
-            schema_context="public.orders\n  - total_amount numeric",
+            schema_context=schema,
             conn=conn,
             max_iterations=1,
         )

--- a/backend/tests/test_pg_react_agent_service.py
+++ b/backend/tests/test_pg_react_agent_service.py
@@ -285,4 +285,3 @@ def test_hallucinated_table_names_are_caught_and_corrected():
     assert "public.patients" in retry_prompt
     assert "public.diagnoses" in retry_prompt
     assert "patient_pathology" in retry_prompt
-

--- a/backend/tests/test_pg_react_agent_service.py
+++ b/backend/tests/test_pg_react_agent_service.py
@@ -237,8 +237,8 @@ def test_invalid_query_retries_with_llm_on_second_iteration():
 
 
 def test_hallucinated_table_names_are_caught_and_corrected():
-    """_evaluate short-circuits with a correction when the SQL references tables
-    that are not listed in the schema context."""
+    """When execution fails, _evaluate short-circuits with a schema-aware
+    correction instead of spending an LLM evaluator call on the raw driver error."""
     conn = MagicMock()
     schema_context = (
         "public.patients\n"
@@ -272,8 +272,13 @@ def test_hallucinated_table_names_are_caught_and_corrected():
             ],
         ) as gen_content,
         patch.object(
-            agent, "execute_sql", return_value={"columns": [], "rows": []}
-        ) as exec_sql,
+            agent,
+            "execute_sql",
+            side_effect=[
+                {"error": 'relation "patient" does not exist'},
+                {"columns": [], "rows": []},
+            ],
+        ),
     ):
         out = agent.run_sql_generator(
             user_input="Show me all patients with a heart failure pathology.",
@@ -285,6 +290,9 @@ def test_hallucinated_table_names_are_caught_and_corrected():
 
     assert out["is_valid"] is True
     assert out["generated_code"] == corrected_sql
+    # 2 generates + 1 evaluate: the failed attempt was rejected statically,
+    # without an LLM evaluator call.
+    assert gen_content.call_count == 3
     retry_prompt = gen_content.call_args_list[1].kwargs["contents"]
     assert "public.patients" in retry_prompt
     assert "public.diagnoses" in retry_prompt

--- a/backend/tests/test_pg_sql_utils.py
+++ b/backend/tests/test_pg_sql_utils.py
@@ -49,11 +49,16 @@ def test_validate_sql_operators_flags_any_on_scalar_user_defined_column():
 
 def test_normalize_categorical_literals_snake_cases_enum_like_values():
     schema_context = "public.acquisition\n  - heart_failure user-defined"
-    sql = "SELECT * FROM public.acquisition AS a WHERE a.heart_failure = 'Heart Failure'"
+    sql = (
+        "SELECT * FROM public.acquisition AS a WHERE a.heart_failure = 'Heart Failure'"
+    )
 
     normalized = _normalize_categorical_literals(sql, schema_context)
 
-    assert normalized == "SELECT * FROM public.acquisition AS a WHERE a.heart_failure = 'heart_failure'"
+    assert (
+        normalized
+        == "SELECT * FROM public.acquisition AS a WHERE a.heart_failure = 'heart_failure'"
+    )
 
 
 def test_normalize_categorical_literals_snake_cases_enum_like_values_in_any():
@@ -62,7 +67,10 @@ def test_normalize_categorical_literals_snake_cases_enum_like_values_in_any():
 
     normalized = _normalize_categorical_literals(sql, schema_context)
 
-    assert normalized == "SELECT a.human_id FROM public.acquisition AS a WHERE 'heart_failure' = ANY (a.pathology) LIMIT 50"
+    assert (
+        normalized
+        == "SELECT a.human_id FROM public.acquisition AS a WHERE 'heart_failure' = ANY (a.pathology) LIMIT 50"
+    )
 
 
 def test_normalize_categorical_literals_rewrites_unknown_json_bucket_to_enum_column():
@@ -100,7 +108,9 @@ def test_normalize_categorical_literals_rewrites_array_contains_to_any_membershi
 
 
 def test_normalize_categorical_literals_prefers_hinted_value_format_for_scalar_enum():
-    schema_context = "public.acquisition\n  - modality user-defined -- values: 'CT', 'MR'"
+    schema_context = (
+        "public.acquisition\n  - modality user-defined -- values: 'CT', 'MR'"
+    )
     sql = "SELECT * FROM public.acquisition AS a WHERE a.modality = 'ct'"
 
     normalized = _normalize_categorical_literals(sql, schema_context)

--- a/backend/tests/test_pg_sql_utils.py
+++ b/backend/tests/test_pg_sql_utils.py
@@ -1,0 +1,120 @@
+from services.pg_sql_utils import (
+    _normalize_categorical_literals,
+    _validate_sql_columns,
+    _validate_sql_operators,
+)
+
+
+def test_validate_sql_columns_suggests_enum_column_for_unknown_bucket():
+    schema_context = (
+        "public.acquisition\n"
+        "  - human_id text\n"
+        "  - heart_failure user-defined -- values: 'heart_failure', 'none'"
+    )
+    sql = (
+        "SELECT a.human_id FROM public.acquisition AS a "
+        "WHERE a.heart_conditions ->> 'heart failure' IS NOT NULL LIMIT 50"
+    )
+
+    violation = _validate_sql_columns(sql, schema_context)
+
+    assert violation is not None
+    assert "heart_conditions" in violation
+    assert "heart_failure" in violation
+    assert "snake_case literal 'heart_failure'" in violation
+
+
+def test_validate_sql_operators_flags_user_defined_column_json_operator_usage():
+    schema_context = "public.acquisition\n  - heart_failure user-defined"
+    sql = "SELECT * FROM public.acquisition AS a WHERE a.heart_failure ->> 'heart_failure' IS NOT NULL"
+
+    violation = _validate_sql_operators(sql, schema_context)
+
+    assert violation is not None
+    assert "heart_failure" in violation
+    assert "Operator mismatch" in violation
+
+
+def test_validate_sql_operators_flags_any_on_scalar_user_defined_column():
+    schema_context = "public.acquisition\n  - pathology user-defined"
+    sql = "SELECT a.human_id FROM public.acquisition AS a WHERE 'heart failure' = ANY (a.pathology) LIMIT 50"
+
+    violation = _validate_sql_operators(sql, schema_context)
+
+    assert violation is not None
+    assert "ANY/ALL mismatch" in violation
+    assert "pathology" in violation
+    assert "pathology = 'heart_failure'" in violation
+
+
+def test_normalize_categorical_literals_snake_cases_enum_like_values():
+    schema_context = "public.acquisition\n  - heart_failure user-defined"
+    sql = "SELECT * FROM public.acquisition AS a WHERE a.heart_failure = 'Heart Failure'"
+
+    normalized = _normalize_categorical_literals(sql, schema_context)
+
+    assert normalized == "SELECT * FROM public.acquisition AS a WHERE a.heart_failure = 'heart_failure'"
+
+
+def test_normalize_categorical_literals_snake_cases_enum_like_values_in_any():
+    schema_context = "public.acquisition\n  - pathology user-defined"
+    sql = "SELECT a.human_id FROM public.acquisition AS a WHERE 'Heart Failure' = ANY (a.pathology) LIMIT 50"
+
+    normalized = _normalize_categorical_literals(sql, schema_context)
+
+    assert normalized == "SELECT a.human_id FROM public.acquisition AS a WHERE 'heart_failure' = ANY (a.pathology) LIMIT 50"
+
+
+def test_normalize_categorical_literals_rewrites_unknown_json_bucket_to_enum_column():
+    schema_context = (
+        "public.acquisition\n"
+        "  - human_id text\n"
+        "  - heart_failure user-defined -- values: 'heart_failure', 'none'"
+    )
+    sql = (
+        "SELECT a.human_id FROM public.acquisition AS a "
+        "WHERE a.heart_conditions ->> 'heart_failure' IS NOT NULL LIMIT 50"
+    )
+
+    normalized = _normalize_categorical_literals(sql, schema_context)
+
+    assert normalized == (
+        "SELECT a.human_id FROM public.acquisition AS a "
+        "WHERE a.heart_failure = 'heart_failure' LIMIT 50"
+    )
+
+
+def test_normalize_categorical_literals_rewrites_array_contains_to_any_membership():
+    schema_context = "public.acquisition\n  - pathology user-defined[]"
+    sql = (
+        "SELECT a.human_id FROM public.acquisition AS a "
+        "WHERE a.pathology @> ARRAY ['heart failure'] LIMIT 50"
+    )
+
+    normalized = _normalize_categorical_literals(sql, schema_context)
+
+    assert normalized == (
+        "SELECT a.human_id FROM public.acquisition AS a "
+        "WHERE 'heart_failure' = ANY(a.pathology) LIMIT 50"
+    )
+
+
+def test_normalize_categorical_literals_prefers_hinted_value_format_for_scalar_enum():
+    schema_context = "public.acquisition\n  - modality user-defined -- values: 'CT', 'MR'"
+    sql = "SELECT * FROM public.acquisition AS a WHERE a.modality = 'ct'"
+
+    normalized = _normalize_categorical_literals(sql, schema_context)
+
+    assert normalized == "SELECT * FROM public.acquisition AS a WHERE a.modality = 'CT'"
+
+
+def test_normalize_categorical_literals_prefers_hinted_value_format_for_any_membership():
+    schema_context = "public.acquisition\n  - pathology user-defined[] -- values: 'heart_failure', 'none'"
+    sql = "SELECT a.human_id FROM public.acquisition AS a WHERE 'heart failure' = ANY(a.pathology) LIMIT 50"
+
+    normalized = _normalize_categorical_literals(sql, schema_context)
+
+    assert normalized == (
+        "SELECT a.human_id FROM public.acquisition AS a "
+        "WHERE 'heart_failure' = ANY(a.pathology) LIMIT 50"
+    )

--- a/backend/tests/test_pg_sql_utils.py
+++ b/backend/tests/test_pg_sql_utils.py
@@ -1,8 +1,54 @@
+import pytest
+
 from services.pg_sql_utils import (
     _normalize_categorical_literals,
     _validate_sql_columns,
     _validate_sql_operators,
+    _validate_sql_references,
 )
+
+_VALID_SQL_SCHEMA = (
+    "public.orders\n"
+    "  - id integer [PK]\n"
+    "  - customer_id integer [FK -> customers.id]\n"
+    "  - status character varying -- values: 'active', 'cancelled'\n"
+    "  - created_at timestamp without time zone\n\n"
+    "public.customers\n"
+    "  - id integer [PK]\n"
+    "  - name text"
+)
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # CTE name is not a schema table, but is a legal reference.
+        "WITH recent AS (SELECT o.id, o.status FROM public.orders o) "
+        "SELECT r.id FROM recent r LIMIT 50",
+        # Derived-table alias projects a column that exists in no table.
+        "SELECT s.cnt FROM (SELECT count(*) AS cnt FROM public.orders) s",
+        # EXTRACT/TRIM put FROM inside a function call.
+        "SELECT EXTRACT(YEAR FROM o.created_at) AS yr FROM public.orders o "
+        "GROUP BY yr LIMIT 50",
+        "SELECT TRIM(BOTH ' ' FROM c.name) FROM public.customers c LIMIT 50",
+        # LATERAL is a keyword, not a table.
+        "SELECT a.id FROM public.orders a JOIN LATERAL (SELECT 1) b ON true",
+        # A string literal that happens to contain 'from'.
+        "SELECT c.name FROM public.customers c WHERE c.name = 'from paris' LIMIT 50",
+    ],
+)
+def test_validators_do_not_reject_valid_sql(sql):
+    """Regression: these shapes are all legal SQL and must not be flagged.
+
+    The static validators only run when the database gave no verdict, so a false
+    positive here would burn the retry budget and surface a bogus critique.
+    """
+    for check in (
+        _validate_sql_references,
+        _validate_sql_columns,
+        _validate_sql_operators,
+    ):
+        assert check(sql, _VALID_SQL_SCHEMA) is None, f"{check.__name__} false positive"
 
 
 def test_validate_sql_columns_suggests_enum_column_for_unknown_bucket():

--- a/frontend/pages/PostgresDataExplorerPage.tsx
+++ b/frontend/pages/PostgresDataExplorerPage.tsx
@@ -19,7 +19,7 @@ const cellText = (v: unknown): string =>
 const KeyBadge: React.FC<{ col: Column }> = ({ col }) =>
   col.pk ? <span className="ws-keybadge pk" title="Primary key">PK</span>
     : col.fk ? <span className="ws-keybadge fk" title={`Foreign key -> ${col.fk}`}>FK</span>
-      : <span className="ws-keybadge none">·</span>;
+      : null;
 
 const PostgresDataExplorerPage: React.FC = () => {
   const { serverId: rawServerId, database: rawDatabase } = useParams<{ serverId: string; database?: string }>();
@@ -282,7 +282,7 @@ const PostgresDataExplorerPage: React.FC = () => {
                           if (meta?.fk) return (
                             <td key={j} onClick={(e) => { e.stopPropagation(); onFkClick(meta.fk!, v); }} style={{ color: 'var(--accent)', cursor: 'pointer' }} title={`Go to ${meta.fk}`}>{cellText(v)} →</td>
                           );
-                          if (typeof v === 'number') return <td key={j} style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{v}</td>;
+                          if (typeof v === 'number') return <td key={j} style={{ fontVariantNumeric: 'tabular-nums' }}>{v}</td>;
                           const text = cellText(v);
                           return <td key={j} title={text} style={{ maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis' }}>{text}</td>;
                         })}

--- a/frontend/pages/PostgresDataExplorerPage.tsx
+++ b/frontend/pages/PostgresDataExplorerPage.tsx
@@ -38,7 +38,7 @@ const PostgresDataExplorerPage: React.FC = () => {
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(0);
   const [filters, setFilters] = useState<PgFilter[]>([]);
-  const [sort, setSort] = useState<PgSort | null>(null);
+  const [sort, setSort] = useState<PgSort | null | undefined>(undefined);
   const [loading, setLoading] = useState(false);
   const [schemaLoading, setSchemaLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -80,17 +80,22 @@ const PostgresDataExplorerPage: React.FC = () => {
     return () => { cancelled = true; };
   }, [serverId, database, navigate]);
 
-  // On table change: load column metadata, reset view.
+  // On table change: load column metadata and set default sort before first fetch.
   useEffect(() => {
     if (!activeSchema || !activeTable) return;
     let cancelled = false;
     (async () => {
       try {
         setError(null);
+        setRows([]);
+        setColNames([]);
         const token = await getAuthenticatedToken();
         const info = await getPgTableInfo(token, serverId, database, activeSchema, activeTable) as { columns: Column[] };
         if (cancelled) return;
         setColumns(info.columns);
+        // Default sort by PK
+        const pkCols = info.columns.filter(c => c.pk);
+        setSort(pkCols.length > 0 ? { column: pkCols[0].name, dir: 'asc' } : null);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       }
@@ -99,7 +104,7 @@ const PostgresDataExplorerPage: React.FC = () => {
   }, [activeKey, serverId, database]);
 
   const fetchRows = useCallback(async () => {
-    if (!activeSchema || !activeTable) return;
+    if (!activeSchema || !activeTable || sort === undefined) return; // wait for default sort
     try {
       setLoading(true); setError(null);
       const token = await getAuthenticatedToken();
@@ -120,7 +125,7 @@ const PostgresDataExplorerPage: React.FC = () => {
   // Manual table pick clears the view; the column-load effect only loads
   // columns (it must NOT reset filters, or FK-nav filters below get clobbered).
   const onPgTableSelect = useCallback((s: string, t: string) => {
-    setActiveKey(`${s}.${t}`); setFilters([]); setSort(null); setPage(0);
+    setActiveKey(`${s}.${t}`); setFilters([]); setSort(undefined); setPage(0);
   }, []);
 
   // Connection-chip database switcher (parity with the Cosmos explorer). DbInfo
@@ -271,8 +276,8 @@ const PostgresDataExplorerPage: React.FC = () => {
                     </tr>
                   </thead>
                   <tbody>
-                    {loading && <tr><td colSpan={colNames.length + 1} style={{ padding: 16, color: 'var(--muted)' }}>Loading…</td></tr>}
-                    {!loading && rows.length === 0 && <tr><td colSpan={colNames.length + 1} style={{ padding: 16, color: 'var(--muted)' }}>No rows.</td></tr>}
+                    {(loading || sort === undefined) && <tr><td colSpan={colNames.length + 1} style={{ padding: 16, color: 'var(--muted)' }}>Loading…</td></tr>}
+                    {!loading && sort !== undefined && rows.length === 0 && <tr><td colSpan={colNames.length + 1} style={{ padding: 16, color: 'var(--muted)' }}>No rows.</td></tr>}
                     {!loading && rows.map((r, i) => (
                       <tr key={i} style={{ cursor: 'pointer' }} onClick={() => setDrawer({ mode: 'edit', row: rowToObject(r as unknown[]) })}>
                         <td className="rownum">{from + i}</td>

--- a/frontend/pages/PostgresWorkspacePage.tsx
+++ b/frontend/pages/PostgresWorkspacePage.tsx
@@ -240,7 +240,7 @@ const ResultsGrid: React.FC<{ columns: string[]; rows: any[][] }> = ({ columns, 
           <td className="rownum">{i + 1}</td>
           {r.map((v, j) => {
             if (v === null || v === undefined) return <td key={j} className="null">NULL</td>;
-            if (typeof v === 'number') return <td key={j} style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{v}</td>;
+            if (typeof v === 'number') return <td key={j} style={{ fontVariantNumeric: 'tabular-nums' }}>{v}</td>;
             const text = cellText(v);
             return <td key={j} title={text} style={{ maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis' }}>{text}</td>;
           })}

--- a/frontend/src/design-tokens.css
+++ b/frontend/src/design-tokens.css
@@ -325,11 +325,11 @@ html.dark {
 
 /* results grid */
 .ws-grid { width: 100%; border-collapse: collapse; }
-.ws-grid thead th { position: sticky; top: 0; z-index: 1; background: var(--panel); text-align: left; padding: 7px 12px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); font-weight: 500; white-space: nowrap; border-bottom: 1px solid var(--border); }
-.ws-grid tbody td { padding: 6px 12px; font-family: var(--font-mono); font-size: 11.5px; border-bottom: 1px solid var(--border); white-space: nowrap; color: var(--fg); }
+.ws-grid thead th { position: sticky; top: 0; z-index: 1; background: var(--panel); text-align: center; padding: 7px 12px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); font-weight: 500; white-space: nowrap; border-bottom: 1px solid var(--border); }
+.ws-grid tbody td { padding: 6px 12px; font-family: var(--font-mono); font-size: 11.5px; border-bottom: 1px solid var(--border); white-space: nowrap; color: var(--fg); text-align: center; }
 .ws-grid tbody tr:hover td { background: var(--soft); }
 .ws-grid tbody tr:last-child td { border-bottom: none; }
-.ws-grid .rownum { color: var(--muted); text-align: right; width: 34px; user-select: none; }
+.ws-grid .rownum { color: var(--muted); text-align: center; width: 34px; user-select: none; }
 .ws-grid .null { color: var(--muted); font-style: italic; }
 
 /* query plan */


### PR DESCRIPTION
Release from `dev` to `production`.

### Included PRs

- #59 — Align values in SQL table columns
- #60 — Sort SQL table results before showing
- #61 — Prevent SQL hallucinations with schema validation and value hints

### Notes

#61 adds schema enrichment with low-cardinality sample-value hints to the PostgreSQL NL2SQL agent, plus static validators for hallucinated table/column references and JSON/array operators on text columns. The validators run only when Postgres gave no verdict (execution errored, or was skipped for a write/DDL), and abstain on CTEs, derived tables and `LATERAL` — shapes a regex checker can't model — so valid SQL is never rejected before the LLM evaluator sees it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)